### PR TITLE
Clarify setup-env.sh command line parameter and warn if srcdir == objdir

### DIFF
--- a/setup-env.sh
+++ b/setup-env.sh
@@ -20,6 +20,7 @@ fi
 SRCDIR=`(cd "$1"; pwd)`
 
 if [ -z "$2" ]; then
+  echo -e "\e[1;33mThe object dir equals source dir (not recommended).\e[0m\n"
   export OBJDIR="$1"
 else
   export OBJDIR="$2"


### PR DESCRIPTION
I have renamed the help text for the setup-env.sh to clarify that the second parameter is actually the object dir (not the "data" dir). Also warn if object dir == source dir since a) it is not recommended and b) we will warn in the situation when someone actually has src dir != obj dir but forgot to pass the parameter to setup-env.sh.
