### PR TITLE
Don't hardcode python2.6 in search.cgi

### DIFF
--- a/dxr/htmlbuilders.py
+++ b/dxr/htmlbuilders.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.6
+#!/usr/bin/env python2
 
 import os
 import dxr

--- a/dxr/tokenizers.py
+++ b/dxr/tokenizers.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.6
+#!/usr/bin/env python2
 
 # Tokenizer code adapted by David Humphrey from Neal Norwitz's C++ tokenizer:
 #

--- a/www/getinfo.cgi
+++ b/www/getinfo.cgi
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.6
+#!/usr/bin/env python2
 
 import json
 import cgitb; cgitb.enable()

--- a/www/search.cgi
+++ b/www/search.cgi
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.6
+#!/usr/bin/env python2
 
 import cgitb; cgitb.enable()
 import cgi


### PR DESCRIPTION
With Python 2.7 you get opaque server errors. However python2
with Python 2.5 at worst leads to understandable backtraces
