### PR TITLE
Fix extents for overloaded operators.

### DIFF
--- a/plugins/clang/dxr-index.cpp
+++ b/plugins/clang/dxr-index.cpp
@@ -225,6 +225,8 @@ public:
   }
 
   void printExtent(SourceLocation begin, SourceLocation end) {
+    if (!end.isValid())
+      end = begin;
     if (begin.isMacroID() || end.isMacroID())
       return;
     *out << ",extent," << sm.getDecomposedSpellingLoc(begin).second << ":" <<

--- a/plugins/clang/htmlifier.py
+++ b/plugins/clang/htmlifier.py
@@ -21,7 +21,11 @@ class ClangHtmlifier:
     tokenizer = tokenizers.CppTokenizer(self.text)
     for token in tokenizer.getTokens():
       if token.token_type == tokenizer.KEYWORD:
-        yield (token.start, token.end, 'k')
+        # "operator" is going to be part of something bigger like
+        # "operator++" or "operator new" so we don't want to create
+        # a region here that only covers part of that
+        if token.name != "operator":
+          yield (token.start, token.end, 'k')
       elif token.token_type == tokenizer.STRING:
         yield (token.start, token.end, 'str')
       elif token.token_type == tokenizer.COMMENT:


### PR DESCRIPTION
- For declarations only the "operator" part was hyperlinked, not the part
  following.  Now the entire name (e.g. "operator++") will be hyperlinked.
- For calls only the first character was being hyperlinked.  In
  "a += b", only the "+" was hyperlinked.  Now "+=" is hyperlinked.
