### PR TITLE
Add extents for preprocessor macros.

### DIFF
--- a/plugins/clang/dxr-index.cpp
+++ b/plugins/clang/dxr-index.cpp
@@ -637,6 +637,7 @@ public:
     if (defnStart < length)
       recordValue("macrotext", std::string(contents + defnStart,
         length - defnStart), true);
+    printExtent(nameStart, nameStart);
     *out << std::endl;
   }
   virtual void MacroExpands(const Token &tok, const MacroInfo *MI, SourceRange Range) {

--- a/plugins/clang/indexer.py
+++ b/plugins/clang/indexer.py
@@ -102,6 +102,8 @@ schema = dxr.schema.Schema({
     ("macroname", "VARCHAR(256)", False), # The name of the macro
     ("macroargs", "VARCHAR(256)", True),  # The args of the macro (if any)
     ("macrotext", "TEXT", True),          # The macro contents
+    ("extent_start", "INTEGER", True),
+    ("extent_end", "INTEGER", True),
     ("_location", True)
   ],
   # The following two tables are combined to form the callgraph implementation.
@@ -323,6 +325,7 @@ def process_macro(args, conn):
     args['macrotext'] = args['macrotext'].replace("\\\n", "\n").strip()
   if not fixupEntryPath(args, 'macroloc', conn):
     return None
+  fixupExtent(args, 'extent')
   return schema.get_insert_sql('macros', args)
 
 def process_call(args, conn):

--- a/server/query.py
+++ b/server/query.py
@@ -638,7 +638,11 @@ filters.append(ExistsLikeFilter(
                        WHERE %s
                          AND macros.file_id = files.ID
                     """,
-    ext_sql       = None, #TODO Add extent_start, extent_end to macros table!
+    ext_sql       = """SELECT macros.extent_start, macros.extent_end FROM macros
+                       WHERE macros.file_id = ?
+                         AND %s
+                       ORDER BY macros.extent_start
+                    """,
     like_name     = "macros.macroname",
     qual_name     = "macros.macroname"
 ))


### PR DESCRIPTION
Now macro: searches show proper results on the search page.
