### PR TITLE
Fix for "Jump to definition" sometimes jumping to a declaration instead.

### DIFF
--- a/plugins/clang/dxr-index.cpp
+++ b/plugins/clang/dxr-index.cpp
@@ -372,33 +372,36 @@ public:
     else if (!d->isDefined())
       return true;
 
-    beginRecord("function", d->getLocation());
-    recordValue("fname", d->getNameAsString());
-    recordValue("fqualname", getQualifiedName(*d));
-    recordValue("ftype", d->getResultType().getAsString());
-    std::string args("(");
-    for (FunctionDecl::param_iterator it = d->param_begin();
-        it != d->param_end(); it++) {
-      args += ", ";
-      args += (*it)->getType().getAsString();
-    }
-    if (d->getNumParams() > 0)
-      args.erase(1, 2);
-    args += ")";
-    recordValue("fargs", args);
-    recordValue("floc", locationToString(d->getLocation()));
-    printScope(d);
-    printExtent(d->getNameInfo().getBeginLoc(), d->getNameInfo().getEndLoc());
-    // Print out overrides
-    if (CXXMethodDecl::classof(d)) {
-      CXXMethodDecl *cxxd = dyn_cast<CXXMethodDecl>(d);
-      CXXMethodDecl::method_iterator iter = cxxd->begin_overridden_methods();
-      if (iter) {
-        recordValue("overridename", getQualifiedName(**iter));
-        recordValue("overrideloc", locationToString((*iter)->getLocation()));
+    if (d->isThisDeclarationADefinition())
+    {
+      beginRecord("function", d->getLocation());
+      recordValue("fname", d->getNameAsString());
+      recordValue("fqualname", getQualifiedName(*d));
+      recordValue("ftype", d->getResultType().getAsString());
+      std::string args("(");
+      for (FunctionDecl::param_iterator it = d->param_begin();
+          it != d->param_end(); it++) {
+        args += ", ";
+        args += (*it)->getType().getAsString();
       }
+      if (d->getNumParams() > 0)
+        args.erase(1, 2);
+      args += ")";
+      recordValue("fargs", args);
+      recordValue("floc", locationToString(d->getLocation()));
+      printScope(d);
+      printExtent(d->getNameInfo().getBeginLoc(), d->getNameInfo().getEndLoc());
+      // Print out overrides
+      if (CXXMethodDecl::classof(d)) {
+        CXXMethodDecl *cxxd = dyn_cast<CXXMethodDecl>(d);
+        CXXMethodDecl::method_iterator iter = cxxd->begin_overridden_methods();
+        if (iter) {
+          recordValue("overridename", getQualifiedName(**iter));
+          recordValue("overrideloc", locationToString((*iter)->getLocation()));
+        }
+      }
+      *out << std::endl;
     }
-    *out << std::endl;
 
     if (d->isDefined(def) && def != d)
       declDef(d, def, d->getNameInfo().getBeginLoc(), d->getNameInfo().getEndLoc());

--- a/plugins/clang/htmlifier.py
+++ b/plugins/clang/htmlifier.py
@@ -48,6 +48,22 @@ class ClangHtmlifier:
     for start, end, fqualname in self.conn.execute(sql, args):
       yield start, end, self.function_menu(fqualname)
 
+    # Extents for functions declared here
+    sql = """
+      SELECT decldef.extent_start,
+             decldef.extent_end,
+             functions.fqualname,
+             (SELECT path FROM files WHERE files.ID = functions.file_id),
+             functions.file_line
+        FROM decldef, functions
+       WHERE decldef.defid = functions.funcid
+         AND decldef.file_id = ?
+    """
+    for start, end, fqualname, path, line in self.conn.execute(sql, args):
+      menu = self.function_menu(fqualname)
+      self.add_jump_definition(menu, path, line)
+      yield start, end, menu
+
     # Extents for variables defined here
     sql = """
       SELECT extent_start, extent_end, vqualname


### PR DESCRIPTION
Now "function" is emitted to the .csv only for function definitions, not
declarations.  Declarations will get a "decldef" if a definition is
available elsewhere in the translation unit.

Having multiple "function" entries for a single function would cause
the UNION in indexer.py:update_refs to return more than one row
(one from functions and one from decldef).  If the one from decldef
won then "Jump to definition" worked.  If the one from functions won
then you'd be taken to the declaration instead.  SQLite seems to
break this tie based on the numeric value of the ID so the behavior
was somewhat nondeterministic when minor changes were made to the
source code.
