### PR TITLE
Add profiling ability for SQL queries.

### DIFF
--- a/server/search.py
+++ b/server/search.py
@@ -88,7 +88,8 @@ else:
     try:
       results = list(query.fetch_results(
         conn, q,
-        offset, limit
+        offset, limit,
+        querystring.has_key("explain")
       ))
     except sqlite3.OperationalError, e:
       if e.message.startswith("REGEXP:"):


### PR DESCRIPTION
Appending "&explain=true" to the end of the URL of any query will run
the query as normal but not return the results to the browser.
Instead it will report the results of "EXPLAIN QUERY PLAN" for every
SQL statement that is run along with the time that each statement took.

This can be useful in diagnosing slow queries and figuring out how to
speed them up.
