### PR TITLE
dxr-build: allow specifying tree build order

### DIFF
--- a/dxr/utils.py
+++ b/dxr/utils.py
@@ -92,7 +92,14 @@ class Config:
       sys.exit(1)
 
     # Load trees
-    for tree in parser.sections():
+    def section_cmp(a, b):
+      if parser.has_option(a, "order") and parser.has_option(b, "order"):
+        return cmp(parser.getint(a, "order"), parser.getint(b, "order"))
+      if (not parser.has_option(a, "order")) and (not parser.has_option(b, "order")):
+        return cmp(a, b)
+      return -1 if parser.has_option(a, "order") else 1
+
+    for tree in sorted(parser.sections(), section_cmp):
       if tree not in ('DXR', 'Template'):
         self.trees.append(TreeConfig(self, self.configfile, tree))
 


### PR DESCRIPTION
Add support for an optional |order| parameter to tree configs; it should be
an integer, with smaller values being built first.  Trees with unspecified
order will be built after those with specified order, in sorted by tree
name.

This is necessary because I'm running this against a tree that requires the objdir of a second tree to actually build.  (In this case, I need to build the bulk of Mozilla before building Komodo; similar things happened with Songbird, where a XULRunner + TagLib + gstreamer + etc. build was required before building Songbird itself.)  See also, say, GCC needing binutils.  Basically, anything that needs to build some imported code in a separate build step separate from the main build system (mostly because the imported code takes a long time to build and does not change often).

This at least introduces a defined build order to things - before it was just building things in whatever order dict().keys() was returning, which is unspecified.
