### PR TITLE
Export compiler command lines in DXR-specific env variables.

### DIFF
--- a/plugins/clang/indexer.py
+++ b/plugins/clang/indexer.py
@@ -26,6 +26,9 @@ def pre_process(tree, env):
     flags_str += ' -Xclang ' + flag
   env['CC']   = "clang %s"   % flags_str
   env['CXX']  = "clang++ %s" % flags_str
+  env['DXR_CC'] = env['CC']
+  env['DXR_CXX'] = env['CXX']
+  env['DXR_CLANG_FLAGS'] = flags_str
   env['DXR_CXX_CLANG_OBJECT_FOLDER']  = tree.object_folder
   env['DXR_CXX_CLANG_TEMP_FOLDER']    = temp_folder
 


### PR DESCRIPTION
Resolve Issue #55.

Rather than just export CC and CXX environment variables, export the
same information as DXR-specific environment variables.  This helps
integration into non-GNU build systems.
