### PR TITLE
Don't emit "type"s for declarations, only definitions

### DIFF
--- a/plugins/clang/dxr-index.cpp
+++ b/plugins/clang/dxr-index.cpp
@@ -257,7 +257,7 @@ public:
   }
 
   void declDef(const NamedDecl *decl, const NamedDecl *def, SourceLocation begin, SourceLocation end) {
-    if (!def)
+    if (!def || def == decl)
       return;
 
     beginRecord("decldef", decl->getLocation());
@@ -302,32 +302,26 @@ public:
 
   // Tag declarations: class, struct, union, enum
   bool VisitTagDecl(TagDecl *d) {
-    TagDecl *definition;
     if (!interestingLocation(d->getLocation()))
       return true;
 
-    if (d->isClass()) {
-      definition = d->getDefinition();
-
-      if (!definition)
-        return true;
-    } else
-      definition = d;
-
-    // Information we need for types: kind, fqname, simple name, location
-    beginRecord("type", definition->getLocation());
-    // We get the name from the typedef if it's an anonymous declaration...
-    NamedDecl *nd = definition->getTypedefNameForAnonDecl();
-    if (!nd)
-      nd = definition;
-    recordValue("tname", nd->getNameAsString());
-    recordValue("tqualname", getQualifiedName(*nd));
-    recordValue("tloc", locationToString(definition->getLocation()));
-    recordValue("tkind", definition->getKindName());
-    printScope(definition);
-    // Linkify the name, not the `enum'
-    printExtent(nd->getLocation(), nd->getLocation());
-    *out << std::endl;
+    if (d->isThisDeclarationADefinition())
+    {
+      // Information we need for types: kind, fqname, simple name, location
+      beginRecord("type", d->getLocation());
+      // We get the name from the typedef if it's an anonymous declaration...
+      NamedDecl *nd = d->getTypedefNameForAnonDecl();
+      if (!nd)
+        nd = d;
+      recordValue("tname", nd->getNameAsString());
+      recordValue("tqualname", getQualifiedName(*nd));
+      recordValue("tloc", locationToString(d->getLocation()));
+      recordValue("tkind", d->getKindName());
+      printScope(d);
+      // Linkify the name, not the `enum'
+      printExtent(nd->getLocation(), nd->getLocation());
+      *out << std::endl;
+    }
 
     declDef(d, d->getDefinition(), d->getLocation(), d->getLocation());
     return true;
@@ -365,8 +359,6 @@ public:
   }
 
   bool VisitFunctionDecl(FunctionDecl *d) {
-    const FunctionDecl *def;
-
     if (!interestingLocation(d->getLocation()))
       return true;
     else if (!d->isDefined())
@@ -403,7 +395,8 @@ public:
       *out << std::endl;
     }
 
-    if (d->isDefined(def) && def != d)
+    const FunctionDecl *def;
+    if (d->isDefined(def))
       declDef(d, def, d->getNameInfo().getBeginLoc(), d->getNameInfo().getEndLoc());
 
     return true;


### PR DESCRIPTION
 Previously code like:
    struct Foo;
    struct Foo;
    struct Foo {};
would emit one "type" and one "decldef" for each line.  This could
result in "Jump to Definition" going to the wrong place.  Now this code
results in one "decldef" for each of the first two lines and one "type"
for the last line.
