### PR TITLE
Add a temporary script that `scp`s the checkout into the Vagrant VM on J...

### DIFF
--- a/vagrant_populate.sh
+++ b/vagrant_populate.sh
@@ -1,0 +1,9 @@
+#!/bin/sh -e
+# Copies the DXR checkout to the Vagrant VM. This is necessary only until we
+# get VirtualBox shared folders working on the Jenkins hosts.
+
+# TODO: Omit the .git directory for speed.
+
+vagrant ssh-config > .vagrant_ssh_config
+scp -r -F .vagrant_ssh_config . default:dxr_for_jenkins
+rm .vagrant_ssh_config


### PR DESCRIPTION
...enkins so we can get CI passing.

Once https://bugzilla.mozilla.org/show_bug.cgi?id=826549 is done, we can remove this.
