### PR TITLE
Don't emit variable definition entries for things which are only declara...

### DIFF
--- a/plugins/clang/htmlifier.py
+++ b/plugins/clang/htmlifier.py
@@ -73,6 +73,22 @@ class ClangHtmlifier:
     for start, end, vqualname in self.conn.execute(sql, args):
       yield start, end, self.variable_menu(vqualname)
 
+    # Extents for variables declared here
+    sql = """
+      SELECT decldef.extent_start,
+             decldef.extent_end,
+             variables.vqualname,
+             (SELECT path FROM files WHERE files.ID = variables.file_id),
+             variables.file_line
+        FROM decldef, variables
+       WHERE decldef.defid = variables.varid
+         AND decldef.file_id = ?
+    """
+    for start, end, vqualname, path, line in self.conn.execute(sql, args):
+      menu = self.variable_menu(vqualname)
+      self.add_jump_definition(menu, path, line)
+      yield start, end, menu
+
     # Extents for types defined here
     sql = """
       SELECT extent_start, extent_end, tqualname, tkind

--- a/plugins/clang/indexer.py
+++ b/plugins/clang/indexer.py
@@ -578,6 +578,12 @@ def update_defids(conn):
         WHERE functions.file_id   = decldef.definition_file_id
           AND functions.file_line = decldef.definition_file_line
           AND functions.file_col  = decldef.definition_file_col
+     UNION
+       SELECT varid
+         FROM variables
+        WHERE variables.file_id   = decldef.definition_file_id
+          AND variables.file_line = decldef.definition_file_line
+          AND variables.file_col  = decldef.definition_file_col
   )
   """
   conn.execute(sql)

--- a/tests/json-test/HelloWorld/makefile
+++ b/tests/json-test/HelloWorld/makefile
@@ -1,5 +1,5 @@
 all: HelloWorld
-HelloWorld: main.c const_overload.cpp
+HelloWorld: main.c const_overload.cpp prototype_parameter.cpp static_member.cpp
 	$(CXX) -o $@ $^
 clean:
 	rm -rf HelloWorld

--- a/tests/json-test/HelloWorld/prototype_parameter.cpp
+++ b/tests/json-test/HelloWorld/prototype_parameter.cpp
@@ -1,0 +1,6 @@
+#include "prototype_parameter.h"
+
+int prototype_parameter_function(int prototype_parameter)
+{
+    return prototype_parameter;
+}

--- a/tests/json-test/HelloWorld/prototype_parameter.h
+++ b/tests/json-test/HelloWorld/prototype_parameter.h
@@ -1,0 +1,1 @@
+int prototype_parameter_function(int prototype_parameter);

--- a/tests/json-test/HelloWorld/static_member.cpp
+++ b/tests/json-test/HelloWorld/static_member.cpp
@@ -1,0 +1,3 @@
+#include "static_member.h"
+
+int StaticMember::static_member = 0;

--- a/tests/json-test/HelloWorld/static_member.h
+++ b/tests/json-test/HelloWorld/static_member.h
@@ -1,0 +1,5 @@
+class StaticMember
+{
+public:
+    static int static_member;
+};

--- a/tests/json-test/search-test.py
+++ b/tests/json-test/search-test.py
@@ -45,5 +45,10 @@ test("member:BitField", ["BitField.h"])
 test('+function:ConstOverload::foo()', ["const_overload.cpp"])
 test('+function:"ConstOverload::foo() const"', ["const_overload.cpp"])
 
+test('+var:prototype_parameter_function(int)::prototype_parameter', ['prototype_parameter.cpp'])
+test('+var-ref:prototype_parameter_function(int)::prototype_parameter', ['prototype_parameter.cpp'])
+
+test('+var:StaticMember::static_member', ['static_member.cpp'])
+
 if failed:
   sys.exit(1)


### PR DESCRIPTION
...tions.

Add decldef entries for variable declarations.

This fixes "Jump to definition" on a static class member jumping to the header instead of the actual definition.
It also avoids duplicate definitions for function parameters that are mentioned by name in the function's prototype.
Now the only the variable in the function definition counts as the definition.
