### PR TITLE
Add constructor call information to clang plugin

### DIFF
--- a/plugins/clang/dxr-index.cpp
+++ b/plugins/clang/dxr-index.cpp
@@ -548,6 +548,33 @@ public:
     return true;
   }
 
+  bool VisitCXXConstructExpr(CXXConstructExpr *e) {
+    if (!interestingLocation(e->getLocStart()))
+      return true;
+
+    CXXConstructorDecl *callee = e->getConstructor();
+    if (!callee || !interestingLocation(callee->getLocation()) ||
+        !NamedDecl::classof(callee))
+      return true;
+
+    // Fun facts about call exprs:
+    // 1. callee isn't necessarily a function. Think function pointers.
+    // 2. We might not be in a function. Think global function decls
+    // 3. Virtual functions need not be called virtually!
+    beginRecord("call", e->getLocStart());
+    if (m_currentFunction) {
+      recordValue("callername", getQualifiedName(*m_currentFunction));
+      recordValue("callerloc", locationToString(m_currentFunction->getLocation()));
+    }
+    recordValue("calleename", getQualifiedName(*dyn_cast<NamedDecl>(callee)));
+    recordValue("calleeloc", locationToString(callee->getLocation()));
+    // Determine the type of call
+    const char *type = "static";
+    recordValue("calltype", type);
+    *out << std::endl;
+    return true;
+  }
+
   // For binding stuff inside the directory, we need to find the containing
   // function. Unfortunately, there is no way to do this in clang, so we have
   // to maintain the function stack ourselves. Why is it a stack? Consider:

--- a/tests/json-test/HelloWorld/main.c
+++ b/tests/json-test/HelloWorld/main.c
@@ -6,6 +6,7 @@
 // Hello World Example
 int main(int argc, char* argv[]){
   printf("%s\n", getHello());
+  BitField b(8);
   return 0;
 }
 


### PR DESCRIPTION
This is just a slightly modified copy of the regular function/method
call code. Unfortunately there's no place to click on the constructor
invocation to find the definition, but on clicking on the definition
you can find callers and references. I've added a creation of a
BitField object HelloWorld/main.c as an example (click on the BitField
constructor, and main in main.c can be found as a caller).
