### PR TITLE
Fix include links for filenames which are suffixes of other filenames.

### DIFF
--- a/dxr/plugins/clang/htmlifier.py
+++ b/dxr/plugins/clang/htmlifier.py
@@ -203,7 +203,7 @@ class ClangHtmlifier:
                     continue
                 inc_name = match.group(1)
                 sql = "SELECT path FROM files WHERE path LIKE ?"
-                rows = self.conn.execute(sql, ("%%%s" % (inc_name),)).fetchall()
+                rows = self.conn.execute(sql, (inc_name,)).fetchall()
 
                 if rows is None or len(rows) == 0:
                     basename = os.path.basename(inc_name)


### PR DESCRIPTION
Previously if bar.h and foo_bar.h both existed then #include "bar.h" would not be hyperlinked.
