### PR TITLE
Make sure we use at least one worker when building HTML

### DIFF
--- a/bin/dxr-build.py
+++ b/bin/dxr-build.py
@@ -408,7 +408,7 @@ def run_html_workers(tree, conn):
     # Make some slices
     slices = []
     # Don't make slices bigger than 500
-    step = min(500, int(file_count) / int(tree.config.nb_jobs))
+    step = max(min(500, int(file_count) / int(tree.config.nb_jobs)), 1)
     start = None    # None, is not --start argument
     for end in xrange(step, file_count, step):
         slices.append((start, end))


### PR DESCRIPTION
When there are more workers than files, we can end up with a `step` of `0`.  `xrange` really doesn't like that, and throws an exception.  This makes sure that it gets at least 1, so that it just iterates over an empty range instead.
