### PR TITLE
clang plugin: allow overriding llvm-config binary

### DIFF
--- a/dxr/plugins/clang/makefile
+++ b/dxr/plugins/clang/makefile
@@ -1,5 +1,6 @@
-LLVM_LDFLAGS := $(shell llvm-config --ldflags)
-CXXFLAGS := $(shell llvm-config --cxxflags) -Wall -Wno-strict-aliasing \
+LLVM_CONFIG ?= llvm-config
+LLVM_LDFLAGS := $(shell ${LLVM_CONFIG} --ldflags)
+CXXFLAGS := $(shell ${LLVM_CONFIG} --cxxflags) -Wall -Wno-strict-aliasing \
 	$(if $(DEBUG),-O0 -g)
 LDFLAGS := -fPIC -g -Wl,-R -Wl,'$$ORIGIN' $(LLVM_LDFLAGS) -shared
 


### PR DESCRIPTION
ppa:h-rayflood/llvm has a llvm-3.2 (and clang) with the llvm-config binary named llvm-config-3.2 instead (that is, version suffixed); this allows building the clang plugin with `make LLVM_CONFIG=llvm-config-3.2` to succeed (since the package doesn't use update-alternatives for some reason).

This does not change the default behaviour.
