### PR TITLE
Run dxr-worker.py via sys.executable

### DIFF
--- a/dxr/build.py
+++ b/dxr/build.py
@@ -406,7 +406,7 @@ def run_html_workers(tree, conn):
             print " - Starting worker %i" % next_id
 
             # TODO: Switch to multiprocessing.
-            cmd = [os.path.join(dirname(__file__), 'dxr-worker.py')] + args
+            cmd = [sys.executable, os.path.join(dirname(__file__), 'dxr-worker.py')] + args
 
             # Write command to log
             log.write(" ".join(cmd) + "\n")


### PR DESCRIPTION
When `dxr-worker.py` gets installed, it can lose its execute bit.  Always run it via `sys.executable` so we don't have to worry about this (and also makes sure we end up running the correct instance of python to boot).
