### PR TITLE
Update the "This page was generated" text on a pageshow event.

### DIFF
--- a/dxr/static/dxr.js
+++ b/dxr/static/dxr.js
@@ -61,6 +61,9 @@ dxr.tree = function(){
 window.addEventListener('load', function (){
   prettifyDates();
 }, false);
+window.addEventListener('pageshow', function (){
+  prettifyDates();
+}, false);
 
 /** Export dxr as defined here */
 return dxr;


### PR DESCRIPTION
This makes sure the information is not stale when a page comes
out of the bfcache or session restore.
