### PR TITLE
Fixed crash on negated phrase search

### DIFF
--- a/dxr/query.py
+++ b/dxr/query.py
@@ -76,7 +76,7 @@ class Query:
                     else:
                         self.phrases.append(token["keyword"])
             if token["notphrase"]:
-                self.notphrase.append(token["notphrase"])
+                self.notphrases.append(token["notphrase"])
     def single_term(self):
         """ Returns the single term making up the query, None for complex queries """
         count = 0


### PR DESCRIPTION
When preparing a reply on the mailing list...
Noticed a crash when searching with a negated phrase, for example [printf -"sprintf"](http://dxr.mozilla.org/search?tree=mozilla-central&q=printf+-%22sprintf%22&redirect=true)

It looks like a minor typo... So this might just fix it...
