### PR TITLE
Notify user when a search request is pending in the background.

### DIFF
--- a/dxr/static/search.js
+++ b/dxr/static/search.js
@@ -246,6 +246,7 @@ function fetch_results(display_fetcher){
 
   // Start a new request
   request.open("GET", createSearchUrl(params), true);
+  dxr.setTip("Search in progress ...");
   request.send();
 }
 


### PR DESCRIPTION
If a request takes a long time then there was no indication that
something was still going on in the background or that the currently
displayed results do not match the contents of the search box.
