### PR TITLE
WSGI: grab DXR_FOLDER from os.environ if not specified in WSGI environ

### DIFF
--- a/dxr/dxr.wsgi
+++ b/dxr/dxr.wsgi
@@ -1,12 +1,20 @@
 from dxr.app import make_app
+import os
 
 
 def application(environ, start_response):
     """Pull the instance path out of an env var, and then instantiate the WSGI
     app as normal.
 
-    Note that this isn't a process-level env var but rather the sort you'd
-    create with a SetEnv call in your Apache config.
+    This prefers the Apache SetEnv sort of environment; but if that's missing,
+    try the process-level env var instead since it's easier to set for some
+    users.  It still needs to be set in one of the two places though.
 
     """
-    return make_app(environ['DXR_FOLDER'])(environ, start_response)
+    try:
+        dxr_folder = environ['DXR_FOLDER']
+    except KeyError:
+        # Not be in WSGI environ, try process environment block
+        # If this still fails, this is a fatal error.
+        dxr_folder = os.environ['DXR_FOLDER']
+    return make_app(dxr_folder)(environ, start_response)


### PR DESCRIPTION
This makes it easier to pass it in in some cases (e.g. stackato)

This should properly die if it's not given anywhere.  Also, updated the comments, and tried to be more verbose.  I guess blindly-leap-ahead-and-catch-the-exception is more Pythonic anyway...

Not sure why github decided to just... disappear my previous pull request.  Perhap because I rebased + amended?
