### PR TITLE
setup.py: ship the clang plugin

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,6 +19,7 @@ setup(
     author_email='erik@mozilla.com',
     license='MIT',
     packages=find_packages(exclude=['ez_setup']),
+    package_data={'dxr': ['plugins/clang/*.so']},
     scripts=['bin/dxr-build.py', 'bin/dxr-serve.py'],
     install_requires=['Flask>=0.9', 'Pygments>=1.4', 'Jinja2>=2.6'],
     tests_require=['nose'],


### PR DESCRIPTION
Without this, installed packages don't work very well for indexing.

Note that I don't know my way around setuptools/distribute/whatever so don't trust me on this - it's more of a bug report that _not_ doing this doesn't work, I guess?  Anyway, with `setup.py install`, it didn't include the .so so actually using clang wasn't very productive.  If we're going to ship the rest of the clang plugin anyway...
