### PR TITLE
Stop &explain=true from corrupting all future queries.

### DIFF
--- a/dxr/app.py
+++ b/dxr/app.py
@@ -32,6 +32,11 @@ def make_app(instance_path):
     return app
 
 
+@dxr_blueprint.before_request
+def before_request():
+    Query.before_request()
+
+
 @dxr_blueprint.route('/')
 def index():
     return send_file(current_app.open_instance_resource('trees/index.html'))

--- a/dxr/query.py
+++ b/dxr/query.py
@@ -97,6 +97,12 @@ class Query:
             return None
         return term
 
+    @classmethod
+    def before_request(cls):
+        flask.g._should_explain = False
+        flask.g._sql_profile = []
+
+
 #TODO Use named place holders in filters, this would make the filters easier to write
 
 def _execute_sql(conn, sql, *parameters):
@@ -122,7 +128,6 @@ def fetch_results(conn, query,
                                     should_explain = False,
                                     markup = "<b>", markdown = "</b>"):
     flask.g._should_explain = should_explain
-    flask.g._sql_profile = []
     sql = """
         SELECT files.path, files.icon, trg_index.text, files.id,
         extents(trg_index.contents)


### PR DESCRIPTION
This was using global variables and was broken since the conversion
to Flask.  Move this data to the flask.request object so it doesn't
affect other requests.
