### PR TITLE
Restore compatibility with Python 2.6

### DIFF
--- a/dxr/query.py
+++ b/dxr/query.py
@@ -320,7 +320,7 @@ def _highlit_line(content, offsets, markup, markdown):
             next_newline = None
         yield cgi.escape(content[chars_before:next_newline])
     ret = ''.join(chunks())
-    return ret.decode('utf-8', errors='replace')
+    return ret.decode('utf-8', 'replace')
 
 
 def _highlit_lines(content, offsets, markup, markdown):


### PR DESCRIPTION
str.decode() only gained support for kwargs in Python 2.7
