### PR TITLE
Fix for Bug 758628

### DIFF
--- a/dxr/build.py
+++ b/dxr/build.py
@@ -20,6 +20,36 @@ import dxr.languages
 import dxr.mime
 from dxr.utils import load_template_env, connect_database, open_log
 
+def create_navigable_pathname(path, tree):
+    """Converts pathname into s list of tuples that can be used to display
+    on the header of the file or folder pages
+
+    :arg path: The path that will be split
+    
+    """
+    # Holds the root of the tree
+    components = [("/%s/source"%tree.name, tree.name)]
+    # Populates each sub tree
+    dirs = path.split(os.sep)
+    # A special case when we're dealing with the root tree. Without
+    # this, it repeats.
+    if not path: 
+        return components
+
+    for idx in range(1, len(dirs)+1):
+        sub_tree_path = os.path.join("/",
+                                     tree.name,
+                                     "source",
+                                     os.sep.join(dirs[:idx]))
+        sub_tree_name = os.path.split(sub_tree_path)[1] or tree.name
+        components.append((sub_tree_path, sub_tree_name))
+
+    # print 20*"="
+    # import pprint
+    # pprint.pprint(components)
+    # print 20*"="
+    return components
+
 
 def build_instance(config_path, nb_jobs=None, tree=None):
     """Build a DXR instance.
@@ -272,22 +302,25 @@ def build_folder(tree, conn, folder, indexed_files, indexed_folders):
     dst_path = os.path.join(tree.target_folder,
                             folder,
                             tree.config.directory_index)
+
+    source_file_path_components = create_navigable_pathname(folder, tree)
+
     _fill_and_write_template(
         jinja_env,
         'folder.html',
         dst_path,
         {# Common template variables:
-          'wwwroot':        tree.config.wwwroot,
-          'tree':           tree.name,
-          'trees':          [t.name for t in tree.config.trees],
-          'config':         tree.config.template_parameters,
-          'generated_date': tree.config.generated_date,
-
+          'wwwroot':           tree.config.wwwroot,
+          'tree':              tree.name,
+          'trees':             [t.name for t in tree.config.trees],
+          'config':            tree.config.template_parameters,
+          'generated_date':    tree.config.generated_date,
+          'source_components': source_file_path_components,
           # Folder template variables:
-          'name':           name,
-          'path':           folder,
-          'folders':        folders,
-          'files':          files})
+          'name':              name,
+          'path':              folder,
+          'folders':           folders,
+          'files':             files})
 
 
 def _join_url(*args):
@@ -460,19 +493,23 @@ def htmlify(tree, conn, icon, path, text, dst_path, plugins):
     env = load_template_env(tree.config.temp_folder,
                             tree.config.template_folder)
     tmpl = env.get_template('file.html')
+
+    source_file_path_components = create_navigable_pathname(path, tree)
+
     arguments = {
         # Set common template variables
-        'wwwroot':        tree.config.wwwroot,
-        'tree':           tree.name,
-        'trees':          [t.name for t in tree.config.trees],
-        'config':         tree.config.template_parameters,
-        'generated_date': tree.config.generated_date,
-        # Set file template variables
-        'icon':           icon,
-        'path':           path,
-        'name':           os.path.basename(path),
-        'lines':          build_lines(tree, conn, path, text, htmlifiers),
-        'sections':       build_sections(tree, conn, path, text, htmlifiers)
+        'wwwroot':            tree.config.wwwroot,
+        'tree':               tree.name,
+        'trees':              [t.name for t in tree.config.trees],
+        'config':             tree.config.template_parameters,
+        'generated_date':     tree.config.generated_date,
+        # Set file template   variables
+        'source_components':  source_file_path_components,
+        'icon':               icon,
+        'path':               path,
+        'name':               os.path.basename(path),
+        'lines':              build_lines(tree, conn, path, text, htmlifiers),
+        'sections':           build_sections(tree, conn, path, text, htmlifiers)
     }
     # Fill-in variables and dump to file with utf-8 encoding
     tmpl.stream(**arguments).dump(dst_path, encoding='utf-8')

--- a/dxr/static/layout.css
+++ b/dxr/static/layout.css
@@ -340,3 +340,21 @@ table.folder-content {
     width: 100%;
     text-align: center;
 }
+
+div.file-name { 
+                /* border: 1px solid black; */
+                padding: 0 1em;
+                font-weight: bold;
+ }
+div.file-name a { 
+                  text-decoration: none;
+ }
+div.file-name span.slash { 
+                           padding: 0 0.5em;
+ }
+
+div.file-name a:hover { 
+                       text-decoration: underline;
+                       background-color: #eee;
+ }
+

--- a/dxr/templates/file.html
+++ b/dxr/templates/file.html
@@ -52,4 +52,6 @@
 {%- endfor -%}
 </pre>
 </div>
+
+
 {% endblock %}

--- a/dxr/templates/layout.html
+++ b/dxr/templates/layout.html
@@ -60,16 +60,21 @@
           </div>
           <div class="shown-with-results">
             <div id="tree-tip">
-              Browsing {% if not showing_tree_menu %}<b>{{ tree }}</b>{% endif %}
+              <div class = "file-name"> 
+                {%- for path, name in source_components -%}
+                <span class="slash">/</span><a href="{{ path }}">{{ name }}</a>
+                {%- endfor -%}
+                <!-- Browsing {% if not showing_tree_menu %}<b>{{ tree }}</b>{% endif %} -->
+              </div>
             </div>
             <div id="tip">
               {%- block tip -%}
-                Enter search query here
+              <label for="query">Enter search query here</label>
               {%- endblock -%}
             </div>
           </div>
 
-          <input type="text" name="q" value="{{ query }}" maxlength="2048" id="query" accesskey="s" title="Search" autocomplete="off" autofocus>
+          <input type="text" name="q" value="{{ query }}" maxlength="2048" id="query" accesskey="s" title="Search" autocomplete="off" autofocus >
           <input type="hidden" name="redirect" value="true" id="redirect">
 
           <div class="hidden-with-results">


### PR DESCRIPTION
This implements a navigable header on top of the file and folder pages. The header will contain the full name of the file or directory currently being looked at. It can easily be cut/pasted into an editor or terminal. Each of the individual components of the path can be clicked on for easy navigation. This is similar to how http://lxr.free-electrons.com/source/block/blk-cgroup.c works. 

I have a demo version of the new interface at http://noufalibrahim.name:8080/code/source/
