### PR TITLE
Fix tests on Python 2.6.

### DIFF
--- a/dxr/app.py
+++ b/dxr/app.py
@@ -34,7 +34,7 @@ def make_app(instance_path):
     app.config.from_pyfile(os.path.join(app.instance_path, 'config.py'))
 
     # Log to Apache's error log in production:
-    app.logger.addHandler(StreamHandler(stream=stderr))
+    app.logger.addHandler(StreamHandler(stderr))
     return app
 
 

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ import sys
 # Prevent spurious errors during `python setup.py test`, a la
 # http://www.eby-sarna.com/pipermail/peak/2010-May/003357.html:
 try:
-    import multiprocessing
+    import concurrent.futures
 except ImportError:
     pass
 


### PR DESCRIPTION
- logging.StreamHandler doesn't support a named parameter "stream"
- The workaround for errors from setuptools needs to be updated
  to use concurrent.futures instead of multiprocessing since the
  tests were changed to use concurrent.futures.
