### PR TITLE
Prepend wwwroot to breadcrumbs

### DIFF
--- a/dxr/templates/layout.html
+++ b/dxr/templates/layout.html
@@ -62,7 +62,7 @@
             <div id="tree-tip">
               <div class="file-name">
                 {%- for path, name in paths_and_names -%}
-                  <span class="slash">/</span><a href="{{ path }}">{{ name }}</a>
+                  <span class="slash">/</span><a href="{{ wwwroot }}{{ path }}">{{ name }}</a>
                 {%- endfor -%}
               </div>
             </div>


### PR DESCRIPTION
The URL associated with the breadcrumbs seems not to be correct if wwwroot is set. I think something like this will
fix it.
