### PR TITLE
Emit decldef for C variables even when there's just a tentative definiti...

### DIFF
--- a/dxr/plugins/clang/dxr-index.cpp
+++ b/dxr/plugins/clang/dxr-index.cpp
@@ -475,8 +475,22 @@ public:
       printExtent(d->getLocation(), d->getLocation());
       *out << std::endl;
     }
-    if (VarDecl *vd = dyn_cast<VarDecl>(d))
-      declDef("variable", vd, vd->getDefinition(), vd->getLocation(), vd->getLocation());
+    if (VarDecl *vd = dyn_cast<VarDecl>(d)) {
+      VarDecl *def = vd->getDefinition();
+      if (!def) {
+        VarDecl *First = vd->getFirstDeclaration();
+        VarDecl *LastTentative = 0;
+        for (VarDecl::redecl_iterator I = First->redecls_begin(), E = First->redecls_end();
+             I != E; ++I) {
+          VarDecl::DefinitionKind Kind = I->isThisDeclarationADefinition();
+          if (Kind == VarDecl::TentativeDefinition) {
+            LastTentative = *I;
+          }
+        }
+        def = LastTentative;
+      }
+      declDef("variable", vd, def, vd->getLocation(), vd->getLocation());
+    }
   }
 
   bool VisitEnumConstantDecl(EnumConstantDecl *d) { visitVariableDecl(d); return true; }

--- a/tests/test_c_vardecl/code/extern.c
+++ b/tests/test_c_vardecl/code/extern.c
@@ -1,0 +1,9 @@
+#include "extern.h"
+
+int global;
+
+void
+set_global()
+{
+  global = 0;
+}

--- a/tests/test_c_vardecl/code/extern.h
+++ b/tests/test_c_vardecl/code/extern.h
@@ -1,0 +1,10 @@
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+extern int global;
+
+void set_global(void);
+#ifdef __cplusplus
+}
+#endif

--- a/tests/test_c_vardecl/code/main.cpp
+++ b/tests/test_c_vardecl/code/main.cpp
@@ -1,0 +1,9 @@
+#include <stdio.h>
+#include "extern.h"
+
+// Hello World Example
+int main(int argc, char* argv[]){
+  set_global();
+  printf("Hello World");
+  return global;
+}

--- a/tests/test_c_vardecl/code/makefile
+++ b/tests/test_c_vardecl/code/makefile
@@ -1,0 +1,12 @@
+all: code
+code: main.o extern.o
+	$(CXX) -o $@ $^
+
+main.o: main.cpp extern.h
+	$(CXX) -I. -c main.cpp
+
+extern.o: extern.c extern.h
+	$(CC) -I. -c extern.c
+
+clean:
+	rm -rf code *.o

--- a/tests/test_c_vardecl/dxr.config.in
+++ b/tests/test_c_vardecl/dxr.config.in
@@ -1,0 +1,10 @@
+[DXR]
+enabled_plugins     = pygmentize clang
+temp_folder         = PWD/temp
+target_folder       = PWD/target
+nb_jobs             = 4
+
+[code]
+source_folder       = PWD/code
+object_folder       = PWD/code
+build_command       = make clean; make -j $jobs

--- a/tests/test_c_vardecl/makefile
+++ b/tests/test_c_vardecl/makefile
@@ -1,0 +1,13 @@
+all:
+	# Link paths in dxr.config.in to current working directory
+	# replaces PWD with `pwd` and produces dxr.config
+	cat dxr.config.in | sed -e 's?PWD?'`pwd`'?g' > dxr.config
+	# Navigate into the DXR folder, build using config file
+	LD_LIBRARY_PATH=$$LD_LIBRARY_PATH:../../trilite dxr-build.py
+	# Launch test server at port 8000:
+	# dxr-serve.py target
+clean:
+	rm -rf dxr.config
+	rm -rf temp
+	rm -rf target
+	cd code; make clean; cd -

--- a/tests/test_c_vardecl/test_c_vardecl.py
+++ b/tests/test_c_vardecl/test_c_vardecl.py
@@ -1,0 +1,13 @@
+from dxr.testing import DxrInstanceTestCase
+
+
+class CVarDeclTests(DxrInstanceTestCase):
+    """Tests matching up C global variables"""
+
+    def test_decl(self):
+        """Search for C variable declaration."""
+        self.found_line_eq('var-decl:global', u'extern int <b>global</b>;', 5)
+
+    def test_defn(self):
+        """Search for C variable definition."""
+        self.found_line_eq('var:global', u'int <b>global</b>;', 3)


### PR DESCRIPTION
...on

The issue is that getDefinition() will return 0 for things in C at
file scope like

```
extern int i;
int i;           /* This isn't a definition --- it's tentative */
```

In C++ that is a definition. While technically it's not a definition,
matching up variable references seems to work better in C code that
I've seen if we assume that such tentative definitions are in fact
definitions, as they are in C++.
