### PR TITLE
Don't retry fetching results on failure, 500 or otherwise. Fix bug 848480

### DIFF
--- a/dxr/static/search.js
+++ b/dxr/static/search.js
@@ -228,17 +228,16 @@ function fetchResults(displayFetcher){
       if(data["error"])
         dxr.setErrorTip(data["error"]);
       request = null;
-    }else if(request.readyState == 4){
-      // Something failed, who cares try again :)
-      request = null;
-      fetchResults();
-    }
-    // Hide fetcher if finished request
-    if(request == null){
+
+      // Hide fetcher when request finished:
       fetcher.style.display    = 'block';
       fetcher.style.visibility = 'hidden';
-      // Fetch results if there's no scrollbar initially
-      if(atPageBottom()) fetchResults();
+
+      // Fetch results again if there's no scrollbar initially. Otherwise, the
+      // user can't scroll to the bottom to let us know he wants even more
+      // results.
+      if(atPageBottom())
+        fetchResults();
     }
   }
 


### PR DESCRIPTION
I'm not sure why we were being so failure-tolerant in the JS before; perhaps the CGI failed or timed out a lot. With WSGI, we no longer have timeouts to worry about, and, if we have other failures, we should solve the root problem.

If there is an error, the user can "retry" just by changing the search query or hitting Return, both of which should be natural reactions.
