### PR TITLE
Hide the popup menu when the user follows a link

### DIFF
--- a/dxr/static/menu.js
+++ b/dxr/static/menu.js
@@ -28,6 +28,7 @@ menu.populate = function(links){
     var icon = wwwroot + "/static/icons/" + link.icon + ".png";
     content += "<a href=\"" + htmlEntities(link.href) + "\"";
     content += " title=\"" + htmlEntities(link.title) + "\"";
+    content += " onclick=\"menu.hide(); return true;\"";
     content += " style=\"background-image: url('" + icon + "')\">";
     content += htmlEntities(link.text) + "</a>";
   }


### PR DESCRIPTION
I find it annoying when I follow a link from the popup menu, then hit back and the menu is still displayed. That is not the usual behaviour for menus. This one line patch fixes that.

Note that adding a listener on window for the beforeunload event does not work because the followed link might be on the same page. Using an onclick property on the link is a bit old school, but it doesn't seem worth the effort to add an id, getElementById and then add an event listener for click in this case.
