### PR TITLE
Change found_lines_eq to understand escaped HTML entities in the expecte...

### DIFF
--- a/dxr/testing.py
+++ b/dxr/testing.py
@@ -187,6 +187,14 @@ foot_text =
         else:
             print 'Not deleting instance in %s.' % cls._config_dir_path
 
+    def _source_for_query(self, s):
+        return (s.replace('<b>', '')
+                 .replace('</b>', '')
+                 .replace('&lt;', '<')
+                 .replace('&gt;', '>')
+                 .replace('&quot;', '"')
+                 .replace('&amp;', '&'))
+
     def found_line_eq(self, query, content, line=None):
         """A specialization of ``found_line_eq`` that computes the line number
         if not given
@@ -198,7 +206,7 @@ foot_text =
         """
         if not line:
             line = self.source.count( '\n', 0, self.source.index(
-                content.replace('<b>', '').replace('</b>', ''))) + 1
+                self._source_for_query(content))) + 1
         super(SingleFileTestCase, self).found_line_eq(query, content, line)
 
 

--- a/tests/test_callers.py
+++ b/tests/test_callers.py
@@ -85,8 +85,7 @@ class IndirectCallTests(SingleFileTestCase):
         """ + MINIMAL_MAIN
 
     def test_callers(self):
-        self.found_lines_eq('+callers:Base::foo()', [
-            ('void <b>c1</b>(Base &amp;b)', 16)])
+        self.found_line_eq('+callers:Base::foo()', 'void <b>c1</b>(Base &amp;b)')
         self.found_lines_eq('+callers:Derived::foo()', [
             ('void <b>c1</b>(Base &amp;b)', 16),
             ('void <b>c2</b>(Derived &amp;d)', 21)])
@@ -95,5 +94,4 @@ class IndirectCallTests(SingleFileTestCase):
         self.found_lines_eq('called-by:c1', [
             ('virtual void <b>foo</b>() {}', 6),
             ('virtual void <b>foo</b>() {}', 13)])
-        self.found_lines_eq('called-by:c2', [
-            ('virtual void <b>foo</b>() {}', 13)])
+        self.found_line_eq('called-by:c2', 'virtual void <b>foo</b>() {}', 13)

--- a/tests/test_type_templates.py
+++ b/tests/test_type_templates.py
@@ -17,7 +17,7 @@ class TypeTests(SingleFileTestCase):
         self.found_line_eq('type:Foo',
                            'class <b>Foo</b>')
         self.found_line_eq('type-ref:Foo',
-                           '<b>Foo</b>&lt;int&gt;();', 8)
+                           '<b>Foo</b>&lt;int&gt;();')
 
 class BaseClassTests(SingleFileTestCase):
     source = r"""
@@ -33,7 +33,7 @@ class BaseClassTests(SingleFileTestCase):
 
     def test_base_class(self):
         self.found_line_eq('type-ref:Foo',
-                           'class Bar : public <b>Foo</b>&lt;T&gt;', 7)
+                           'class Bar : public <b>Foo</b>&lt;T&gt;')
 
 class TemplateParameterTests(SingleFileTestCase):
     source = r"""
@@ -52,10 +52,10 @@ class TemplateParameterTests(SingleFileTestCase):
         self.found_line_eq('+type:Foo::T',
                            'template &lt;typename <b>T</b>&gt;', 2)
         self.found_line_eq('+type-ref:Foo::T',
-                           'Foo(const <b>T</b> &amp;);', 5)
+                           'Foo(const <b>T</b> &amp;);')
 
     def test_function_template_parameter(self):
         self.found_line_eq('+type:"bar(const T &)::T"',
                            'template &lt;typename <b>T</b>&gt;', 7)
         self.found_line_eq('+type-ref:"bar(const T &)::T"',
-                           'void bar(const <b>T</b> &amp;)', 8)
+                           'void bar(const <b>T</b> &amp;)')


### PR DESCRIPTION
...d result

when looking for the corresponding source line.
