### PR TITLE
removed Ls from line number fragment

### DIFF
--- a/dxr/static/file.js
+++ b/dxr/static/file.js
@@ -104,12 +104,12 @@ function initMenu(){
   }, false);
 }
 
-var pattern = /^#l[0-9]+$/;
+var pattern = /^#[0-9]+$/;
 /** Find line by anchor */
 function findLine(){
   var result;
   if((result = pattern.exec(window.location.hash)) != null){
-    return parseInt(result[0].substr(2));
+    return parseInt(result[0].substr(1));
   }
   return -1;
 }

--- a/dxr/static/search.js
+++ b/dxr/static/search.js
@@ -13,7 +13,7 @@ var resultTemplate = ""
 
 var linesTemplate = ""
  + "<a class=\"snippet\" "
- + "   href=\"{{wwwroot}}/{{tree}}/source/{{path}}#l{{line_number}}\">"
+ + "   href=\"{{wwwroot}}/{{tree}}/source/{{path}}#{{line_number}}\">"
  + "  <div class=\"line-numbers\">"
  + "    <pre><span class=\"ln\">{{line_number}}</span></pre>"
  + "  </div>"

--- a/dxr/templates/file.html
+++ b/dxr/templates/file.html
@@ -40,9 +40,9 @@
 </div>
 <div class="line-numbers">
   {% for number, line, annotations in lines %}
-  <pre><a href="#l{{ number }}"
+  <pre><a href="#{{ number }}"
           class="ln" id="line-{{ number }}"
-          name="l{{ number }}">{{ number }}</a></pre>
+          name="{{ number }}">{{ number }}</a></pre>
   {%- endfor %}
 </div>
 <div class="file-lines">

--- a/dxr/templates/search.html
+++ b/dxr/templates/search.html
@@ -111,7 +111,7 @@
         {%- endfor -%}
       </div>
       {% for number, line in lines %}
-        <a class="snippet" href="{{ wwwroot }}/{{ tree }}/source/{{ path }}#l{{ number }}">
+        <a class="snippet" href="{{ wwwroot }}/{{ tree }}/source/{{ path }}#{{ number }}">
           <div class="line-numbers">
           <pre><span class="ln">{{ number }}</span></pre>
           </div>


### PR DESCRIPTION
Changed line-number fragment from #l5 to just #5. Lowercase Ls look like ones. 
Referenced here: https://wiki.mozilla.org/DXR_UI_Refresh#UI
