### PR TITLE
Fix annotations being off by one line when there was no annotation

### DIFF
--- a/dxr/build.py
+++ b/dxr/build.py
@@ -918,7 +918,7 @@ def lines_and_annotations(lines, htmlifiers):
         Return an iterable of annotations iterables, one for each line.
 
         """
-        next_unannotated_line = 1
+        next_unannotated_line = 0
         for line, annotations in groupby(annotations, itemgetter(0)):
             for next_unannotated_line in xrange(next_unannotated_line,
                                                 line - 1):

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -270,6 +270,19 @@ class AnnotationsTests(TestCase):
              ('five', []),
              ('six', [{'g': 'h'}])])
 
+    def test_jump_ahead(self):
+        """Make sure annotations show up on the correct line even when there is
+        no annotation for the first line."""
+        h1 = Htmlifier(annotations=[(3, {'e': 'f'})])
+
+        results = self._expand_group(lines_and_annotations(
+                    ['one', 'two', 'three', 'four'], [h1]))
+        eq_(results,
+            [('one', []),
+             ('two', []),
+             ('three', [{'e': 'f'}]),
+             ('four', [])])
+
     def test_none(self):
         """If there are no annotations, or if the annotations run short of the
         lines, don't stop emitting lines."""


### PR DESCRIPTION
on the first line in the file.
