### PR TITLE
Increase timeout for the installation of firefox build-deps.

### DIFF
--- a/puppet/manifests/classes/dxr.pp
+++ b/puppet/manifests/classes/dxr.pp
@@ -8,7 +8,8 @@ class dxr ($project_path){
     }
 
     exec { "install-builddeps":
-        command => "/usr/bin/sudo /usr/bin/apt-get -y build-dep firefox";
+        command => "/usr/bin/sudo /usr/bin/apt-get -y build-dep firefox",
+        timeout => 600,
     }
 
     exec { "install_llvm":


### PR DESCRIPTION
It's been timing out on Jenkins.
