### PR TITLE
Use JS with preprocessor pygments lexer

### DIFF
--- a/dxr/plugins/pygmentize/htmlifier.py
+++ b/dxr/plugins/pygmentize/htmlifier.py
@@ -43,11 +43,9 @@ class JavascriptPreprocLexer(JavascriptLexer):
     """
 
     name = 'JavaScriptPreproc'
-    aliases = []
     filenames = []
     mimetypes = []
 
-    flags = re.DOTALL
     tokens = {
         'commentsandwhitespace': [
             # python-style comment


### PR DESCRIPTION
Rebased issue 155. I'm not sure what version of Pygments we are using. If we are up to date, then JavascriptPreprocLexer exists in there repo so we don't need this local one. In which case I can update this pr, just let me know.
