### PR TITLE
Add more options to dxr-serve.py

### DIFF
--- a/README.mkd
+++ b/README.mkd
@@ -35,9 +35,9 @@ On the VM...
     make
     cd ~/dxr/tests/test_basic
     make
-    dxr-serve.py --host 0.0.0.0 target
+    dxr-serve.py --all target
 
-You need to bind to a public interface (0.0.0.0) or else you will be unable to
+You need to bind to all interfaces (--all) or else you will be unable to
 get to the Vagrant box's test server from the host machine.
 Then, on your host box, surf to http://33.33.33.77:8000/, and poke around to
 your heart's content. You may have to substitute the IP address of your Vagrant

--- a/bin/dxr-serve.py
+++ b/bin/dxr-serve.py
@@ -14,6 +14,10 @@ def main():
     parser = OptionParser(usage='usage: %prog [options] build-folder',
                           add_help_option=False)
     parser.add_option('--help', action='help')
+    parser.add_option('-a', '--all', dest='host',
+                      action='store_const',
+                      const='0.0.0.0',
+                      help='Serve on all interfaces.  Equivalent to --host 0.0.0.0')
     parser.add_option('-h', '--host', dest='host',
                       type='string',
                       default='localhost',

--- a/docs/development.mkd
+++ b/docs/development.mkd
@@ -25,7 +25,7 @@ cd tests/test_basic/
 make
 
 # run the server
-../../bin/dxr-serve.py --host 0.0.0.0 target
+../../bin/dxr-serve.py --all target
 # Server should be running on 33.33.33.77:8000.
 
 # all done? ctrl+c to interrupt the server


### PR DESCRIPTION
-h, --host      Hostname to bind to
-j, --jobs      Number of processes to use
-t, --threaded  Use a separate thread for each request
