### PR TITLE
fix conflicting plugins error message

### DIFF
--- a/dxr/config.py
+++ b/dxr/config.py
@@ -96,9 +96,11 @@ class Config(object):
             self.enabled_plugins = self.enabled_plugins.split()
 
         # Test for conflicting plugins settings
-        if any((p in self.disabled_plugins for p in self.enabled_plugins)):
-            msg = "Plugin: '%s' is both enabled and disabled in '%s'"
-            print >> sys.stderr, msg % (p, name)
+        conflicts = [p for p in self.disabled_plugins if p in self.enabled_plugins]
+        if len(conflicts) > 0:
+            msg = "Plugin: '%s' is both enabled and disabled"
+            for p in conflicts:
+                print >> sys.stderr, msg % p
             sys.exit(1)
 
         # Load trees
@@ -181,9 +183,11 @@ class TreeConfig(object):
             self.enabled_plugins = self.enabled_plugins.split()
 
         # Test for conflicting plugins settings
-        if any(p in self.disabled_plugins for p in self.enabled_plugins):
+        conflicts = [p for p in self.disabled_plugins if p in self.enabled_plugins]
+        if len(conflicts) > 0:
             msg = "Plugin: '%s' is both enabled and disabled in '%s'"
-            print >> sys.stderr, msg % (p, name)
+            for p in conflicts:
+                print >> sys.stderr, msg % (p, name)
             sys.exit(1)
 
         # Warn if $jobs isn't used...


### PR DESCRIPTION
Print out a more correct message when a plugin is marked as both enabled and disabled.
Previously:

```
File "/home/vagrant/dxr/dxr/config.py", line 101, in __init__
    print >> sys.stderr, msg % (p, name)
UnboundLocalError: local variable 'p' referenced before assignment
```

Now:

```
Plugin: 'pygmentize' is both enabled and disabled
Plugin: 'clang' is both enabled and disabled
```
