### PR TITLE
enable vagrantfile to work with vagrant versions 1 and 2

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -15,10 +15,21 @@ end
 CONF = _config
 MOUNT_POINT = '/home/vagrant/dxr'
 
+
 Vagrant::Config.run do |config|
     config.vm.box = "precise64"
     config.vm.box_url = "http://files.vagrantup.com/precise64.box"
-    config.vm.customize ["modifyvm", :id, "--memory", CONF['memory']]
+
+    Vagrant.configure("1") do |config|
+        config.vm.customize ["modifyvm", :id, "--memory", CONF['memory']]
+    end
+
+    Vagrant.configure("2") do |config|
+        config.vm.provider "virtualbox" do |v|
+          v.name = "DXR_VM"
+          v.customize ["modifyvm", :id, "--memory", CONF['memory']]
+        end
+    end
 
     is_jenkins = ENV['USER'] == 'jenkins'
 
@@ -32,8 +43,16 @@ Vagrant::Config.run do |config|
         config.vm.forward_port 80, 8000
     end
 
-    # Enable symlinks, which trilite uses during build:
-    config.vm.customize ["setextradata", :id, "VBoxInternal2/SharedFoldersEnableSymlinksCreate/vagrant-root", "1"]
+    Vagrant.configure("1") do |config|
+        # Enable symlinks, which trilite uses during build:
+        config.vm.customize ["setextradata", :id,
+            "VBoxInternal2/SharedFoldersEnableSymlinksCreate/vagrant-root", "1"]
+    end
+
+    Vagrant.configure("2") do |config|
+        v.customize ["setextradata", :id,
+            "VBoxInternal2/SharedFoldersEnableSymlinksCreate/vagrant-root", "1"]
+    end
 
     if CONF['boot_mode'] == 'gui'
         config.vm.boot_mode = :gui


### PR DESCRIPTION
take code that relies on differences in the api between vagrant versions and wrap them in configure blocks that will conditionally execute. this allows backwards compatibility and removes pesky warnings from Jenkins.
