### PR TITLE
Override plugins to build from environment

### DIFF
--- a/makefile
+++ b/makefile
@@ -1,4 +1,4 @@
-PLUGINS = clang pygmentize
+PLUGINS ?= clang pygmentize
 
 BUILD_PLUGINS = $(PLUGINS:%=build-plugin-%)
 CHECK_PLUGINS = $(PLUGINS:%=check-plugin-%)


### PR DESCRIPTION
This makes it easier to change the list of plugins to build:

``` sh
PLUGINS=pygmentize python setup.py build
```
