### PR TITLE
refs bug 969248: added event.state check to prevent #anchor reloads

### DIFF
--- a/dxr/static/js/dxr.js
+++ b/dxr/static/js/dxr.js
@@ -469,7 +469,10 @@ $(function() {
 
     // Reload the page when we go back or forward.
     function popStateHandler(event) {
-        window.onpopstate = null;
-        window.location.reload();
+        //check for event state first to avoid nasty complete page reloads on #anchors
+	if (event.state != null) {
+            window.onpopstate = null;
+            window.location.reload();
+	}
     }
 });


### PR DESCRIPTION
Splitting this patch out into a separate branch so that it can be merged before the multi-select patch in a different pull request.
