### PR TITLE
Fix missing lines from highlights on shift-select upwards and then down again

### DIFF
--- a/dxr/static/js/code-highlighter.js
+++ b/dxr/static/js/code-highlighter.js
@@ -57,8 +57,8 @@ $(function () {
             var lastSelected = $('.last-selected'),
                 highlightedLines = $('highlighted');
             line = $('#' + clickedNum);
-            //Remove existing highlights. 
-            $('.highlighted').removeClass('last-selected highlighted');
+            //Remove existing highlights.
+            $('.highlighted').removeClass('last-selected highlighted clicked');
             //toggle highlighting on for any line that was not previously clicked
             if (parseInt(lastSelected.attr('id'), 10) !== clickedNum) {
                 //With this we're one better than github, which doesn't allow toggling single lines


### PR DESCRIPTION
 I think this fixes it. I have tried to reproduce by selecting upwards and then down again with all manner of clicking and haven't see the dreaded zebra stripes :)
