### PR TITLE
Restore warning icons that have been missing since the new UI landed.

### DIFF
--- a/dxr/plugins/clang/htmlifier.py
+++ b/dxr/plugins/clang/htmlifier.py
@@ -429,7 +429,6 @@ class ClangHtmlifier(object):
 
 
     def annotations(self):
-        icon = "background-image: url('%s/static/icons/warning.png');" % self.tree.config.wwwroot
         sql = "SELECT msg, opt, file_line FROM warnings WHERE file_id = ? ORDER BY file_line"
         for msg, opt, line in self.conn.execute(sql, (self.file_id,)):
             if opt:
@@ -437,7 +436,7 @@ class ClangHtmlifier(object):
             yield line, {
                 'title': msg,
                 'class': "note note-warning",
-                'style': icon
+                'style': ''
             }
 
     def links(self):

--- a/dxr/static/css/dxr.css
+++ b/dxr/static/css/dxr.css
@@ -133,6 +133,18 @@ table td {
 td.code {
     padding: 0 0 0 .5em;
 }
+.annotation-set:after {
+    content: "\a0";  /* non-breaking space */
+}
+.note {
+    float: left;
+    height: 16px;
+    width: 16px;
+    margin-bottom: -1px;
+}
+.note-warning {
+    background-image: url('/static/icons/warning.png');
+}
 td#line-numbers {
     position: absolute;
     width: 95%;

--- a/dxr/static/css/dxr.css
+++ b/dxr/static/css/dxr.css
@@ -133,6 +133,14 @@ table td {
 td.code {
     padding: 0 0 0 .5em;
 }
+#annotations {
+    width: 3%;
+    min-width: 45px;
+}
+.annotation-set {
+    height: 1.3em;
+    overflow: hidden;
+}
 .annotation-set:after {
     content: "\a0";  /* non-breaking space */
 }
@@ -211,7 +219,7 @@ table.result_snippet tr,
     vertical-align: baseline;
 }
 .result_snippet td:first-child,
-.file td:first-child {
+.file td#line-numbers {
     border-right: 1px solid #fff;
     color: #aaa;
     text-align: right;
@@ -239,7 +247,7 @@ table.result_snippet tr,
 .file td {
     padding: 0 .5em 0 .5em;
 }
-.file td:first-child a {
+.file td#line-numbers a {
     display: block;
     padding: 0 .5rem;
 }

--- a/dxr/static/css/dxr.css
+++ b/dxr/static/css/dxr.css
@@ -223,6 +223,8 @@ table.result_snippet tr,
     border-right: 1px solid #fff;
     color: #aaa;
     text-align: right;
+}
+.result_snippet td:first-child {
     width: 4%;
 }
 .result_snippet td {

--- a/dxr/static/templates/file.html
+++ b/dxr/static/templates/file.html
@@ -49,25 +49,25 @@
     </div>
   {% endif %}
 
-  <div id="annotations">
-    {% for line, annotations in lines %}
-      <div class="annotation-set" id="aset-{{ loop.index }}">
-        {%- for annotation in annotations -%}
-          <div {% for key, value in annotation.items() %}
-                {{ key }}="{{ value }}"
-               {% endfor %} ></div>
-        {%- endfor -%}
-      </div>
-    {%- endfor -%}
-  </div>
-
   <table id="file" class="file">
     <thead class="visually-hidden">
+        <th scope="col">Annotations</th>
         <th scope="col">Line</th>
         <th scope="col">Code</th>
     </thead>
     <tbody>
       <tr>
+        <td id="annotations">
+          {% for line, annotations in lines %}
+            <div class="annotation-set" id="aset-{{ loop.index }}">
+              {%- for annotation in annotations -%}
+                <div {% for key, value in annotation.items() %}
+                      {{ key }}="{{ value }}"
+                     {% endfor %} ></div>
+              {%- endfor -%}
+            </div>
+          {%- endfor -%}
+        </td>
         <td id="line-numbers">
           {% for line in lines %}
             <span id="{{ loop.index }}" class="line-number" unselectable="on" rel="#{{ loop.index }}">{{ loop.index }}</span>


### PR DESCRIPTION
I'm not sure why the annotations column takes up the amount of horizontal space that it does or what the best way to adjust that is.
