### PR TITLE
Only !merge local vagrant params when present

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -6,8 +6,11 @@ _config = YAML.load(File.open(File.join(File.dirname(__FILE__),
 
 # Local-specific/not-git-managed config -- vagrantconfig_local.yaml
 begin
-    _config.merge!(YAML.load(File.open(File.join(File.dirname(__FILE__),
-                   "vagrantconfig_local.yaml"), File::RDONLY).read))
+    extra = YAML.load(File.open(File.join(File.dirname(__FILE__),
+                      "vagrantconfig_local.yaml"), File::RDONLY).read)
+    if extra
+        _config.merge!(extra)
+    end
 rescue Errno::ENOENT # No vagrantconfig_local.yaml found -- that's OK; just
                      # use the defaults.
 end


### PR DESCRIPTION
If vagrantconfig_local.yaml is empty `YAML.load()` will eval to false and upon
running `vagrant up` you will get the error: "ERROR loader: Vagrantfile load
error: no implicit conversion of false into Hash." This patch checks to make
sure some YAML was parsed before merging it.
