### PR TITLE
Make url hash is consistent with ranges, ctrl/cmd toggles single lines properly

### DIFF
--- a/docs/source/code-highlighter.rst
+++ b/docs/source/code-highlighter.rst
@@ -39,7 +39,7 @@ the first line to highlight the entire range of lines.
 ``Ctrl/Commnd+click``
 ---------------------
 
-Hold Ctrl/Command while selecting a line and the individual line will be added
+Hold ``Ctrl/Command`` while selecting a line and the individual line will be added
 to any other highlighted lines or ranges of lines. ``Ctrl/Command+click`` a
 selected line to deselect it.
 
@@ -52,5 +52,5 @@ range will be split at the line in question.
 
 After selecting a line or range of lines, use ``Ctrl/Command+click`` to start
 highlight the first line in another range of lines. You can then use
-Shift+click and the second range will be highlighted, in addition to
+``Shift+click`` and the second range will be highlighted, in addition to
 any others.

--- a/dxr/static/js/code-highlighter.js
+++ b/dxr/static/js/code-highlighter.js
@@ -93,7 +93,7 @@ $(function () {
         }
     }
 
-    //parse windwow.location.hash on new requsts into two arrays
+    //parse window.location.hash on new requsts into two arrays
     //one of single lines and one multilines
     //use with singleLinesArray and rangesArray for adding/changing new highlights
     function getSortedHashLines() {
@@ -198,7 +198,8 @@ $(function () {
             lastModifierKey = 'shift';
             // since all highlighed items are stripped, add one back, mark new last-selected
             lastSelected.addClass(classToAdd);
-            lastSelected.removeClass('last-selected');
+            lastSelected.removeClass('last-selected highlighted');
+            //line.removeClass('highlighted');
             line.addClass(classToAdd);
             line.addClass('last-selected');
 
@@ -210,6 +211,7 @@ $(function () {
             selected = $('.last-selected').nextUntil($('.clicked'));
             selected.each(function () {
                 selected.addClass('multihighlight');
+                selected.removeClass('highlighted');
             });
             line.addClass('multihighlight');
 
@@ -219,7 +221,12 @@ $(function () {
             line = $('#' + clickedNum);
             $('.highlighted').addClass('multihighlight');
             $('.line-number').removeClass('last-selected clicked highlighted');
-            line.toggleClass('clicked last-selected multihighlight');
+            if (parseInt(lastSelected.attr('id'), 10) !== clickedNum) {
+                line.toggleClass('clicked last-selected multihighlight');
+            } else {
+                line.toggleClass('multihighlight');
+                history.replaceState(null, '', '#');
+            }
 
         } else {
             //set lastModifierKey ranges and single lines to null, then clear all highlights


### PR DESCRIPTION
This fix is for bugs #991990 & #991991, and some spelling too.
