### PR TITLE
Add compatibility for clang 3.5 (svn)

### DIFF
--- a/dxr/plugins/clang/dxr-index.cpp
+++ b/dxr/plugins/clang/dxr-index.cpp
@@ -442,7 +442,11 @@ public:
       beginRecord("function", d->getLocation());
       recordValue("name", d->getNameAsString());
       recordValue("qualname", getQualifiedName(*d));
+#if CLANG_AT_LEAST(3, 5)
+      recordValue("type", d->getCallResultType().getAsString());
+#else
       recordValue("type", d->getResultType().getAsString());
+#endif
       std::string args("(");
       for (FunctionDecl::param_iterator it = d->param_begin();
           it != d->param_end(); it++) {
@@ -1164,8 +1168,8 @@ protected:
     if (!abs_src) {
       DiagnosticsEngine &D = CI.getDiagnostics();
       unsigned DiagID = D.getCustomDiagID(DiagnosticsEngine::Error,
-        "Source directory '" + args[0] + "' does not exist");
-      D.Report(DiagID);
+        "Source directory '%0' does not exist");
+      D.Report(DiagID) << args[0];
       return false;
     }
     srcdir = abs_src;
@@ -1178,8 +1182,8 @@ protected:
     if (!abs_output) {
       DiagnosticsEngine &D = CI.getDiagnostics();
       unsigned DiagID = D.getCustomDiagID(DiagnosticsEngine::Error,
-        "Output directory '" + output + "' does not exist");
-      D.Report(DiagID);
+        "Output directory '%0' does not exist");
+      D.Report(DiagID) << output;
       return false;
     }
     output = realpath(output.c_str(), NULL);
@@ -1195,8 +1199,8 @@ protected:
     if(!abs_tmpdir){
       DiagnosticsEngine &D = CI.getDiagnostics();
       unsigned DiagID = D.getCustomDiagID(DiagnosticsEngine::Error,
-        "Temporary directory '" + output + "' does not exist");
-      D.Report(DiagID);
+        "Temporary directory '%0' does not exist");
+      D.Report(DiagID) << tmpdir;
       return false;
     }
     tmpdir = realpath(tmpdir.c_str(), NULL);


### PR DESCRIPTION
- FunctionDecl::getResultType() was renamed to FunctionDecl::getCallResultType()
- We were misusing DiagnosticsEngine::getCustomDiagID as it should always
  take a constant string.  Switch to using formatted output to make this work
  on both clang 3.5 and previous versions.
- Correct a copy-paste error where we were printing the name of the output
  directory instead of the name of the temporary directory in an error
  message.
