### PR TITLE
 Fixing bugs: 1053423, 1052524 and 965652 

### DIFF
--- a/dxr/static/css/dxr.css
+++ b/dxr/static/css/dxr.css
@@ -175,6 +175,9 @@ td pre code {
 code a {
     cursor: pointer;
 }
+.code code a {
+    cursor: context-menu;
+}
 mark {
     position: relative;
     padding: .5rem;
@@ -269,7 +272,6 @@ mark {
 }
 .context-menu a {
     display: block;
-    padding: .4rem;
     text-decoration: none;
 }
 .context-menu li:first-child a:hover {
@@ -439,7 +441,6 @@ mark {
 .panel section a {
     display: inline-block;
     background-color: #fff;
-    padding: .3rem .5rem .3rem 1.5rem;
     width: 100%;
 }
 .panel section a:hover {

--- a/dxr/static/css/icons.css
+++ b/dxr/static/css/icons.css
@@ -3,13 +3,12 @@
     background: transparent url(/static/icons/folder.png) .5em 7px no-repeat;
     padding: .5em .5em .5em 30px;  /* 30px = 16px icon + 7px padding above + a little more whitespace */
 }
-.folder-content,
-.result {
+.folder-content {
     clear: both;
 }
-.folder-content .icon {
+.icon {
     background-color: transparent;
-    background-position: .5em 6px;
+    background-position: .5em center;
     background-repeat: no-repeat;
     padding: .5em .5em .5em 30px;
 }
@@ -19,27 +18,8 @@
     float: right;
     padding: 8px; /* Makes the container 16x16 in order to show full icon. */
 }
-a.reference {
-    background: transparent url(/static/icons/reference.png) 4px 8px no-repeat;
-    padding-left: 1.5rem;
-}
-a.method {
-    background: transparent url(/static/icons/method.png) 4px 8px no-repeat;
-    padding-left: 1.5rem;
-}
-a.field {
-    background: transparent url(/static/icons/field.png) 2px 8px no-repeat;
-    padding-left: 1.5rem;
-}
-a.search {
-    background: transparent url(/static/icons/search.png) 4px 8px no-repeat;
-    padding-left: 1.5rem;
-}
-a.class {
-    background: transparent url(/static/icons/class.png) 4px 2px no-repeat;
-    padding-left: 1.5rem;
-}
-/* Folder context menu */
+
+/* Folder context-menu */
 a.goto-folder {
     background: transparent url(/static/icons/goto_folder.png) 4px 8px no-repeat;
     padding-left: 1.5rem;
@@ -52,10 +32,78 @@ a.exclude-path {
     background: transparent url(/static/icons/exclude_path.png) 4px 8px no-repeat;
     padding-left: 1.5rem;
 }
+/* End of folder context-menu */
+
+/* Context-menu and Panel icons */
+a.class {
+    background-image: url(/static/icons/class.png);
+}
+a.method {
+    background-image: url(/static/icons/method.png);
+}
+a.field {
+    background-image: url(/static/icons/field.png);
+}
+/* End of Context-menu and Panel icons */
+
+/* Context-menu only icons */
+a.reference {
+    background-image: url(/static/icons/reference.png);
+}
+a.search {
+    background-image: url(/static/icons/search.png);
+}
+a.buglink {
+    background-image: url(/static/icons/buglink.png);
+}
+a.external_link {
+    background-image: url(/static/icons/external_link.png);
+}
+a.jump {
+    background-image: url(/static/icons/jump.png);
+}
+a.members {
+    background-image: url(/static/icons/members.png);
+}
+a.type {
+    background-image: url(/static/icons/type.png);
+}
+/* End of Context-menu only icons */
+
+/* Panel only icons */
+
+/* Panel icons that are always shown - uncomment when ready! ->
+.panel .blame {
+    background-image: url(/static/icons/blame.png);
+}
+.panel .diff {
+    background-image: url(/static/icons/diff.png);
+}
+.panel .log {
+    background-image: url(/static/icons/log.png);
+}
+.panel .raw {
+    background-image: url(/static/icons/raw.png);
+}
+/* End of Panel icons that are always shown */
+
+.enum {
+    background-image: url(/static/icons/enum.png);
+}
+.struct {
+    background-image: url(/static/icons/struct.png);
+}
+.union {
+    background-image: url(/static/icons/union.png);
+}
+.macro {
+    background-image: url(/static/icons/macro.png);
+}
+/* End of Panel only icons */
+
 /* MimeType Icons */
 .build {
-    background: transparent url(/static/icons/mimetypes/build.png) no-repeat;
-    padding-left: 1.5rem;
+    background-image: url(/static/icons/mimetypes/build.png);
 }
 /* The .c calss is used in files for comments. This definition is there just to prevent overriding.*/
 .icon-container.c,
@@ -74,7 +122,9 @@ a.exclude-path {
 .css {
     background-image: url(/static/icons/mimetypes/css.png);
 }
-.diff {
+/* Prevents display of diff icon in the panel, which has it's own */
+.results .diff,
+.folder-content .diff {
     background-image: url(/static/icons/mimetypes/diff.png);
 }
 .h {

--- a/dxr/static/templates/context_menu.html
+++ b/dxr/static/templates/context_menu.html
@@ -1,5 +1,5 @@
 <ul id="context-menu" class="context-menu" tabindex="0">
     {% for item in menuItems %}
-        <li><a href="{{ item.href }}" class="{{ item.icon }}">{{ item.html|default(item.text)|safe }}</a></li>
+        <li><a href="{{ item.href }}" class="{{ item.icon }} icon">{{ item.html|default(item.text)|safe }}</a></li>
     {% endfor %}
 </ul>

--- a/dxr/static/templates/file.html
+++ b/dxr/static/templates/file.html
@@ -41,7 +41,7 @@
           <ul>
           {% for icon, title, href in items %}
             <li>
-              <a href="{{ href }}" title="{{ title }}" class="{{ icon }}">{{ title }}</a>
+              <a href="{{ href }}" title="{{ title }}" class="{{ icon }} icon">{{ title }}</a>
             </li>
           {%- endfor %}
           </ul>


### PR DESCRIPTION
- **For 965652:**
  - dxr.css :
  - Added a rule for .code code a in order to show availability of context-menus but limited in order not to overwrite a rule somewhere else.
- **For 1052524:**
  - file.html :
  - Added the .icon class to all anchors in the panel
  - dxr.css :
  - Removed padding form (.panel section a) since it blocks the added .icon class
- **For 1053423:**
  - context_menu.html :
  - Added the .icon class to all anchors in the list in order to have a pseudoparent class and eliminate a lot of repeating in icons.css
  - dxr.css :
  - Removed padding from (.context-menu a) since it blocks the added .icon class
  - icons.css :
  - Made a lot of changes and removed the repeating rules for background since they are no longer needed because of the .icon class
- **Other:**
  - Fixed .build in icons.css that I missed it the last time.
  - Added comments in icons.css in order to show rearanged sections.
  - Added a lot missing icon classes which are referenced in .panel and .context-menu .
  - Since the .panel icons that are always shown are probably going to be redone they are commented out until the time has come.
- That's about it. Will mention if I find something else.
