### PR TITLE
Make sure that the Diff link in the navigation menu doesn't pick up the style for diff files

### DIFF
--- a/dxr/static/css/icons.css
+++ b/dxr/static/css/icons.css
@@ -52,6 +52,9 @@ a.exclude-path {
     background: transparent url(/static/icons/exclude_path.png) 4px 8px no-repeat;
     padding-left: 1.5rem;
 }
+a.diff {
+    background: none; /* Do not inherit the rule for .diff below. */
+}
 /* MimeType Icons */
 .build {
     background: transparent url(/static/icons/mimetypes/build.png) no-repeat;


### PR DESCRIPTION
This fixes https://bugzilla.mozilla.org/show_bug.cgi?id=1055131
