### PR TITLE
Fix locale issue

### DIFF
--- a/vagrant_provision.sh
+++ b/vagrant_provision.sh
@@ -6,6 +6,10 @@ set -x
 
 apt-get update
 
+#configure locales:
+export LC_ALL="en_US.UTF-8"
+locale-gen en_US.UTF-8
+
 # node and npm:
 apt-get install -y npm
 # Homogenize binary name with production RHEL:


### PR DESCRIPTION
When you typo in the shell in vagrant, it'll provide better helpful text
rather than giving you locale errors.

Based on Ian's fix in fjord.

Mostly cosmetic. Just makes "vagrant ssh" a little easier to use for people who fat-finger things like me.

r?
