### PR TITLE
Register Needle Filters for clang plugin

### DIFF
--- a/dxr/plugins/clang/__init__.py
+++ b/dxr/plugins/clang/__init__.py
@@ -373,193 +373,125 @@ class TreeToIndex(plugins.TreeToIndex):
 # These filters get pickled because the plugins are built using futures
 
 
-class FunctionFilter(NeedleFilter):
+class CNeedleFilter(NeedleFilter):
     lang = 'c'
+
+
+class FunctionFilter(CNeedleFilter):
     name = 'function'
     description = Markup('Function or method definition: <code>function:foo</code>')
-    def __init__(self, term):
-        super(FunctionFilter, self).__init__(term)
 
 
-class FunctionRefFilter(NeedleFilter):
-    lang = 'c'
+class FunctionRefFilter(CNeedleFilter):
     name = 'function-ref'
     description = 'Function or method references'
-    def __init__(self, term):
-        super(FunctionRefFilter, self).__init__(term, )
 
 
-class FunctionDeclFilter(NeedleFilter):
-    lang = 'c'
+class FunctionDeclFilter(CNeedleFilter):
     name = 'function-decl'
     description = 'Function or method declaration'
-    def __init__(self, term):
-        super(FunctionDeclFilter, self).__init__(term, )
 
 
-class TypeRefFilter(NeedleFilter):
-    lang = 'c'
+class TypeRefFilter(CNeedleFilter):
     name = 'type-ref'
     description = 'Type or class references, uses, or instantiations'
-    def __init__(self, term):
-        super(TypeRefFilter, self).__init__(term, )
 
 
-class TypeDeclFilter(NeedleFilter):
-    lang = 'c'
+class TypeDeclFilter(CNeedleFilter):
     name = 'type-decl'
     description = 'Type or class declaration'
-    def __init__(self, term):
-        super(TypeDeclFilter, self).__init__(term, )
 
 
-class TypeFilter(NeedleFilter):
-    lang = 'c'
+class TypeFilter(CNeedleFilter):
     name = 'type'
     description = 'Type, function, or class definition: <code>type:Stack</code>'
-    def __init__(self, term):
-        super(TypeFilter, self).__init__(term, )
 
 
-class VariableFilter(NeedleFilter):
-    lang = 'c'
+class VariableFilter(CNeedleFilter):
     name = 'variable'
     description = 'Variable definition'
-    def __init__(self, term):
-        super(VariableFilter, self).__init__(term, )
 
 
-class VariableRefFilter(NeedleFilter):
-    lang = 'c'
+class VariableRefFilter(CNeedleFilter):
     name = 'variable'
     description = 'Variable uses (lvalue, rvalue, dereference, etc.)'
-    def __init__(self, term):
-        super(VariableRefFilter, self).__init__(term, )
 
 
-class VarDeclFilter(NeedleFilter):
-    lang = 'c'
+class VarDeclFilter(CNeedleFilter):
     name = 'Variable declaration'
     description = 'Type or class declaration'
-    def __init__(self, term):
-        super(VarDeclFilter, self).__init__(term, )
 
 
-class MacroFilter(NeedleFilter):
-    lang = 'c'
+class MacroFilter(CNeedleFilter):
     name = 'macro'
     description = 'Macro definition'
-    def __init__(self, term):
-        super(MacroFilter, self).__init__(term, )
 
 
-class MacroRefFilter(NeedleFilter):
-    lang = 'c'
+class MacroRefFilter(CNeedleFilter):
     name = 'macro-ref'
     description = 'Macro uses'
-    def __init__(self, term):
-        super(MacroRefFilter, self).__init__(term, )
 
 
-class NamespaceFilter(NeedleFilter):
-    lang = 'c'
+class NamespaceFilter(CNeedleFilter):
     name = 'namespace'
     description = 'Namespace definition'
-    def __init__(self, term):
-        super(NamespaceFilter, self).__init__(term, )
 
 
-class NamespaceRefFilter(NeedleFilter):
-    lang = 'c'
+class NamespaceRefFilter(CNeedleFilter):
     name = 'namespace-ref'
     description = 'Namespace references'
-    def __init__(self, term):
-        super(NamespaceRefFilter, self).__init__(term, )
 
 
-class NamespaceAliasFilter(NeedleFilter):
-    lang = 'c'
+class NamespaceAliasFilter(CNeedleFilter):
     name = 'namespace-alias'
     description = 'Namespace alias'
-    def __init__(self, term):
-        super(NamespaceAliasFilter, self).__init__(term, )
 
 
-class NamespaceAliasRefFilter(NeedleFilter):
-    lang = 'c'
+class NamespaceAliasRefFilter(CNeedleFilter):
     name = 'namespace-alias-ref'
     description = 'Namespace alias references'
-    def __init__(self, term):
-        super(NamespaceAliasRefFilter, self).__init__(term, )
 
 
-class WarningFilter(NeedleFilter):
-    lang = 'c'
+class WarningFilter(CNeedleFilter):
     name = 'warning'
     description = 'Compiler warning messages'
-    def __init__(self, term):
-        super(WarningFilter, self).__init__(term, )
 
 
-class WarningOptFilter(NeedleFilter):
-    lang = 'c'
+class WarningOptFilter(CNeedleFilter):
     name = 'warning-opt'
     description = 'Warning messages brought on by a given compiler command-line option'
-    def __init__(self, term):
-        super(WarningOptFilter, self).__init__(term, )
 
 
-class CalleeFilter(NeedleFilter):
-    lang = 'c'
+class CalleeFilter(CNeedleFilter):
     name = 'callee'
     description = 'Functions or methods which are called by the given one'
-    def __init__(self, term):
-        super(CalleeFilter, self).__init__(term, )
 
 
-class CallerFilter(NeedleFilter):
-    lang = 'c'
+class CallerFilter(CNeedleFilter):
     name = 'caller'
     description = Markup('Functions which call the given function or method: <code>callers:GetStringFromName</code>')
-    def __init__(self, term):
-        super(CallerFilter, self).__init__(term, )
 
 
-class ChildFilter(NeedleFilter):
-    lang = 'c'
+class ChildFilter(CNeedleFilter):
     name = 'child'
     description = Markup('Superclasses of a class: <code>bases:SomeSubclass</code>')
-    def __init__(self, term):
-        super(ChildFilter, self).__init__(term, )
 
 
-class ParentFilter(NeedleFilter):
-    lang = 'c'
+class ParentFilter(CNeedleFilter):
     name = 'parent'
     description = Markup('Subclasses of a class: <code>derived:SomeSuperclass</code>')
-    def __init__(self, term):
-        super(ParentFilter, self).__init__(term, )
 
 
-class MemberFilter(NeedleFilter):
-    lang = 'c'
+class MemberFilter(CNeedleFilter):
     name = 'member'
     description = Markup('Member variables, types, or methods of a class: <code>member:SomeClass</code>')
-    def __init__(self, term):
-        super(MemberFilter, self).__init__(term, )
 
 
-class OverridesFilter(NeedleFilter):
-    lang = 'c'
+class OverridesFilter(CNeedleFilter):
     name = 'overrides'
     description = Markup('Methods which override the given one: <code>overrides:someMethod</code>')
-    def __init__(self, term):
-        super(OverridesFilter, self).__init__(term, )
 
 
-class OverriddenFilter(NeedleFilter):
-    lang = 'c'
+class OverriddenFilter(CNeedleFilter):
     name = 'overridden'
     description = Markup('Methods which are overridden by the given one. Useful mostly with fully qualified methods, like <code>+overridden:Derived::foo()</code>.')
-    def __init__(self, term):
-        super(OverriddenFilter, self).__init__(term, )

--- a/dxr/plugins/utils.py
+++ b/dxr/plugins/utils.py
@@ -3,7 +3,7 @@
 from collections import namedtuple
 from operator import itemgetter
 
-from dxr.plugins import LINE
+from dxr.plugins import Filter
 
 
 Extent = namedtuple('Extent', ['start', 'end'])
@@ -29,7 +29,7 @@ def is_function((_, obj)):
     return hasattr(type_, 'input') and hasattr(type_, 'output')
 
 
-class NeedleFilter(object):
+class NeedleFilter(Filter):
     """Filter for a simple needle.
 
     Will highlight and filter based on the field_name cls attribute.
@@ -37,8 +37,6 @@ class NeedleFilter(object):
     """
     lang = ''
     name = ''
-    domain = LINE
-    description = ''
 
     def __init__(self, term):
         self.term = term
@@ -48,13 +46,5 @@ class NeedleFilter(object):
         # TODO use self.field_name to select which term to filter for
         return {}
 
-    def highlight(self, result, field):
-        content = result['content']
-        def _highlight(needle):
-            return needle['start'], needle['end'] or len(content)
-
-        highlights = sorted((_highlight(needle) for needle
-                             in content[field]
-                             if content['term'] == self.term),
-                            key=itemgetter('start'))
-        return {'content': highlights}
+    def highlight_content(self, result):
+        return []


### PR DESCRIPTION
Have the filters show up in the interface.
The current implementation uses an empty filter.

The next step is to write a proper filter for elastic search.
