### PR TITLE
Fix the FILE/LINE superset problem with documentation for now.

### DIFF
--- a/docs/source/development.rst
+++ b/docs/source/development.rst
@@ -314,6 +314,15 @@ API
 <http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/mapping
 -types.html>`__ is also outlined in the ES documentation.
 
+.. warning::
+
+    Since a FILE-domain query will be promoted to a LINE query if any other
+    query term triggers a line-based query, it's important to keep field names
+    and semantics the same between lines and files. In other words, a LINE
+    mapping should generally be a superset of a FILE mapping. Otherwise, ES
+    will guess mappings for the undeclared fields, and surprising search
+    results will likely ensue.
+
 Analyzers
 =========
 

--- a/dxr/plugins/__init__.py
+++ b/dxr/plugins/__init__.py
@@ -9,9 +9,7 @@ from pkg_resources import iter_entry_points
 
 
 # Domain constants:
-FILE = 'file'  # A FILE query will be promoted to a LINE query if any other query
-               # term triggers a line-based query. Thus, it's important to keep
-               # field names and semantics the same between lines and files.
+FILE = 'file'
 LINE = 'line'
 
 
@@ -423,7 +421,11 @@ class Plugin(object):
             plugin's ES-destined data. A dict with keys for each doctype and
             values reflecting the structure described at
             http://www.elasticsearch.org/guide/en/elasticsearch/reference/
-            current/indices-put-mapping.html.
+            current/indices-put-mapping.html. Since a FILE-domain query will
+            be promoted to a LINE query if any other query term triggers a
+            line-based query, it's important to keep field names and semantics
+            the same between lines and files. In other words, a LINE mapping
+            should generally be a superset of a FILE mapping.
         :arg analyzers: Analyzer, tokenizer, and token and char filter
             definitions for the elasticsearch mappings. A dict with keys
             "analyzer", "tokenizer", etc., following the structure outlined at

--- a/dxr/plugins/core.py
+++ b/dxr/plugins/core.py
@@ -11,6 +11,22 @@ from dxr.trigrammer import regex_grammar, SubstringTreeVisitor, NGRAM_LENGTH
 # TODO: RegexFilter, ExtFilter, PathFilter, any needles for those
 
 
+PATH_MAPPING = {  # path/to/a/folder/filename.cpp
+    'type': 'string',
+    'index': 'not_analyzed',  # support JS source fetching & sorting
+    'fields': {
+        'trigrams_lower': {
+            'type': 'string',
+            'analyzer': 'trigramalyzer_lower'  # accelerate wildcards
+        },
+        'trigrams': {
+            'type': 'string',
+            'analyzer': 'trigramalyzer'
+        }
+    }
+}
+
+
 mappings = {
     # We also insert entries here for folders. This gives us folders in dir
     # listings and the ability to find matches in folder pathnames.
@@ -20,20 +36,7 @@ mappings = {
         },
         'properties': {
             # FILE filters query this. It supports globbing via JS regex script.
-            'path': {  # path/to/a/folder/filename.cpp
-                'type': 'string',
-                'index': 'not_analyzed',  # support JS source fetching & sorting
-                'fields': {
-                    'trigrams_lower': {
-                        'type': 'string',
-                        'analyzer': 'trigramalyzer_lower'  # accelerate wildcards
-                    },
-                    'trigrams': {
-                        'type': 'string',
-                        'analyzer': 'trigramalyzer'
-                    }
-                }
-            },
+            'path': PATH_MAPPING,
 
             # Folder listings query by folder and then display filename, size,
             # and mod date.
@@ -67,25 +70,11 @@ mappings = {
             'enabled': False
         },
         'properties': {
-            'path': {
-                'type': 'string',
-                'index': 'not_analyzed',  # support sorting
-                'fields': {
-                    'trigrams_lower': {
-                        'type': 'string',
-                        'analyzer': 'trigramalyzer_lower'
-                    },
-                    'trigrams': {
-                        'type': 'string',
-                        'analyzer': 'trigramalyzer'
-                    }
-
-                }
-            },
-            # TODO: Use match_phrase_prefix queries on non-globbed paths,
-            # analyzing them with the path analyzer, for max perf. Perfect!
-            # Otherwise, fall back to trigram-accelerated substring or wildcard
-            # matching.
+            'path': PATH_MAPPING,
+            # TODO: After the query language refresh, use match_phrase_prefix
+            # queries on non-globbed paths, analyzing them with the path
+            # analyzer, for max perf. Perfect! Otherwise, fall back to trigram-
+            # accelerated substring or wildcard matching.
 
             'number': {
                 'type': 'integer'


### PR DESCRIPTION
Fix bug 1058945.

We can change the API to make it more automatic if it turns out to be a burden for plugin. In that case, most likely just move the folder, name, size, modified, and is_folder fields (the ones that aren't touched by queries) out of the core plugin and into build.py itself, then have something deep_update() LINE mappings with their corresponding FILE ones.
