### PR TITLE
Fix crash in dxr/build.py when source tree is empty.

### DIFF
--- a/dxr/build.py
+++ b/dxr/build.py
@@ -168,11 +168,15 @@ def build_instance(config_path, nb_jobs=None, tree=None, verbose=False):
             print "Building HTML for the '%s' tree." % tree.name
 
             max_file_id = conn.execute("SELECT max(files.id) FROM files").fetchone()[0]
-            if config.disable_workers:
-                print " - Worker pool disabled (due to 'disable_workers')"
-                _build_html_for_file_ids(tree, 0, max_file_id)
+
+            if max_file_id:
+                if config.disable_workers:
+                    print " - Worker pool disabled (due to 'disable_workers')"
+                    _build_html_for_file_ids(tree, 0, max_file_id)
+                else:
+                    run_html_workers(tree, config, max_file_id)
             else:
-                run_html_workers(tree, config, max_file_id)
+                    print " - Skipping htmlifying (due to '%s' tree being empty)" % tree.name
 
         # Close connection
         conn.commit()

--- a/tests/test_empty_tree/dxr.config.in
+++ b/tests/test_empty_tree/dxr.config.in
@@ -1,0 +1,10 @@
+[DXR]
+enabled_plugins     = pygmentize clang
+temp_folder         = PWD/temp
+target_folder       = PWD/target
+nb_jobs             = 4
+
+[code]
+source_folder       = PWD/code
+object_folder       = PWD/code
+build_command       = /bin/true

--- a/tests/test_empty_tree/makefile
+++ b/tests/test_empty_tree/makefile
@@ -1,0 +1,13 @@
+all:
+	# Link paths in dxr.config.in to current working directory
+	# replaces PWD with `pwd` and produces dxr.config
+	cat dxr.config.in | sed -e 's?PWD?'`pwd`'?g' > dxr.config
+	# Navigate into the DXR folder, build using config file
+	LD_LIBRARY_PATH=$$LD_LIBRARY_PATH:../../trilite dxr-build.py
+	# Launch test server at port 8000:
+	# dxr-serve.py target# 
+clean:
+	rm -rf dxr.config
+	rm -rf temp
+	rm -rf target
+	rm -rf code

--- a/tests/test_empty_tree/test_empty_tree.py
+++ b/tests/test_empty_tree/test_empty_tree.py
@@ -1,0 +1,8 @@
+from dxr.testing import DxrInstanceTestCase
+
+class TestEmptyTree(DxrInstanceTestCase):
+    """Tests for empty source tree"""
+
+    def test_empty(self):
+        """Test empty"""
+        self.found_nothing('path:*.*', is_case_sensitive=False)


### PR DESCRIPTION
Indexing an empty source tree causes the following crash:

```
Finalize database:
 - Building database statistics for query optimization
 - Running integrity check
Building HTML for the 'code' tree.
 - Initializing worker pool
 - Enqueuing jobs
Traceback (most recent call last):
  File "/usr/local/bin/dxr-build.py", line 10, in <module>
    execfile(__file__)
  File "/home/vagrant/dxr/bin/dxr-build.py", line 56, in <module>
    main()
  File "/home/vagrant/dxr/bin/dxr-build.py", line 52, in main
    verbose=options.verbose)
  File "/home/vagrant/dxr/dxr/build.py", line 177, in build_instance
    run_html_workers(tree, config, max_file_id)
  File "/home/vagrant/dxr/dxr/build.py", line 472, in run_html_workers
    (start, end) in _sliced_range_bounds(1, max_file_id, 500)]
  File "/home/vagrant/dxr/dxr/build.py", line 461, in _sliced_range_bounds
    this_min = this_max + 1
TypeError: unsupported operand type(s) for +: 'NoneType' and 'int'
```

It doesn't make much sense to index an empty source tree but `dxr-build.py` should not crash. The build now earlies out if `max_file_id` is `None` which happens when the source tree is empty.
