### PR TITLE
Allowed gzipped html files to be servered by dxr/app.py. 

### DIFF
--- a/dxr/app.py
+++ b/dxr/app.py
@@ -172,7 +172,15 @@ def search(tree):
 def browse(tree, path=''):
     """Show a directory listing or a single file from one of the trees."""
     tree_folder = _tree_folder(tree)
-    return send_from_directory(tree_folder, _html_file_path(tree_folder, path))
+    disk_path = _html_file_path(tree_folder, path)
+    gzip_path = disk_path+'.gz'
+    print gzip_path
+    if isfile(join(tree_folder,gzip_path)):
+    	response = send_from_directory(tree_folder, gzip_path)
+    	response.headers['Content-Encoding'] = 'gzip'
+    	return response
+    else:
+	return send_from_directory(tree_folder, _html_file_path(tree_folder, path))
 
 
 @dxr_blueprint.route('/<tree>/')

--- a/dxr/plugins/clang/indexer.py
+++ b/dxr/plugins/clang/indexer.py
@@ -5,7 +5,7 @@ import dxr.schema
 import os, sys
 import re, urllib
 from dxr.languages import language_schema
-
+csv.field_size_limit(sys.maxsize)
 
 PLUGIN_NAME   = 'clang'
 

--- a/tests/test_basic/dxr.config.in
+++ b/tests/test_basic/dxr.config.in
@@ -3,6 +3,7 @@ enabled_plugins     = pygmentize clang
 temp_folder         = PWD/temp
 target_folder       = PWD/target
 nb_jobs             = 4
+wwwroot = /dxr 
 
 [code]
 source_folder       = PWD/code


### PR DESCRIPTION
The CMS experiment offline software is almost 1 GB of source code. When I created the dxr index it ended up being 13GB with a 1.3GB xref database. I gzipped all of the htmlized source code files and made this patch to allow the server side to display them correctly. 

I also ran into problems during the csv import stage so I increased the csv field buffer to the max. This and the addition of the default wwwroot  can be skipped.

The prototype index for your software can be found at

http://cmslxr.fnal.gov/dxr
