### PR TITLE
Bug 965649 - Don't link full page width in search results

### DIFF
--- a/dxr/static/css/dxr.css
+++ b/dxr/static/css/dxr.css
@@ -209,8 +209,7 @@ mark {
 }
 .results a {
     cursor: pointer;
-    display: block;
-    width: 100%;
+    display: inline-block;
 }
 .file a:target {
     background-color: gray;


### PR DESCRIPTION
Removing results links 100% width
Switching results link from block display to inline-block
