### PR TITLE
Fixed a typo in clang/filters.py.

### DIFF
--- a/dxr/plugins/clang/filters.py
+++ b/dxr/plugins/clang/filters.py
@@ -170,7 +170,7 @@ class VariableRefFilter(_QualifiedNameFilter):
 
 class VarDeclFilter(_QualifiedNameFilter):
     name = 'var-decl'
-    description = 'Type or class declaration'
+    description = 'Variable declaration'
 
 
 class MacroFilter(_NameFilter):


### PR DESCRIPTION
VarDeclFilter had a description of 'Type or class declaration'.
