### PR TITLE
Fix "Running A Test Index" doc

### DIFF
--- a/docs/source/development.rst
+++ b/docs/source/development.rst
@@ -46,7 +46,7 @@ with. To get it running... ::
 
     cd ~/dxr/tests/test_basic
     make
-    dxr-serve.py -a target
+    LD_LIBRARY_PATH=$LD_LIBRARY_PATH:../../trilite dxr-serve.py -a target
 
 You can then surf to http://33.33.33.77:8000/ from the host machine and play
 around. When you're done, stop the server with :kbd:`Control-C`.


### PR DESCRIPTION
It didn't work without adding ../.. to `LD_LIBRARY_PATH`.
