### PR TITLE
Apply opacity to context-menu

### DIFF
--- a/dxr/static/css/dxr.css
+++ b/dxr/static/css/dxr.css
@@ -268,6 +268,7 @@ mark {
     width: auto;
     list-style: none;
     z-index: 2;
+    opacity: 0.85;
 }
 .context-menu a {
     display: block;


### PR DESCRIPTION
When you click an identifier, it is usual that there is a match nearby. But the context menu could cover that match, so that you can never find it.

By making the context menu translucent, the covered hightlight can be noticed.

![context-menu-translucent](https://cloud.githubusercontent.com/assets/333750/5192582/d713257a-754c-11e4-8521-03a4ad4904aa.png)
