### PR TITLE
Move hg serve into a comment since it's not needed for the diff link test

### DIFF
--- a/tests/test_diff_link/makefile
+++ b/tests/test_diff_link/makefile
@@ -4,13 +4,11 @@ all:
 	cat dxr.config.in | sed -e 's?PWD?'`pwd`'?g' > dxr.config
 	# Navigate into the DXR folder, build using config file
 	dxr-build.py
-	# Launch the hg web view
-	cd code; hg serve -p 8001 --pid-file ../hgserve.pid > /dev/null 2>/dev/null &
 	# Launch test server at port 8000:
 	# dxr-serve.py target
+	# Launch the hg web view at port 8001:
+	# cd code; hg serve -p 8001
 clean:
 	rm -rf dxr.config
 	rm -rf temp
 	rm -rf target
-	if [ -f hgserve.pid ]; then cat hgserve.pid | xargs kill; fi;
-	rm -f hgserve.pid

--- a/tests/test_diff_link/test_diff_link.py
+++ b/tests/test_diff_link/test_diff_link.py
@@ -4,10 +4,6 @@ from nose import SkipTest
 from nose.tools import ok_
 
 
-# "make clean" fails on Jenkins during teardown_class().
-raise SkipTest
-
-
 class DiffLinkTests(DxrInstanceTestCase):
     """Tests that the diff links for files go somewhere helpful"""
     def test_diff_file1(self):


### PR DESCRIPTION
I think this should fix the test's failure on Jenkins.
