### PR TITLE
BUGZILLA-1111383 Don't assume that 'kind' is a valid key

### DIFF
--- a/dxr/plugins/clang/indexers.py
+++ b/dxr/plugins/clang/indexers.py
@@ -224,7 +224,7 @@ class FileToIndex(FileToIndexBase):
 @autocurry
 def kind_getter(field, kind, condensed):
     """Reach into a field and filter based on the kind."""
-    return (ref for ref in condensed.get(field) if ref['kind'] == kind)
+    return (ref for ref in condensed.get(field) if ref.get('kind') == kind)
 
 
 def _members(condensed, key, id_):

--- a/dxr/plugins/clang/menus.py
+++ b/dxr/plugins/clang/menus.py
@@ -40,7 +40,7 @@ def macro_menu(tree, macro):
 
 def type_menu(tree, type):
     """Return menu for type reference."""
-    qualname, kind = type['qualname'], type['kind']
+    qualname, kind = type['qualname'], type.get('kind')
     menu = [{'html': "Find declarations",
              'title': "Find declarations of this class",
              'href': search(tree, "+type-decl:%s" % quote(qualname)),

--- a/dxr/plugins/clang/needles.py
+++ b/dxr/plugins/clang/needles.py
@@ -39,7 +39,7 @@ def needles(condensed, name, suffix='', kind=None, subkind=None, keys=('name', '
 
     """
     kind = kind or name
-    matches_subkind = (lambda entity: entity['kind'] == subkind if subkind
+    matches_subkind = (lambda entity: entity.get('kind') == subkind if subkind
                        else lambda entity: True)
     return (('c_{0}{1}'.format(name, suffix),
              dict((k, entity[k]) for k in keys),


### PR DESCRIPTION
This is an update to the pull request https://github.com/mozilla/dxr/pull/374, rebased to a single commit, based on this suggestion on stack overflow: http://stackoverflow.com/questions/11396069/squash-to-only-one-proper-commit-for-github-pull-request
# 

BUGZILLA-1111383 Don't assume that 'kind' is a valid key
'kind' is not necessarily emitted during a declDef record creation,
so we should provide a default value of None to avoid crashing.

https://bugzilla.mozilla.org/show_bug.cgi?id=1111383
