### PR TITLE
Bug fix for 1091122

### DIFF
--- a/dxr/static/css/dxr.css
+++ b/dxr/static/css/dxr.css
@@ -387,6 +387,7 @@ mark {
     overflow-y: auto;
     overflow-x: hidden;
     max-height: calc(100% - 150px);
+    max-width: 30%;
     z-index: 2;
 }
 .panel button{


### PR DESCRIPTION
The panel UI component (shown here: http://dxr.mozilla.org/mozilla-central/source/dom/base/nsDocument.cpp) previously expanded according to its contents' width. I've added a maximum-width CSS rule limiting it to 30% of the windows' width.

Referenced issue: https://bugzilla.mozilla.org/show_bug.cgi?id=1091122