### PR TITLE
Add callers: and called-by: filters for the Python plugin.

### DIFF
--- a/dxr/plugins/python/filters.py
+++ b/dxr/plugins/python/filters.py
@@ -1,9 +1,13 @@
 from jinja2 import Markup
 
-from dxr.filters import QualifiedNameFilterBase
+from dxr.filters import NameFilterBase, QualifiedNameFilterBase
 
 
-class _PyFilter(QualifiedNameFilterBase):
+class _QualifiedPyFilter(QualifiedNameFilterBase):
+    lang = 'py'
+
+
+class _PyFilter(NameFilterBase):
     lang = 'py'
 
 
@@ -17,11 +21,16 @@ class FunctionFilter(_PyFilter):
     description = Markup("Function or method definition: <code>function:foo</code>")
 
 
-class DerivedFilter(_PyFilter):
+class DerivedFilter(_QualifiedPyFilter):
     name = 'derived'
     description = Markup("Subclasses of a class: <code>derived:SomeSuperclass</code>")
 
 
-class BasesFilter(_PyFilter):
+class BasesFilter(_QualifiedPyFilter):
     name = 'bases'
     description = Markup("Superclasses of a class: <code>bases:SomeSubclass</code>")
+
+
+class CallersFilter(_PyFilter):
+    name = 'callers'
+    description = Markup("Functions which call the given function: <code>callers:some_function</code>")

--- a/dxr/plugins/python/tests/test_calls.py
+++ b/dxr/plugins/python/tests/test_calls.py
@@ -1,0 +1,51 @@
+from textwrap import dedent
+
+from dxr.plugins.python.tests import PythonSingleFileTestCase
+
+
+class CallersTests(PythonSingleFileTestCase):
+    source = dedent("""
+    def call_once():
+        called_once()
+
+    def call_multiple():
+        called_multiple()
+        called_multiple()
+
+    def call_in_separate_functions_1():
+        called_in_separate_functions()
+
+    def call_in_separate_functions_2():
+        called_in_separate_functions()
+
+    def outer_call_bar():
+        def inner_call_foo():
+            foo()
+        bar()
+    """)
+
+    def test_called_once(self):
+        self.found_line_eq('callers:called_once', 'def <b>call_once</b>():')
+
+    def test_called_multiple_times(self):
+        self.found_line_eq('callers:called_multiple', 'def <b>call_multiple</b>():')
+
+    def test_called_in_several_functions(self):
+        self.found_lines_eq('callers:called_in_separate_functions', [
+            'def <b>call_in_separate_functions_1</b>():',
+            'def <b>call_in_separate_functions_2</b>():',
+        ])
+
+    def test_called_in_inner_function(self):
+        """Make sure a call within an inner function matches the inner
+        function only.
+
+        """
+        self.found_line_eq('callers:foo', 'def <b>inner_call_foo</b>():')
+
+    def test_called_in_outer_function(self):
+        """Make sure inner function definitions do not affect other
+        calls in the outer function.
+
+        """
+        self.found_line_eq('callers:bar', 'def <b>outer_call_bar</b>():')


### PR DESCRIPTION
Because the return order of `ast.walk` is not guaranteed to mean anything, I needed to be able to control the order that we walk through the tree if I wanted to correctly assign function calls to the right caller. The first commit refactors the Python plugin to move all the searching for needles to a NodeVisitor subclass. The second commit adds the new filters and some tests for them.

I spent some time trying to see if I could make a NodeVisitor subclass that returned a generator of needles, but I couldn't figure anything out, and I didn't want to copy over the NodeVisitor code and tweak it just for that. Oh well.