### PR TITLE
Add a sleep after "vagrant up" to dodge ssh intermittent failures.

### DIFF
--- a/jenkins.sh
+++ b/jenkins.sh
@@ -7,6 +7,7 @@ if [ ! "$VBGUEST" ]; then
 fi;
 
 /opt/vagrant/bin/vagrant up
+sleep 2  # Dodge "SSH connection was refused" errors.
 /opt/vagrant/bin/vagrant ssh -c 'cd /home/vagrant/dxr && source /home/vagrant/venv/bin/activate && make clean && make test'
 RESULT=$?
 /opt/vagrant/bin/vagrant destroy --force || exit $?


### PR DESCRIPTION
Example: https://ci.mozilla.org/job/dxr-github/856/console