### PR TITLE
Add overrides: and overridden: filters and refactor analysis.

### DIFF
--- a/dxr/plugins/python/analysis.py
+++ b/dxr/plugins/python/analysis.py
@@ -1,0 +1,205 @@
+"""Tools for analyzing a Python codebase as a whole. Analysis happens
+before indexing in order to compute data that requires knowledge of the
+entire codebase.
+
+"""
+import ast
+import os
+from collections import defaultdict
+from warnings import warn
+
+from dxr.build import file_contents
+from dxr.plugins.python.utils import (ClassFunctionVisitorMixin,
+                                      convert_node_to_name, package_for_module,
+                                      path_to_module)
+
+
+class TreeAnalysis(object):
+    """Performs post-build analysis and stores the results."""
+
+    def __init__(self, python_path, source_folder, paths):
+        """Analyze the given paths.
+
+        :arg python_path: Absolute path to the root folder where Python
+        modules for the tree are stored.
+
+        :arg source_folder: Absolute path to the root folder storing all the
+        files in the tree. Used to generate relative paths when emitting
+        warnings.
+
+        :arg paths: Iterable containing tuples of the form (path, encoding)
+        for each file that should be analyzed.
+        """
+        self.python_path = python_path
+        self.source_folder = source_folder
+
+        self.base_classes = defaultdict(list)
+        self.derived_classes = defaultdict(list)
+        self.class_functions = defaultdict(list)
+        self.overridden_functions = defaultdict(list)
+        self.overriding_functions = defaultdict(list)
+        self.names = {}
+        self.ignore_paths = set()
+
+        for path, encoding in paths:
+            self._analyze_file(path, encoding)
+        self._finish_analysis()
+
+    def _analyze_file(self, path, encoding):
+        """Analyze an individual file. If the file isn't valid Python, add
+        it to the ignore_paths list on the analysis.
+
+        """
+        try:
+            syntax_tree = ast.parse(file_contents(path, encoding))
+        except (SyntaxError, TypeError) as error:
+            rel_path = os.path.relpath(path, self.source_folder)
+            warn('Failed to analyze {filename} due to error "{error}".'.format(
+                 filename=rel_path, error=error))
+            self.ignore_paths.add(rel_path)
+            return
+
+        module_path = path_to_module(self.python_path, path)
+        visitor = AnalyzingNodeVisitor(module_path, self)
+        visitor.visit(syntax_tree)
+
+    def _finish_analysis(self):
+        """Finishes the analysis by computing some relations that
+        depend on the entire tree having been analyzed, such as method
+        overrides (which we can't compute until we've analyzed every
+        class method).
+
+        """
+        # Compute derived classes from base class relations.
+        for class_name, bases in self.base_classes.iteritems():
+            for base_name in bases:
+                base_name = self.normalize_name(base_name)
+                self.derived_classes[base_name].append(class_name)
+
+        # Compute which functions override other functions.
+        for class_name, functions in self.class_functions.iteritems():
+            functions = set(functions)
+            base_classes = self.get_base_classes(class_name)
+
+            # For each base class, find the union of functions within
+            # the current class and functions in the base; those are
+            # overridden methods!
+            for base_class in base_classes:
+                # Use get here to avoid modifying class_functions while
+                # looping over it.
+                base_class_functions = self.class_functions.get(base_class, set())
+                matches = functions.intersection(base_class_functions)
+                for match in matches:
+                    function_qualname = class_name + '.' + match
+                    overridden_qualname = base_class + '.' + match
+                    self.overriding_functions[function_qualname].append(overridden_qualname)
+
+        # Compute which functions are overridden by which (the reverse
+        # of what we just computed above).
+        for function, overridden_functions in self.overriding_functions.iteritems():
+            for overridden_function in overridden_functions:
+                self.overridden_functions[overridden_function].append(function)
+
+    def get_base_classes(self, absolute_class_name):
+        """Return a list of all the classes that the given class
+        inherits from in their canonical form.
+
+        """
+        for base in self.base_classes[absolute_class_name]:
+            base = self.normalize_name(base)
+            yield base
+            for base_parent in self.get_base_classes(base):
+                yield base_parent
+
+    def get_derived_classes(self, absolute_class_name):
+        """Return a list of all the classes that derive from the given
+        class in their canonical form.
+
+        """
+        for derived in self.derived_classes[absolute_class_name]:
+            yield derived
+            for derived_child in self.get_derived_classes(derived):
+                yield derived_child
+
+    def normalize_name(self, absolute_local_name):
+        """Given a local name, figure out the actual module that the
+        thing that name points to lives and return that name.
+
+        For example, if you have `from os import path` in a module
+        called `foo.bar`, then the name `foo.bar.path` would return
+        `os.path`.
+
+        """
+        while absolute_local_name in self.names:
+            absolute_local_name = self.names[absolute_local_name]
+
+        # For cases when you `import foo.bar` and refer to `foo.bar.baz`, we
+        # need to normalize the `foo.bar` prefix in case it's not the
+        # canonical name of that module.
+        if '.' in absolute_local_name:
+            prefix, local_name = absolute_local_name.rsplit('.', 1)
+            return self.normalize_name(prefix) + '.' + local_name
+        else:
+            return absolute_local_name
+
+
+class AnalyzingNodeVisitor(ast.NodeVisitor, ClassFunctionVisitorMixin):
+    """Node visitor that analyzes code for data we need prior to
+    indexing, including:
+
+    - A graph of imported names and the files that they were originally
+      defined in.
+    - A mapping of class names to the classes they inherit from.
+
+    """
+    def __init__(self, module_path, tree_analysis):
+        super(AnalyzingNodeVisitor, self).__init__()
+
+        self.module_path = module_path
+        self.tree_analysis = tree_analysis
+
+    def visit_ClassDef(self, node):
+        super(AnalyzingNodeVisitor, self).visit_ClassDef(node)
+
+        # Save the base classes of any class we find.
+        class_path = self.module_path + '.' + node.name
+        bases = []
+        for base in node.bases:
+            base_name = convert_node_to_name(base)
+            if base_name:
+                bases.append(self.module_path + '.' + base_name)
+        self.tree_analysis.base_classes[class_path] = bases
+
+    def visit_ClassFunction(self, class_node, function_node):
+        """Save any member functions we find on a class."""
+        class_path = self.module_path + '.' + class_node.name
+        self.tree_analysis.class_functions[class_path].append(function_node.name)
+
+    def visit_Import(self, node):
+        self.analyze_import(node)
+        self.generic_visit(node)
+
+    def visit_ImportFrom(self, node):
+        self.analyze_import(node)
+        self.generic_visit(node)
+
+    def analyze_import(self, node):
+        """Whenever we import something, remember the local name of what
+        was imported and where it actually lives.
+
+        """
+        for alias in node.names:
+            local_name = alias.asname or alias.name
+            absolute_local_name = self.module_path + '.' + local_name
+
+            import_name = alias.name
+            if isinstance(node, ast.ImportFrom):
+                # `from . import x` means node.module is None.
+                if node.module:
+                    import_name = node.module + '.' + import_name
+                else:
+                    package_path = package_for_module(self.module_path)
+                    if package_path:
+                        import_name = package_path + '.' + import_name
+
+            self.tree_analysis.names[absolute_local_name] = import_name

--- a/dxr/plugins/python/filters.py
+++ b/dxr/plugins/python/filters.py
@@ -13,24 +13,34 @@ class _PyFilter(NameFilterBase):
 
 class TypeFilter(_PyFilter):
     name = 'type'
-    description = Markup("Class definition: <code>type:Stack</code>")
+    description = Markup('Class definition: <code>type:Stack</code>')
 
 
 class FunctionFilter(_PyFilter):
     name = 'function'
-    description = Markup("Function or method definition: <code>function:foo</code>")
+    description = Markup('Function or method definition: <code>function:foo</code>')
 
 
 class DerivedFilter(_QualifiedPyFilter):
     name = 'derived'
-    description = Markup("Subclasses of a class: <code>derived:SomeSuperclass</code>")
+    description = Markup('Subclasses of a class: <code>derived:SomeSuperclass</code>')
 
 
 class BasesFilter(_QualifiedPyFilter):
     name = 'bases'
-    description = Markup("Superclasses of a class: <code>bases:SomeSubclass</code>")
+    description = Markup('Superclasses of a class: <code>bases:SomeSubclass</code>')
 
 
 class CallersFilter(_PyFilter):
     name = 'callers'
-    description = Markup("Functions which call the given function: <code>callers:some_function</code>")
+    description = Markup('Functions which call the given function: <code>callers:some_function</code>')
+
+
+class OverridesFilter(_QualifiedPyFilter):
+    name = 'overrides'
+    description = Markup('Methods which override the given one: <code>overrides:some_method</code>')
+
+
+class OverriddenFilter(_QualifiedPyFilter):
+    name = 'overridden'
+    description = Markup('Methods which are overridden by the given one. Useful mostly with fully qualified methods, like <code>+overridden:foo.bar.some_method</code>.')

--- a/dxr/plugins/python/tests/test_overrides/code/child.py
+++ b/dxr/plugins/python/tests/test_overrides/code/child.py
@@ -1,0 +1,6 @@
+from parent import Parent
+
+
+class Child(Parent):
+    def overridden(self):
+        pass

--- a/dxr/plugins/python/tests/test_overrides/code/parent.py
+++ b/dxr/plugins/python/tests/test_overrides/code/parent.py
@@ -1,0 +1,3 @@
+class Parent(object):
+    def overridden(self):
+        """This method is overridden in the child class."""

--- a/dxr/plugins/python/tests/test_overrides/dxr.config.in
+++ b/dxr/plugins/python/tests/test_overrides/dxr.config.in
@@ -1,0 +1,13 @@
+[DXR]
+enabled_plugins     = pygmentize python
+temp_folder         = PWD/temp
+target_folder       = PWD/target
+es_index            = dxr_test_{format}_{tree}_{unique}
+es_alias            = dxr_test_{format}_{tree}
+
+[code]
+source_folder       = PWD/code
+object_folder       = PWD/code
+build_command       = /bin/true
+    [[python]]
+    python_path     = PWD/code

--- a/dxr/plugins/python/tests/test_overrides/makefile
+++ b/dxr/plugins/python/tests/test_overrides/makefile
@@ -1,0 +1,12 @@
+all:
+	# Link paths in dxr.config.in to current working directory
+	# replaces PWD with `pwd` and produces dxr.config
+	cat dxr.config.in | sed -e 's?PWD?'`pwd`'?g' > dxr.config
+	# Navigate into the DXR folder, build using config file
+	dxr-build.py
+	# Launch test server at port 8000:
+	# dxr-serve.py target
+clean:
+	rm -rf dxr.config
+	rm -rf temp
+	rm -rf target

--- a/dxr/plugins/python/tests/test_overrides/test_overrides.py
+++ b/dxr/plugins/python/tests/test_overrides/test_overrides.py
@@ -1,0 +1,102 @@
+from textwrap import dedent
+
+from dxr.plugins.python.tests import PythonSingleFileTestCase
+from dxr.testing import DxrInstanceTestCase
+
+
+class OverridesTests(PythonSingleFileTestCase):
+    source = dedent("""
+    class Grandparent(object):
+        def overridden_all(self): #grandparent
+            '''Overridden in all children.'''
+
+        def not_overridden(self): #grandparent
+            '''Not overridden in any children.'''
+
+    class Parent(Grandparent):
+        def overridden_all(self): #parent
+            '''Overridden in all children.'''
+
+        def overridden_child(self): #parent
+            '''Overridden in the child class.'''
+
+
+    class Child(Parent):
+        def overridden_all(self): #child
+            '''Overridden in all children.'''
+
+        def overridden_child(self): #child
+            '''Overridden in the child class.'''
+    """)
+
+    def test_overrides_direct(self):
+        """Make sure that overrides: finds methods overridden in child
+        classes.
+
+        """
+        self.found_line_eq('overrides:overridden_child',
+                           'def <b>overridden_child</b>(self): #child')
+
+    def test_overrides_multiple(self):
+        """Make sure that overrides: finds methods overridden in
+        multiple descendants.
+
+        """
+        self.found_lines_eq('overrides:overridden_all', [
+            'def <b>overridden_all</b>(self): #parent',
+            'def <b>overridden_all</b>(self): #child'
+        ])
+
+    def test_overrides_nothing(self):
+        """Make sure that overrides: finds nothing for methods that are
+        not overridden.
+
+        """
+        self.found_nothing('overrides:not_overridden')
+
+    def test_overrides_qualname(self):
+        """Make sure that overrides: supports qualnames."""
+        self.found_line_eq('overrides:main.Parent.overridden_child',
+                           'def <b>overridden_child</b>(self): #child')
+
+    def test_overridden_direct(self):
+        """Make sure that overridden: finds methods overridden from
+        parent classes.
+
+        """
+        self.found_line_eq('overridden:overridden_child',
+                           'def <b>overridden_child</b>(self): #parent')
+
+    def test_overridden_multiple(self):
+        """Make sure that overridden: finds methods overridden from
+        multiple parents.
+
+        """
+        self.found_lines_eq('overridden:overridden_all', [
+            'def <b>overridden_all</b>(self): #grandparent',
+            'def <b>overridden_all</b>(self): #parent'
+        ])
+
+    def test_overridden_nothing(self):
+        """Make sure that overridden: finds nothing for methods that are
+        not overridden.
+
+        """
+        self.found_nothing('overridden:not_overridden')
+
+    def test_overridden_qualname(self):
+        """Make sure that overridden: supports qualnames."""
+        self.found_line_eq('overridden:main.Child.overridden_child',
+                           'def <b>overridden_child</b>(self): #parent')
+
+
+class ImportOverrideTests(DxrInstanceTestCase):
+    def test_overrides(self):
+        """Make sure the overrides filter works across imports."""
+        self.found_line_eq('overrides:parent.Parent.overridden',
+                           'def <b>overridden</b>(self):', 5)
+
+    def test_overridden(self):
+        """Make sure the overridden filter works across imports."""
+        self.found_line_eq('overridden:child.Child.overridden',
+                           'def <b>overridden</b>(self):', 2)

--- a/dxr/plugins/python/utils.py
+++ b/dxr/plugins/python/utils.py
@@ -1,0 +1,77 @@
+import ast
+import os
+from contextlib import contextmanager
+
+
+def package_for_module(module_path):
+    return module_path.rsplit('.', 1)[0] if '.' in module_path else None
+
+
+def convert_node_to_name(node):
+    """Convert an AST node to a name if possible. Return None if we
+    can't (such as function calls).
+
+    """
+    if isinstance(node, ast.Name):
+        return node.id
+    elif isinstance(node, ast.Attribute):
+        value_name = convert_node_to_name(node.value)
+        if value_name:
+            return value_name + '.' + node.attr
+    else:
+        return None
+
+
+def path_to_module(python_path, module_path):
+    """Convert a file path into a dotted module path, using the given
+    python_path as the base directory that modules live in.
+
+    """
+    module_path = trim_end(module_path, '.py')
+    module_path = trim_end(module_path, '/__init__')
+    common_path = os.path.commonprefix([python_path, module_path])
+    return module_path.replace(common_path, '', 1).replace('/', '.').strip('.')
+
+
+def trim_end(string, end):
+    if string.endswith(end):
+        return string[:-len(end)]
+    else:
+        return string
+
+
+class ClassFunctionVisitorMixin(object):
+    """Mixin for NodeVisitors that detects member functions on classes
+    and handles them specifically.
+
+    """
+    def __init__(self, *args, **kwargs):
+        super(ClassFunctionVisitorMixin, self).__init__(*args, **kwargs)
+
+        self._current_class = None
+        self._visiting_class_functions = False
+
+    def visit_ClassDef(self, node):
+        old_class = self._current_class
+        self._current_class = node
+        with self._visit_class_functions(True):
+            self.generic_visit(node)
+        self._current_class = old_class
+
+    def visit_FunctionDef(self, node):
+        if self._visiting_class_functions:
+            self.visit_ClassFunction(self._current_class, node)
+
+        # Disable collection in case there are any inner functions.
+        with self._visit_class_functions(False):
+            self.generic_visit(node)
+
+    def visit_ClassFunction(self, class_node, function_node):
+        raise NotImplementedError()
+
+    @contextmanager
+    def _visit_class_functions(self, visiting):
+        old = self._visiting_class_functions
+        self._visiting_class_functions = visiting
+        yield
+        self._visiting_class_functions = old


### PR DESCRIPTION
Adds two new filters for finding overridden methods. ALSO HEY LETS REFACTOR AGAIN

For reals though, similar to how I switching to using NodeVisitor for indexing, I found that I needed to use a NodeVisitor for analysis as well. And once I did that, I realized that there was a lot of related pieces of information being generated during analysis that were being passed into the FileToIndex constructor, so I figured:

- Moving post-build analysis to a module would makes things easier to grok.
- Grouping all the analysis results into a single thing that could be passed around would help with the increasing amount of parameters to FileToIndex.