### PR TITLE
Fix infinite scroll

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -21,13 +21,13 @@ module.exports = function(grunt) {
             precompile: {
                 baseDir: 'dxr/static/templates/',
                 src: [
+                    'dxr/static/templates/partial/results_container.html',
                     'dxr/static/templates/partial/results.html',
+                    'dxr/static/templates/partial/result_lines.html',
                     'dxr/static/templates/partial/switch_tree.html',
                     'dxr/static/templates/partial/no_results.html',
                     'dxr/static/templates/context_menu.html',
                     'dxr/static/templates/path_line.html',
-                    'dxr/static/templates/results_container.html'
-
                 ],
                 dest: 'dxr/static/js/templates.js',
                 options: {
@@ -44,12 +44,13 @@ module.exports = function(grunt) {
         watch: {
             nunjucks: {
                 files: [
+                    'dxr/static/templates/partial/results_container.html',
                     'dxr/static/templates/partial/results.html',
+                    'dxr/static/templates/partial/result_lines.html',
                     'dxr/static/templates/partial/switch_tree.html',
                     'dxr/static/templates/partial/no_results.html',
                     'dxr/static/templates/context_menu.html',
                     'dxr/static/templates/path_line.html',
-                    'dxr/static/templates/results_container.html'
                 ],
                 tasks: ['nunjucks']
             }

--- a/dxr/app.py
+++ b/dxr/app.py
@@ -154,12 +154,15 @@ def _search_html(query, tree, query_text, is_case_sensitive, offset, limit, conf
 
     try:
         results = list(query.results(offset, limit))
+        results_line_count = sum(len(r[2]) for r in results)
     except BadTerm as exc:
         return render_template('error.html',
                                error_html=exc.reason,
                                **template_vars), 400
 
-    return render_template('search.html', results=results, **template_vars)
+    return render_template('search.html', results=results,
+                           results_line_count=results_line_count,
+                           **template_vars)
 
 
 def _tree_tuples(query_text, is_case_sensitive):

--- a/dxr/static/js/dxr.js
+++ b/dxr/static/js/dxr.js
@@ -140,7 +140,7 @@ $(function() {
         requestsInFlight = 0,  // Number of search requests in flight, so we know whether to hide the activity indicator
         displayedRequestNumber = 0,
         didScroll = false,
-        resultCount = 0,
+        resultsLineCount = 0,
         dataOffset = 0,
         previousDataLimit = 0,
         defaultDataLimit = 100;
@@ -235,11 +235,11 @@ $(function() {
             didScroll = false;
 
             // If the previousDataLimit is 0 we are on the search.html page and doQuery
-            // has not yet been called, get the previousDataLimit and resultCount from
-            // the page constants.
+            // has not yet been called, get the previousDataLimit and resultsLineCount
+            // from the page constants.
             if (previousDataLimit === 0) {
                 previousDataLimit = stateConstants.data('limit');
-                resultCount = stateConstants.data('result-count');
+                resultsLineCount = stateConstants.data('results-line-count');
             }
 
             var maxScrollY = getMaxScrollY(),
@@ -247,7 +247,7 @@ $(function() {
                 threshold = window.innerHeight + 500;
 
             // Has the user reached the scrolling threshold and are there more results?
-            if ((maxScrollY - currentScrollPos) < threshold && previousDataLimit === resultCount) {
+            if ((maxScrollY - currentScrollPos) < threshold && previousDataLimit === resultsLineCount) {
                 clearInterval(scrollPoll);
 
                 // If a user hits enter on the landing page and there was no direct result,
@@ -264,7 +264,7 @@ $(function() {
                         var state = {};
 
                         // Update result count
-                        resultCount = data.results.length;
+                        resultsLineCount = countLines(data.results);
                         // Use the results.html partial so we do not inject the entire container again.
                         populateResults('partial/results.html', data, true);
                         // update URL with new offset
@@ -279,6 +279,18 @@ $(function() {
                 });
             }
         }
+    }
+
+    /**
+     * Given a list of results from the search API, return the total number of
+     * lines across all results.
+     */
+    function countLines(results) {
+        var total = 0;
+        for (var k = 0; k < results.length; k++) {
+            total += results[k].lines.length;
+        }
+        return total;
     }
 
     /**
@@ -330,7 +342,7 @@ $(function() {
         } else {
 
             var results = data.results;
-            resultCount = results.length;
+            resultsLineCount = countLines(results);
 
             for (var result in results) {
                 var icon = results[result].icon;

--- a/dxr/static/templates/layout.html
+++ b/dxr/static/templates/layout.html
@@ -87,7 +87,7 @@
 
     <!-- avoid inline JS and use data attributes instead. Hackey but hey... -->
     <span id="data" data-root="{{ www_root }}" data-search="{{ www_root }}/{{ tree }}/search" data-tree="{{ tree }}"></span>
-    <span id="state" data-offset="{{state_offset or 0}}" data-limit="{{state_limit or 100}}" data-result-count="{{ results|length }}" data-eof="{{ eof }}"></span>
+    <span id="state" data-offset="{{state_offset or 0}}" data-limit="{{state_limit or 100}}" data-results-line-count="{{ results_line_count }}" data-eof="{{ eof }}"></span>
 
     {% block site_js %}
       <script src="{{ www_root }}/static/js/libs/jquery203.js"></script>

--- a/dxr/static/templates/partial/result_lines.html
+++ b/dxr/static/templates/partial/result_lines.html
@@ -1,0 +1,19 @@
+{% macro result_lines(result, www_root, tree) -%}
+  {% for entry in result.lines %}
+    <tr>
+      <td class="left-column">
+        <a href="{{ www_root }}/{{ tree }}/source/{{ result.path }}#{{ entry.line_number }}">
+          {{ entry.line_number }}
+        </a>
+      </td>
+      <td>
+        <a href="{{ www_root }}/{{ tree }}/source/{{ result.path }}#{{ entry.line_number }}">
+          <code aria-labelledby="{{ entry.line_number }}">{{ entry.line|safe }}</code>
+        </a>
+      </td>
+    </tr>
+  {% endfor %}
+{%- endmacro %}
+
+{# When not being included as a macro, render the code above. #}
+{{ result_lines(result, www_root, tree) }}

--- a/dxr/static/templates/partial/results.html
+++ b/dxr/static/templates/partial/results.html
@@ -1,12 +1,8 @@
-{% if results|length > 0 %}
-  <table class="results">
-    <caption class="visually-hidden">Query matches</caption>
-    <thead class="visually-hidden">
-      <th scope="col">Line</th>
-      <th scope="col">Code Snippet</th>
-    </thead>
-    <tbody>
-    {% for result in results %}
+{% from "partial/result_lines.html" import result_lines -%}
+
+{% macro results_list(results, www_root, tree) -%}
+  {% for result in results %}
+    <tbody class="result" data-path="{{ result.path }}">
       <tr class="result-head">
         <td class="left-column">
           <div class="{{result.iconClass}} icon-container"></div>
@@ -15,23 +11,10 @@
           {{ result.pathLine|safe }}
         </td>
       </tr>
-      {% for entry in result.lines %}
-      <tr>
-        <td class="left-column">
-          <a href="{{ www_root }}/{{ tree }}/source/{{ result.path }}#{{ entry.line_number }}">
-            {{ entry.line_number }}
-          </a>
-        </td>
-        <td>
-<a href="{{ www_root }}/{{ tree }}/source/{{ result.path }}#{{ entry.line_number }}">
-<code aria-labelledby="{{ entry.line_number }}">{{ entry.line|safe }}</code>
-</a>
-        </td>
-      </tr>
-      {% endfor %}
-    {% endfor %}
+      {{ result_lines(result, www_root, tree) }}
     </tbody>
-  </table>
-{% else %}
-    <p class="no-results">{{ user_message }}</p>
-{% endif %}
+  {% endfor %}
+{%- endmacro %}
+
+{# When not being included as a macro, render the code above. #}
+{{ results_list(results, www_root, tree) }}

--- a/dxr/static/templates/partial/results_container.html
+++ b/dxr/static/templates/partial/results_container.html
@@ -1,0 +1,20 @@
+{% from "partial/results.html" import results_list -%}
+{% from "partial/switch_tree.html" import tree_menu -%}
+{% from "partial/no_results.html" import no_results -%}
+
+<p class="top-of-tree">Results from the <a href="{{ top_of_tree }}">{{ tree }}</a> tree:</p>
+
+{{ tree_menu(tree_tuples, tree) }}
+
+{% if results|length > 0 %}
+  <table class="results">
+    <caption class="visually-hidden">Query matches</caption>
+    <thead class="visually-hidden">
+      <th scope="col">Line</th>
+      <th scope="col">Code Snippet</th>
+    </thead>
+    {{ results_list(results, www_root, tree) }}
+  </table>
+{% else %}
+    <p class="no-results">{{ no_results() }}</p>
+{% endif %}

--- a/dxr/static/templates/results_container.html
+++ b/dxr/static/templates/results_container.html
@@ -1,6 +1,0 @@
-{% from "partial/switch_tree.html" import tree_menu %}
-<p class="top-of-tree">Results from the <a href="{{ top_of_tree }}">{{ tree }}</a> tree:</p>
-
-{{ tree_menu(tree_tuples, tree) }}
-
-{% include 'partial/results.html' %}

--- a/dxr/static/templates/search.html
+++ b/dxr/static/templates/search.html
@@ -21,8 +21,8 @@
           <th scope="col">Line</th>
           <th scope="col">Code Snippet</th>
       </thead>
-      <tbody>
       {%- for icon, path, lines in results -%}
+      <tbody class="result" data-path="{{ path }}">
         <tr class="result-head">
           <td class="left-column">
             <div class="{{ icon }} icon-container"></div>
@@ -40,21 +40,21 @@
           </td>
         </tr>
         {% for number, line in lines %}
-        <tr>
-          <td class="left-column">
-            <a href="{{ www_root }}/{{ tree }}/source/{{ path }}#{{ number }}">
-              {{ number }}
-            </a>
-          </td>
-          <td>
-<a href="{{ www_root }}/{{ tree }}/source/{{ path }}#{{ number }}">
-<code aria-labelledby="{{ number }}">{{ line|safe }}</code>
-</a>
-          </td>
-        </tr>
+          <tr>
+            <td class="left-column">
+              <a href="{{ www_root }}/{{ tree }}/source/{{ path }}#{{ number }}">
+                {{ number }}
+              </a>
+            </td>
+            <td>
+              <a href="{{ www_root }}/{{ tree }}/source/{{ path }}#{{ number }}">
+                <code aria-labelledby="{{ number }}">{{ line|safe }}</code>
+              </a>
+            </td>
+          </tr>
         {% endfor %}
-    {% endfor %}
       </tbody>
+      {% endfor %}
     </table>
   {% else %}
     <p class="no-results">{{ no_results() }}</p>


### PR DESCRIPTION
Fixes the infinite scroll to count lines properly (it was previously counting number of files returned) and to append new lines for a file that is already on the page to that file instead of creating a new file group in the search results.

This supersedes #384, which was very helpful in helping me understand what was going wrong. :D