### PR TITLE
Add `dxr shell` command.

### DIFF
--- a/dxr/cli/__init__.py
+++ b/dxr/cli/__init__.py
@@ -10,6 +10,7 @@ from dxr.cli.delete import delete
 from dxr.cli.deploy import deploy
 from dxr.cli.index import index
 from dxr.cli.serve import serve
+from dxr.cli.shell import shell
 from dxr.cli.utils import tree_objects, config_option, tree_names_argument
 
 
@@ -40,4 +41,5 @@ dxr.add_command(index)
 dxr.add_command(clean)
 dxr.add_command(delete)
 dxr.add_command(serve)
+dxr.add_command(shell)
 dxr.add_command(deploy)

--- a/dxr/cli/shell.py
+++ b/dxr/cli/shell.py
@@ -1,0 +1,49 @@
+from click import command, option
+
+from dxr.app import make_app
+from dxr.cli.utils import config_option
+
+
+def _plain_shell(namespace):
+    """Start a plain python shell."""
+    import code
+    import readline
+    import rlcompleter
+
+    readline.set_completer(rlcompleter.Completer(namespace).complete)
+    readline.parse_and_bind('tab:complete;')
+    code.interact(local=namespace)
+
+
+def _ipython(namespace):
+    """Start IPython."""
+    from IPython import start_ipython
+    start_ipython(argv=[], user_ns=namespace)
+
+
+_shells = [_ipython, _plain_shell]
+
+
+@command()
+@config_option
+@option('--plain', '-p',
+        is_flag=True,
+        default=False,
+        help='Use a plain shell instead of IPython if available.')
+def shell(config, plain):
+    """Run a Python interactive interpreter."""
+    app = make_app(config)
+    app.debug = True
+    with app.app_context():
+        namespace = {'app': app, 'config': config}
+
+        if plain:
+            _plain_shell(namespace)
+        else:
+            for shell in _shells:
+                try:
+                    shell(namespace)
+                except ImportError:
+                    pass
+                else:
+                    break


### PR DESCRIPTION
`dxr shell` opens an interactive Python shell within a Flask app
context. It essentially does what `dxr serve` does, but instead of
running the app, gives you a shell to play around with.

I found it useful while trying to execute some code copied from a view, which required the app context to be set up or access to a config file.