### PR TITLE
Update docs for the ES branch

### DIFF
--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -2,14 +2,15 @@
 Configuration
 =============
 
-DXR learns how to index your source trees by means of an ini-formatted
+DXR learns how to index and serve your source trees by means of an ini-formatted
 configuration file:
 
 .. include:: example-configuration.rst
 
-It gets passed to :program:`dxr-build.py` at indexing time::
+When you invoke :program:`dxr`, it defaults to reading :file:`dxr.config`
+in the current directory::
 
-    dxr-build.py my_config_file.config
+    dxr index
 
 Sections
 ========

--- a/docs/source/deployment.rst
+++ b/docs/source/deployment.rst
@@ -2,6 +2,11 @@
 Deployment
 ==========
 
+.. note::
+
+    FIXME: need to update these instructions to use the :program:`dxr` CLI
+    instead of :program:`dxr-*.py`.
+
 Once you decide to put DXR into production for use by multiple people, it's
 time to move beyond the :doc:`getting-started` instructions. You likely need
 real machines—not Vagrant VMs—and you definitely need a robust web server like

--- a/docs/source/development.rst
+++ b/docs/source/development.rst
@@ -10,7 +10,7 @@ Architecture
 
 DXR divides into 2 halves:
 
-1. The indexer, :program:`dxr-build.py`, is a batch job which analyzes code and
+1. The indexer, :program:`dxr index`, is a batch job which analyzes code and
    builds on-disk indices.
 
    The indexer hosts various plugins which handle everything from syntax
@@ -26,7 +26,7 @@ DXR divides into 2 halves:
    strategies that make sense for them.
 
 2. A Flask web application which lets users query those indices.
-   :program:`dxr-serve.py` is a way to run the application for development
+   :program:`dxr serve` is a way to run the application for development
    purposes, but a more robust method should be used for :doc:`deployment`.
 
 
@@ -45,8 +45,8 @@ for manually trying out your changes. ``test_basic`` is a good one to start
 with. To get it running... ::
 
     cd ~/dxr/tests/test_basic
-    make
-    LD_LIBRARY_PATH=$LD_LIBRARY_PATH:../../trilite dxr-serve.py -a target
+    dxr index
+    dxr serve -a
 
 You can then surf to http://33.33.33.77:8000/ from the host machine and play
 around. When you're done, stop the server with :kbd:`Control-C`.
@@ -74,9 +74,9 @@ Changes to HTML templates that are used on the client side:
 Changes to server-side HTML templates or the format of the elasticsearch index:
     Run ``make`` inside :file:`tests/test_basic`.
 
-Stop :program:`dxr-serve.py`, run the build step, and then fire up the server
+Stop :program:`dxr serve`, run the build step, and then fire up the server
 again. If you're changing Python code that runs only at request time, you
-shouldn't need to do anything; :program:`dxr-serve.py` should notice and
+shouldn't need to do anything; :program:`dxr serve` should notice and
 restart itself a few seconds after you save.
 
 
@@ -105,7 +105,7 @@ DXR supports two kinds of tests:
    ``test_ignores`` is an example. Within these instances are one or
    more Python files containing subclasses of ``DxrInstanceTestCase``
    which express the actual tests. These instances can be built like any
-   other using ``dxr-build.py``, in case you want to do manual
+   other using ``dxr index``, in case you want to do manual
    exploration.
 
 Running the Tests

--- a/docs/source/development.rst
+++ b/docs/source/development.rst
@@ -398,6 +398,22 @@ prefix all config keys as ``plugin_<plugin-name>_<key>``. Plugins living in
 the DXR codebase must document their keys in the plugin section of
 :doc:`configuration`.
 
+Contributing documentation
+---------------
+
+We use `Read the Docs`_ for building and hosting the documentation, which uses
+`sphinx`_ to generate HTML documentation from reStructuredText markup.
+
+To make changes to documentation:
+  * Edit :file:`*.rst` files in :file:`docs/source/` in your local checkout.
+    See `reStructuredText primer`_ for syntax aids.
+  * Use ``cd ~/dxr/docs && make html`` in the VM to preview the docs.
+  * When you're satisfied, submit the pull request as usual.
+
+.. _Read the Docs: https://docs.readthedocs.org/
+.. _sphinx: http://sphinx-doc.org/
+.. _reStructuredText primer: http://sphinx-doc.org/rest.html
+
 
 Troubleshooting
 ---------------

--- a/docs/source/getting-started.rst
+++ b/docs/source/getting-started.rst
@@ -12,8 +12,8 @@ The easiest way to get DXR working on your own machine is...
 
 1. Get the source code you want to index.
 2. Tell DXR how to build it.
-3. Run :program:`dxr-build.py` to build and index your code.
-4. Run :program:`dxr-serve.py` to present a web-based search interface.
+3. Run :program:`dxr index` to build and index your code.
+4. Run :program:`dxr serve` to present a web-based search interface.
 
 But first, we have some installation to do.
 
@@ -39,7 +39,7 @@ place is adjacent to your source directory.
    Be sure to replace the placeholder paths in the above config.
 
 By building your project with clang and under the control of
-:program:`dxr-build.py`, DXR gets a chance to interpose a custom compiler
+:program:`dxr index`, DXR gets a chance to interpose a custom compiler
 plugin that emits analysis data. It then processes that into an index.
 
 If you have a non-C++ project and simply want to index it as text, the
@@ -56,7 +56,7 @@ Indexing
 Now that you've told DXR about your codebase, it's time to build an
 :term:`index` (sometimes also called an :term:`instance`)::
 
-    dxr-build.py dxr.config
+    dxr index
 
 .. note::
 
@@ -84,7 +84,7 @@ Now that you've told DXR about your codebase, it's time to build an
     you can get one of the included test cases to work::
 
         cd ~/dxr/tests/test_basic
-        make
+        dxr index
 
     If that works, it's just a matter of getting your configuration right. Pop
     into #static on irc.mozilla.org if you need a hand.
@@ -96,7 +96,7 @@ Serving Your Index
 Congratulations; your index is built! Now, spin up DXR's development server,
 and see what you've wrought::
 
-    dxr-serve.py --all /path/to/the/output
+    dxr serve --all
 
 Surf to http://33.33.33.77:8000/ from the host machine, and poke around
 your fancy new searchable codebase.


### PR DESCRIPTION
I was checking out dxr and came across some outdated docs. In the process of fixing them I had to figure out (again!) how to work with readthedocs, so I added this to development.rst.

Did not update deployment.rst, since I wasn't able to try the instructions listed there.