### PR TITLE
Set "bash strict mode" not only on vagrant_provision but on the subsh…

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -20,7 +20,7 @@ Jinja2==2.7.2
 # sha256: t9XWiL3TRb-ol3d9KXdWaIzwLhs3QsVoheLlwrmW_4I
 MarkupSafe==0.18
 
-# sha256: _x2gVFzdRuvPRzF21Vk3oiu1X_9Rzf-dTC-QD8gLrxA
+# sha256: _x2gVFzdRuvPRzF21Vk3oiu1X_9Rzf-dTC-QD8gLrxABADBAD
 Mercurial==3.4
 
 # sha256: k-YuBcetPaGiM972cx6ChRVnAeNBml_ieQF8Qp7GfOA

--- a/vagrant_provision.sh
+++ b/vagrant_provision.sh
@@ -4,8 +4,7 @@
 # This is idempotent, even though I'm not sure the shell provisioner requires
 # it to be.
 
-set -e
-set -x
+set -euxo pipefile
 
 # Elasticsearch isn't in Debian proper yet, so we get it from
 # elasticsearch.org's repo.
@@ -32,6 +31,7 @@ apt-get install -y libapache2-mod-wsgi python-pip python-virtualenv python2.7-de
 # Build a virtualenv, and install requirements:
 VENV=/home/vagrant/venv
 sudo -H -u vagrant -s -- <<THEEND
+set -euxo pipefile
 virtualenv $VENV
 source $VENV/bin/activate
 cd ~vagrant/dxr

--- a/vagrant_provision.sh
+++ b/vagrant_provision.sh
@@ -4,7 +4,7 @@
 # This is idempotent, even though I'm not sure the shell provisioner requires
 # it to be.
 
-set -euxo pipefile
+set -eux
 
 # Elasticsearch isn't in Debian proper yet, so we get it from
 # elasticsearch.org's repo.
@@ -31,7 +31,7 @@ apt-get install -y libapache2-mod-wsgi python-pip python-virtualenv python2.7-de
 # Build a virtualenv, and install requirements:
 VENV=/home/vagrant/venv
 sudo -H -u vagrant -s -- <<THEEND
-set -euxo pipefile
+set -eux
 virtualenv $VENV
 source $VENV/bin/activate
 cd ~vagrant/dxr


### PR DESCRIPTION
…ell it spawns via sudo.

https://ci.mozilla.org/job/dxr/551/ plowed ahead even after a peep error because we weren't doing this.

See http://redsymbol.net/articles/unofficial-bash-strict-mode/.

NOTE: This is going to fail on purpose to see if the peep failure promptly aborts the script.