### PR TITLE
Fix bug 1166549. Make binaries not clickable in search results.

### DIFF
--- a/dxr/app.py
+++ b/dxr/app.py
@@ -389,7 +389,7 @@ def _browse_file(tree, path, line_docs, file_doc, config, date=None, contents=No
         return render_template(
             'image_file.html',
             **common)
-    else:  # For now, we don't index binary files, so this is always a text one
+    else:  # We don't allow browsing binary files, so this must be a text file.
         # We concretize the lines into a list because we iterate over it multiple times
         lines = [doc['content'] for doc in line_docs]
         if not contents:

--- a/dxr/app.py
+++ b/dxr/app.py
@@ -106,8 +106,9 @@ def _search_json(query, tree, query_text, is_case_sensitive, offset, limit, conf
         # Convert to dicts for ease of manipulation in JS:
         results = [{'icon': icon,
                     'path': path,
-                    'lines': [{'line_number': nb, 'line': l} for nb, l in lines]}
-                   for icon, path, lines in count_and_results['results']]
+                    'lines': [{'line_number': nb, 'line': l} for nb, l in lines],
+                    'is_binary': is_binary}
+                   for icon, path, lines, is_binary in count_and_results['results']]
     except BadTerm as exc:
         return jsonify({'error_html': exc.reason, 'error_level': 'warning'}), 400
 

--- a/dxr/query.py
+++ b/dxr/query.py
@@ -92,7 +92,8 @@ class Query(object):
             {'result_count': 12,
              'results': [(icon,
                           path within tree,
-                          [(line_number, highlighted_line_of_code), ...]),
+                          [(line_number, highlighted_line_of_code), ...],
+                          whether it is binary),
                          ...]}
 
         """

--- a/dxr/query.py
+++ b/dxr/query.py
@@ -72,7 +72,8 @@ class Query(object):
                      highlight(line['content'][0].rstrip('\n\r'),
                                chain.from_iterable(h(line) for h in
                                                    content_highlighters)))
-                    for line in lines])
+                    for line in lines],
+                   False)
 
     def _file_query_results(self, results, path_highlighters):
         """Return an iterable of results of a FILE-domain query."""
@@ -81,7 +82,8 @@ class Query(object):
                    highlight(file['path'][0],
                              chain.from_iterable(
                                  h(file) for h in path_highlighters)),
-                   [])
+                   [],
+                   file.get('is_binary', False))
 
     def results(self, offset=0, limit=100):
         """Return a count of search results and, as an iterable, the results

--- a/dxr/static/js/dxr.js
+++ b/dxr/static/js/dxr.js
@@ -102,7 +102,7 @@ $(function() {
      * @param {string} tree - The tree which was searched and in which this file can be found.
      * @param {string} icon - The icon string returned in the JSON payload.
      */
-    function buildResultHead(fullPath, tree, icon) {
+    function buildResultHead(fullPath, tree, icon, isBinary) {
         var pathLines = '',
             pathRoot = '/' + tree + '/source/',
             paths = fullPath.split('/'),
@@ -122,7 +122,8 @@ $(function() {
                 'display_path': paths[pathIndex],
                 'url': pathRoot + dataPath.join('/'),
                 'is_first_or_only': isFirstOrOnly,
-                'is_dir': !isLastOrOnly
+                'is_dir': !isLastOrOnly,
+                'is_binary': isBinary
             });
         }
 
@@ -345,7 +346,7 @@ $(function() {
 
             for (var result in results) {
                 var icon = results[result].icon;
-                var resultHead = buildResultHead(results[result].path, data.tree, icon);
+                var resultHead = buildResultHead(results[result].path, data.tree, icon, results[result].is_binary);
                 results[result].iconClass = resultHead[0];
                 results[result].pathLine = resultHead[1];
             }

--- a/dxr/static/templates/image_file.html
+++ b/dxr/static/templates/image_file.html
@@ -2,7 +2,7 @@
 
 {% block site_css %}
   {{ super() }}
-  <link href="{{ url_for('.static', filename='/css/image_file.css') }}" rel="stylesheet" type="text/css" media="screen" />
+  <link href="{{ url_for('.static', filename='css/image_file.css') }}" rel="stylesheet" type="text/css" media="screen" />
 {% endblock %}
 
 {% block content %}

--- a/dxr/static/templates/partial/results.html
+++ b/dxr/static/templates/partial/results.html
@@ -3,7 +3,7 @@
 {% macro results_list(results, www_root, tree) -%}
   {% for result in results %}
     <tbody class="result" data-path="{{ result.path }}">
-      <tr class="result-head">
+      <tr class="result-head {% if result.is_binary %} binary_row {% endif %}">
         <td class="left-column">
           <div class="{{result.iconClass}} icon-container"></div>
         </td>

--- a/dxr/static/templates/path_line.html
+++ b/dxr/static/templates/path_line.html
@@ -5,6 +5,6 @@
 <a href="{{ url }}" {%- if is_dir %} data-path="{{ data_path }}" {% endif %}>
 {%- endif -%}
     {{ display_path }}
-{%- if not is_binary -%}
+{%- if not is_binary and not is_dir -%}
 </a>
 {%- endif -%}

--- a/dxr/static/templates/path_line.html
+++ b/dxr/static/templates/path_line.html
@@ -1,4 +1,10 @@
 {%- if not is_first_or_only -%}
 <span class="path-separator">/</span>
 {%- endif -%}
-<a href="{{ url }}" {%- if is_dir %} data-path="{{ data_path }}" {% endif %}>{{ display_path }}</a>
+{%- if not is_binary and not is_dir -%}
+<a href="{{ url }}" {%- if is_dir %} data-path="{{ data_path }}" {% endif %}>
+{%- endif -%}
+    {{ display_path }}
+{%- if not is_binary -%}
+</a>
+{%- endif -%}

--- a/dxr/static/templates/search.html
+++ b/dxr/static/templates/search.html
@@ -18,9 +18,9 @@
           <th scope="col">Line</th>
           <th scope="col">Code Snippet</th>
       </thead>
-      {%- for icon, path, lines in results -%}
+      {%- for icon, path, lines, is_binary in results -%}
       <tbody class="result" data-path="{{ path }}">
-        <tr class="result-head">
+        <tr class="result-head {%- if is_binary %} binary_row {% endif %}">
           <td class="left-column">
             <div class="{{ icon }} icon-container"></div>
           </td>

--- a/tests/test_basic/test_basic.py
+++ b/tests/test_basic/test_basic.py
@@ -53,7 +53,8 @@ class BasicTests(DxrInstanceTestCase):
                   "line": "$(CXX) -o $@ $^"},
                 {"line_number": 4,
                   "line": "clean:"}],
-              "icon": "unknown"}])
+              "icon": "unknown",
+              "is_binary": False}])
 
     def test_case_insensitive_extents(self):
         """Test case-insensitive free-text searching with extents.
@@ -80,7 +81,8 @@ class BasicTests(DxrInstanceTestCase):
         eq_(self.search_results('path:makefile'),
             [{"path": "makefile",
               "lines": [],
-              "icon": "unknown"}])
+              "icon": "unknown",
+              "is_binary": False}])
 
     def test_filter_punting(self):
         """Make sure filters can opt out of filtration--in this case, due to

--- a/tests/test_binary_files/test_binary_files.py
+++ b/tests/test_binary_files/test_binary_files.py
@@ -43,3 +43,10 @@ class BinaryFileTests(DxrInstanceTestCase):
         ok_('some_bytes' in response.data)
         response = self.client().get('/code/source/some_bytes')
         ok_(response.status_code, 404)
+
+    def test_some_bytes(self):
+        """We want some_bytes to show on search page, but not be clickable."""
+        response = self.client().get('/code/search?q=path%3Asome_bytes&redirect=true')
+        ok_('some_bytes' in response.data)
+        ok_('href="/code/source/some_bytes"' not in response.data)
+


### PR DESCRIPTION
Pass is_binary field of FILE to search_html, and gate the anchor tag
in the path_line template on whether the path is to a binary file.