### PR TITLE
Empty out search.html; perform AJAX request instead.

### DIFF
--- a/dxr/app.py
+++ b/dxr/app.py
@@ -160,21 +160,7 @@ def _search_html(query, tree, query_text, is_case_sensitive, offset, limit, conf
             'tree_tuples': _tree_tuples(query_text, is_case_sensitive),
             'www_root': config.www_root}
 
-    try:
-        count_and_results = query.results(offset, limit)
-        results = list(count_and_results['results'])
-        results_line_count = sum(len(r[2]) for r in results)
-    except BadTerm as exc:
-        return render_template('error.html',
-                               error_html=exc.reason,
-                               **template_vars), 400
-
-    return render_template('search.html',
-                           results=results,
-                           result_count=count_and_results['result_count'],
-                           result_count_formatted=format_number(count_and_results['result_count']),
-                           results_line_count=results_line_count,
-                           **template_vars)
+    return render_template('search.html', **template_vars)
 
 
 def _tree_tuples(query_text, is_case_sensitive):

--- a/dxr/app.py
+++ b/dxr/app.py
@@ -96,7 +96,24 @@ def search(tree):
 
 
 def _search_json(query, tree, query_text, is_case_sensitive, offset, limit, config):
-    """Do a normal search, and return the results as JSON."""
+    """Try a "direct search" (for exact identifier matches, etc.). If we have a direct hit,
+    then return {redirect: hit location}.If that doesn't work, fall back to a normal search
+    and return the results as JSON."""
+
+    # If we're asked to redirect and have a direct hit, then return the url to that.
+    if request.values.get('redirect') == 'true':
+        result = query.direct_result()
+        if result:
+            path, line = result
+            # TODO: Does this escape query_text properly?
+            params = {
+                'tree': tree,
+                'path': path,
+                'from': query_text
+            }
+            if is_case_sensitive:
+                params['case'] = 'true'
+            return jsonify({'redirect': url_for('.browse', _anchor=line, **params)})
     try:
         count_and_results = query.results(offset, limit)
         # Convert to dicts for ease of manipulation in JS:
@@ -118,29 +135,9 @@ def _search_json(query, tree, query_text, is_case_sensitive, offset, limit, conf
 
 
 def _search_html(query, tree, query_text, is_case_sensitive, offset, limit, config):
-    """Search a few different ways, and return the results as HTML.
-
-    Try a "direct search" (for exact identifier matches, etc.). If that
-    doesn't work, fall back to a normal search.
+    """Return the rendered template for search.html.
 
     """
-    should_redirect = request.values.get('redirect') == 'true'
-
-    # Try for a direct result:
-    if should_redirect:  # always true in practice?
-        result = query.direct_result()
-        if result:
-            path, line = result
-            # TODO: Does this escape query_text properly?
-            return redirect(
-                '%s/%s/source/%s?from=%s%s#%i' %
-                (config.www_root,
-                 tree,
-                 path,
-                 query_text,
-                 '&case=true' if is_case_sensitive else '',
-                 line))
-
     frozen = frozen_config(tree)
 
     # Try a normal search:

--- a/dxr/static/js/dxr.js
+++ b/dxr/static/js/dxr.js
@@ -7,7 +7,6 @@ $(function() {
     'use strict';
 
     var constants = $('#data');
-    var stateConstants = $('#state');
     var dxr = {},
         docElem = document.documentElement;
 
@@ -175,7 +174,7 @@ $(function() {
      * @param {string} query - The query string
      * @param {bool} isCaseSensitive - Whether the query should be case-sensitive
      * @param {int} limit - The number of results to return.
-     * @param [int] offset - The cursor position
+     * @param {int} offset - The cursor position
      */
     function buildAjaxURL(query, isCaseSensitive, limit, offset) {
         var search = dxr.searchUrl;
@@ -222,33 +221,17 @@ $(function() {
         history.replaceState(state, '', url);
     }
 
-    /**
-     * Add an entry into the history stack whenever we do a new search.
-     */
-    function pushHistoryState(data) {
-        var searchUrl = constants.data('search') + '?' + data.query_string;
-        history.pushState({}, '', searchUrl);
-    }
-
     function infiniteScroll() {
         if (didScroll) {
 
             didScroll = false;
-
-            // If the previousDataLimit is 0 we are on the search.html page and doQuery
-            // has not yet been called, get the previousDataLimit and resultsLineCount
-            // from the page constants.
-            if (previousDataLimit === 0) {
-                previousDataLimit = stateConstants.data('limit');
-                resultsLineCount = stateConstants.data('results-line-count');
-            }
 
             var maxScrollY = getMaxScrollY(),
                 currentScrollPos = window.scrollY,
                 threshold = window.innerHeight + 500;
 
             // Has the user reached the scrolling threshold and are there more results?
-            if ((maxScrollY - currentScrollPos) < threshold && previousDataLimit === resultsLineCount) {
+            if ((maxScrollY - currentScrollPos) < threshold && previousDataLimit <= resultsLineCount) {
                 clearInterval(scrollPoll);
 
                 // If a user hits enter on the landing page and there was no direct result,
@@ -263,10 +246,6 @@ $(function() {
                 $.getJSON(buildAjaxURL(query, caseSensitiveBox.prop('checked'), defaultDataLimit, dataOffset), function(data) {
                     data.query = query;
                     if (data.results.length > 0) {
-                        var state = {};
-
-                        // Update result count
-                        resultsLineCount = countLines(data.results);
                         // Use the results.html partial so we do not inject the entire container again.
                         populateResults(data, true);
                         // update URL with new offset
@@ -370,7 +349,7 @@ $(function() {
                     domFirstResult.append(nunjucks.render('partial/result_lines.html', {
                         www_root: dxr.wwwRoot,
                         tree: dxr.tree,
-                        result: firstResult,
+                        result: firstResult
                     }));
                 }
 
@@ -388,9 +367,18 @@ $(function() {
 
     /**
      * Queries and populates the results templates with the returned data.
+     *
+     * @param {string} [queryString] - The url to which to send the request. By
+     * default, queryString will be constructed from the contents of the query
+     * field.
      */
-    function doQuery() {
+    function doQuery(queryString) {
+        query = $.trim(queryField.val());
+        var myRequestNumber = nextRequestNumber,
+            lineHeight = parseInt(contentContainer.css('line-height'), 10),
+            limit = Math.floor((window.innerHeight / lineHeight) + 25);
 
+        queryString = queryString || buildAjaxURL(query, caseSensitiveBox.prop('checked'), limit, 0);
         function oneMoreRequest() {
             if (requestsInFlight === 0) {
                 $('#search-box').addClass('in-progress');
@@ -407,11 +395,6 @@ $(function() {
 
         clearTimeout(historyWaiter);
 
-        query = $.trim(queryField.val());
-        var myRequestNumber = nextRequestNumber,
-            lineHeight = parseInt(contentContainer.css('line-height'), 10),
-            limit = Math.floor((window.innerHeight / lineHeight) + 25);
-
         if (query.length === 0) {
             hideBubble();  // Don't complain when I delete what I typed. You didn't complain when it was empty before I typed anything.
             return;
@@ -423,19 +406,27 @@ $(function() {
         hideBubble();
         nextRequestNumber += 1;
         oneMoreRequest();
-        $.getJSON(buildAjaxURL(query, caseSensitiveBox.prop('checked'), limit, 0), function(data) {
-            data.query = query;
-            // New results, overwrite
-            if (myRequestNumber > displayedRequestNumber) {
-                displayedRequestNumber = myRequestNumber;
-                populateResults(data, false);
-                historyWaiter = setTimeout(pushHistoryState, timeouts.history, data);
+        $.ajax({
+            dataType: "json",
+            url: queryString,
+            // We need to disable caching of this result because otherwise we break the undo close
+            // tab feature on search pages (Chrome and Firefox).
+            cache: false,
+            success: function (data) {
+                data.query = query;
+                // New results, overwrite
+                if (myRequestNumber > displayedRequestNumber) {
+                    displayedRequestNumber = myRequestNumber;
+                    populateResults(data, false);
+                    historyWaiter = setTimeout(history.pushState.bind(history, {}, '', queryString),
+                        timeouts.history);
+                }
+
+                previousDataLimit = limit;
+                dataOffset = 0;
+
+                oneFewerRequest();
             }
-
-            previousDataLimit = limit;
-            dataOffset = 0;
-
-            oneFewerRequest();
         })
         .fail(function(jqxhr) {
             oneFewerRequest();
@@ -489,9 +480,9 @@ $(function() {
 
 
     /**
-     * Adds aleading 0 to numbers less than 10 and greater that 0
+     * Adds a leading 0 to numbers less than 10 and greater than 0
      *
-     * @param int number The number to test against
+     * @param {int} number The number to test against
      *
      * return Either the original number or the number prefixed with 0
      */
@@ -502,7 +493,7 @@ $(function() {
     /**
      * Converts string to new Date and returns a formatted date in the
      * format YYYY-MM-DD h:m
-     * @param String dateString A date in string form.
+     * @param {string} dateString A date in string form.
      *
      */
     function formatDate(dateString) {
@@ -556,4 +547,11 @@ $(function() {
         });
     });
 
+    // If on load of the search endpoint we have a query string then we need to
+    // load the results of the query.
+    window.addEventListener('load', function() {
+        if (/search$/.test(window.location.pathname) && window.location.search) {
+            doQuery(window.location.href);
+        }
+    });
 });

--- a/dxr/static/templates/search.html
+++ b/dxr/static/templates/search.html
@@ -1,59 +1,10 @@
 {% extends "layout.html" %}
-{% from "partial/results_header.html" import results_header -%}
 
 {% block title %}{{ query }} - DXR Search{% endblock %}
 
 {% block site_css %}
   {{ super() }}
   <link href="{{ url_for('.static', filename='css/tree-selector.css') }}" rel="stylesheet" type="text/css" media="screen" />
-{% endblock %}
-
-{% block content %}
-  {{ results_header(result_count, result_count_formatted, top_of_tree, tree_tuples, tree) }}
-
-  {% if results|length > 0 %}
-    <table class="results">
-      <caption class="visually-hidden">Query matches</caption>
-      <thead class="visually-hidden">
-          <th scope="col">Line</th>
-          <th scope="col">Code Snippet</th>
-      </thead>
-      {%- for icon, path, lines, is_binary in results -%}
-      <tbody class="result" data-path="{{ path }}">
-        <tr class="result-head {%- if is_binary %} binary_row {% endif %}">
-          <td class="left-column">
-            <div class="{{ icon }} icon-container"></div>
-          </td>
-          <td>
-            {%- set paths = path.split('/') -%}
-            {%- for display_path in paths -%}
-              {%- set data_path = '%s/%s' % (data_path, display_path) if data_path else display_path -%}
-              {%- set is_first_or_only = loop.first or paths|length == 1 -%}
-              {%- set is_dir = not loop.last -%}
-              {%- set url = url_for('.browse', tree=tree, path=path) -%}
-
-              {%- include 'path_line.html' -%}
-            {%- endfor -%}
-          </td>
-        </tr>
-        {% for number, line in lines %}
-          <tr>
-            <td class="left-column">
-              <a href="{{ url_for('.browse', tree=tree, path=path, _anchor=number) }}">
-                {{ number }}
-              </a>
-            </td>
-            <td>
-              <a href="{{ url_for('.browse', tree=tree, path=path, _anchor=number) }}">
-                <code aria-labelledby="{{ number }}">{{ line|safe }}</code>
-              </a>
-            </td>
-          </tr>
-        {% endfor %}
-      </tbody>
-      {% endfor %}
-    </table>
-  {% endif %}
 {% endblock %}
 
 {% block site_js %}

--- a/dxr/testing.py
+++ b/dxr/testing.py
@@ -100,14 +100,14 @@ class TestCase(unittest.TestCase):
         path at the given line number."""
         response = self.client().get(
             '/code/search?q=%s&redirect=true&case=%s' %
-                    (quote(query), 'true' if is_case_sensitive else 'false'))
+            (quote(query), 'true' if is_case_sensitive else 'false'),
+            headers={'Accept': 'application/json'})
         if line_number:
-            eq_(response.status_code, 302)
-            location = response.headers['Location']
+            eq_(response.status_code, 200)
+            location = json.loads(response.data)['redirect']
             # Location is something like
-            # http://localhost/code/source/main.cpp?from=main.cpp:6&case=true#6.
-            eq_(location[:location.index('?')],
-                'http://localhost/code/source/' + path)
+            # /code/source/main.cpp?from=main.cpp:6&case=true#6.
+            eq_(location[:location.index('?')], '/code/source/' + path)
             eq_(int(location[location.index('#') + 1:]), line_number)
         else:
             # When line_number is None, just expect a normal search.


### PR DESCRIPTION
Addresses bug [970405](https://bugzilla.mozilla.org/show_bug.cgi?id=970405).
~~Still a bit rough; sometimes when loading a page the location will change after about half a second.~~ Fixed by #423.

Here we remove the content block of search.html and instead perform an AJAX request on load of the search page based on the search portion of the location.
Remark: I do not completely remove search.html because I want to preserve the back button and the ability to link directly to some search results.