### PR TITLE
Fixes bug 1171229. Correctly update title on dynamic searches.

### DIFF
--- a/dxr/static/js/dxr.js
+++ b/dxr/static/js/dxr.js
@@ -382,7 +382,7 @@ $(function() {
         }
 
         if (!append) {
-            document.title = data.query + "- DXR Search";
+            document.title = data.query + " - DXR Search";
         }
     }
 

--- a/dxr/static/js/dxr.js
+++ b/dxr/static/js/dxr.js
@@ -261,6 +261,7 @@ $(function() {
 
                 //Resubmit query for the next set of results.
                 $.getJSON(buildAjaxURL(query, caseSensitiveBox.prop('checked'), defaultDataLimit, dataOffset), function(data) {
+                    data.query = query;
                     if (data.results.length > 0) {
                         var state = {};
 
@@ -423,6 +424,7 @@ $(function() {
         nextRequestNumber += 1;
         oneMoreRequest();
         $.getJSON(buildAjaxURL(query, caseSensitiveBox.prop('checked'), limit, 0), function(data) {
+            data.query = query;
             // New results, overwrite
             if (myRequestNumber > displayedRequestNumber) {
                 displayedRequestNumber = myRequestNumber;


### PR DESCRIPTION
Attach the contents of the query field to the data parameter to populateResults, so the document title updates correctly.