### PR TITLE
Get elasticsearch.org's GPG key over HTTPS.

### DIFF
--- a/vagrant_provision.sh
+++ b/vagrant_provision.sh
@@ -9,7 +9,7 @@ set -x
 
 # Elasticsearch isn't in Debian proper yet, so we get it from
 # elasticsearch.org's repo.
-wget -qO - http://packages.elasticsearch.org/GPG-KEY-elasticsearch | apt-key add -
+wget -qO - https://packages.elasticsearch.org/GPG-KEY-elasticsearch | apt-key add -
 echo 'deb http://packages.elasticsearch.org/elasticsearch/1.4/debian stable main' > /etc/apt/sources.list.d/elasticsearch.list
 
 apt-get update


### PR DESCRIPTION
It's not perfect, but it's better than cleartext.