### PR TITLE
Support id and ref filters.

### DIFF
--- a/dxr/plugins/clang/filters.py
+++ b/dxr/plugins/clang/filters.py
@@ -13,11 +13,13 @@ class _CNameFilter(NameFilterBase):
 
 class FunctionFilter(_CQualifiedNameFilter):
     name = 'function'
+    is_identifier = True
     description = Markup('Function or method definition: <code>function:foo</code>')
 
 
 class FunctionRefFilter(_CQualifiedNameFilter):
     name = 'function-ref'
+    is_reference = True
     description = 'Function or method references'
 
 
@@ -28,6 +30,7 @@ class FunctionDeclFilter(_CQualifiedNameFilter):
 
 class TypeRefFilter(_CQualifiedNameFilter):
     name = 'type-ref'
+    is_reference = True
     description = 'Type or class references, uses, or instantiations'
 
 
@@ -38,16 +41,19 @@ class TypeDeclFilter(_CQualifiedNameFilter):
 
 class TypeFilter(_CQualifiedNameFilter):
     name = 'type'
+    is_identifier = True
     description = Markup('Type or class definition: <code>type:Stack</code>')
 
 
 class VariableFilter(_CQualifiedNameFilter):
     name = 'var'
+    is_identifier = True
     description = 'Variable definition'
 
 
 class VariableRefFilter(_CQualifiedNameFilter):
     name = 'var-ref'
+    is_reference = True
     description = 'Variable uses (lvalue, rvalue, dereference, etc.)'
 
 
@@ -58,31 +64,37 @@ class VarDeclFilter(_CQualifiedNameFilter):
 
 class MacroFilter(_CNameFilter):
     name = 'macro'
+    is_identifier = True
     description = 'Macro definition'
 
 
 class MacroRefFilter(_CNameFilter):
     name = 'macro-ref'
+    is_reference = True
     description = 'Macro uses'
 
 
 class NamespaceFilter(_CQualifiedNameFilter):
     name = 'namespace'
+    is_identifier = True
     description = 'Namespace definition'
 
 
 class NamespaceRefFilter(_CQualifiedNameFilter):
     name = 'namespace-ref'
+    is_reference = True
     description = 'Namespace references'
 
 
 class NamespaceAliasFilter(_CQualifiedNameFilter):
     name = 'namespace-alias'
+    is_identifier = True
     description = 'Namespace alias'
 
 
 class NamespaceAliasRefFilter(_CQualifiedNameFilter):
     name = 'namespace-alias-ref'
+    is_reference = True
     description = 'Namespace alias references'
 
 
@@ -98,11 +110,12 @@ class WarningOptFilter(_CNameFilter):
 
 class CallerFilter(_CQualifiedNameFilter):
     name = 'callers'
+    is_reference = True
     description = Markup('Calls to the given function or method: <code>callers:GetStringFromName</code>')
 
-    def __init__(self, term):
+    def __init__(self, term, enabled_plugins):
         """Massage the needle name so we don't have to call our needle "callers"."""
-        super(CallerFilter, self).__init__(term)
+        super(CallerFilter, self).__init__(term, enabled_plugins)
         self._needle = '{0}_call'.format(self.lang)
 
 

--- a/dxr/plugins/python/filters.py
+++ b/dxr/plugins/python/filters.py
@@ -14,16 +14,19 @@ class _PyFilter(NameFilterBase):
 class ModuleFilter(_QualifiedPyFilter):
     name = 'module'
     domain = FILE
+    is_identifier = True
     description = Markup("Module definition: <code>module:module.name</code>")
 
 
 class TypeFilter(_PyFilter):
     name = 'type'
+    is_identifier = True
     description = Markup('Class definition: <code>type:Stack</code>')
 
 
 class FunctionFilter(_PyFilter):
     name = 'function'
+    is_identifier = True
     description = Markup('Function or method definition: <code>function:foo</code>')
 
 
@@ -39,6 +42,7 @@ class BasesFilter(_QualifiedPyFilter):
 
 class CallersFilter(_PyFilter):
     name = 'callers'
+    is_reference = True
     description = Markup('Calls to the given function: <code>callers:some_function</code>')
 
 

--- a/dxr/plugins/rust/filters.py
+++ b/dxr/plugins/rust/filters.py
@@ -7,14 +7,17 @@ class _QualifiedNameFilter(QualifiedNameFilterBase):
 
 class FunctionFilter(_QualifiedNameFilter):
     name = 'function'
+    is_identifier = True
     description = Markup('Function or method definition: <code>function:foo</code>')
 
 class FunctionRefFilter(_QualifiedNameFilter):
     name = 'function-ref'
+    is_reference = True
     description = 'Function or method references'
 
 class CallersFilter(_QualifiedNameFilter):
     name = 'callers'
+    is_reference = True
     description = 'Function callers'
 
 class CalledByFilter(_QualifiedNameFilter):
@@ -23,6 +26,7 @@ class CalledByFilter(_QualifiedNameFilter):
 
 class FnImplsFilter(_QualifiedNameFilter):
     name = 'fn-impls'
+    is_identifier = True
     description = 'Function implementations'
 
 class DerivedFilter(_QualifiedNameFilter):
@@ -35,41 +39,51 @@ class BasesFilter(_QualifiedNameFilter):
 
 class ImplFilter(_QualifiedNameFilter):
     name = 'impl'
+    is_reference = True
     description = 'Implementations'
 
 class ModuleFilter(_QualifiedNameFilter):
     name = 'module'
+    is_identifier = True
     description = 'Module defintions'
 
 class ModuleUseFilter(_QualifiedNameFilter):
     name = 'module-use'
+    is_reference = True
     description = 'Module imports'
 
 class VarFilter(_QualifiedNameFilter):
     name = 'var'
+    is_identifier = True
     description = 'Variable definitions'
 
 class VarRefFilter(_QualifiedNameFilter):
     name = 'var-ref'
+    is_reference = True
     description = 'Variable references'
 
 class TypeFilter(_QualifiedNameFilter):
     name = 'type'
+    is_identifier = True
     description = 'Type (struct, enum, type, trait) definition'
 
 class TypeRefFilter(_QualifiedNameFilter):
     name = 'type-ref'
+    is_reference = True
     description = 'Type references'
 
 class ModuleRefFilter(_QualifiedNameFilter):
     name = 'module-ref'
+    is_reference = True
     description = 'Module references'
 
 class ModuleAliasRefFilter(_QualifiedNameFilter):
     name = 'module-alias-ref'
     description = 'Module alias references'
+    is_reference = True
 
 class ExternRefFilter(_QualifiedNameFilter):
     name = 'extern-ref'
+    is_reference = True
     description = 'References to items in external crate'
 

--- a/dxr/query.py
+++ b/dxr/query.py
@@ -1,5 +1,5 @@
 import cgi
-from itertools import chain, count, groupby
+from itertools import chain, groupby
 from operator import itemgetter
 import re
 
@@ -102,7 +102,7 @@ class Query(object):
         # will OR the elements of the inner lists and then AND those OR balls
         # together.
         enabled_filters_by_name = filters_by_name(self.enabled_plugins)
-        filters = [[f(term) for f in enabled_filters_by_name[term['name']]]
+        filters = [[f(term, self.enabled_plugins) for f in enabled_filters_by_name[term['name']]]
                    for term in self.terms]
         # See if we're returning lines or just files-and-folders:
         is_line_query = any(f.domain == LINE for f in
@@ -324,6 +324,16 @@ class QueryVisitor(NodeVisitor):
 
         """
         return visited_children or node
+
+
+def some_filters(plugins, condition):
+    """Return a list of filters of the given plugins for which condition(filter) is True.
+
+    :arg plugins: An iterable of plugins
+    :arg condition: A function which takes a filter and returns True or False
+
+    """
+    return filter(condition, chain.from_iterable(p.filters for p in plugins))
 
 
 @cached

--- a/dxr/static/js/dxr.js
+++ b/dxr/static/js/dxr.js
@@ -158,7 +158,7 @@ $(function() {
             searchUrl += '&case=' + isCaseSensitive;
         }
 
-        $('#query').val(decodeURIComponent(fromQuery[1]));
+        queryField.val(decodeURIComponent(fromQuery[1]));
         showBubble('info', viewResultsTxt.replace('{{ url }}', searchUrl));
     }
 

--- a/dxr/utils.py
+++ b/dxr/utils.py
@@ -4,7 +4,7 @@ from contextlib import contextmanager
 from datetime import datetime
 from errno import ENOENT
 import fnmatch
-from functools import wraps
+from functools import partial, wraps
 from itertools import izip
 from os import chdir, dup, fdopen, getcwd
 from os.path import join

--- a/tests/test_core_plugin.py
+++ b/tests/test_core_plugin.py
@@ -32,7 +32,7 @@ class PathFilterTests(TestCase):
                         'arg': u'*hi*hork*.cp?',
                         'qualified': False,
                         'not': False,
-                        'case_sensitive': False}).filter(),
+                        'case_sensitive': False}, []).filter(),
             {
                 'and': [
                     {
@@ -79,7 +79,7 @@ class PathFilterTests(TestCase):
                         'arg': u'fooba[rz]',
                         'qualified': False,
                         'not': False,
-                        'case_sensitive': True}).filter(),
+                        'case_sensitive': True}, []).filter(),
             {
                 'and': [
                     {

--- a/tests/test_filter_aggregates.py
+++ b/tests/test_filter_aggregates.py
@@ -1,0 +1,46 @@
+from dxr.testing import SingleFileTestCase
+
+
+class FilterAggregateTests(SingleFileTestCase):
+    """Tests the id- and ref- aggregate filters defined in query.py"""
+    source = r"""#include <stdio.h>
+
+                 int foo(int n) {
+                     return n - 2;
+                 }
+
+                 // Hello World Example
+                 int main(int argc, char* argv[]){
+                     int a_number = 2;
+                     a_number++;
+                     printf("Hello World %d\n", foo(a_number));
+                     return 0;
+                }
+            """
+
+    def test_id(self):
+        """Test that id-filter works correctly."""
+        self.found_line_eq(
+            'id:foo',
+            'int <b>foo</b>(int n) {',
+            3)
+        self.found_line_eq(
+            'id:main',
+            'int <b>main</b>(int argc, char* argv[]){',
+            8)
+        self.found_line_eq(
+            'id:a_number',
+            'int <b>a_number</b> = 2;',
+            9)
+
+    def test_ref(self):
+        """Test that ref-filter works correctly."""
+        self.found_lines_eq(
+            'ref:a_number',
+            [('<b>a_number</b>++;', 10),
+             ('printf("Hello World %d\\n", foo(<b>a_number</b>));', 11)
+             ])
+        self.found_line_eq(
+            'ref:foo',
+            'printf("Hello World %d\\n", <b>foo(a_number)</b>);',
+            11)


### PR DESCRIPTION
These filters `or` together the filters of enabled plugins that either
find identifiers (i.e. definitions and declarations) or references to
them.
This work is a part of the query language refresh, and a lays groundwork
for result mixing.

To implement this I change the Filter constructor to take a list of enabled plugins, and I add properties is_reference and is_identifier which filters set to True when applicable.