### PR TITLE
Use pkg_resources.resource_filename to find hgext.

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -4,3 +4,4 @@ recursive-include docs *
 include dxr/format
 recursive-include dxr/plugins *.py *.so
 recursive-include dxr/static *
+recursive-include dxr/hgext *

--- a/dxr/vcs.py
+++ b/dxr/vcs.py
@@ -18,15 +18,13 @@ Todos:
 import marshal
 import os
 from os.path import relpath, join, dirname
+from pkg_resources import resource_filename
 import subprocess
 import urlparse
 from warnings import warn
 
-
 import hglib
 from ordereddict import OrderedDict
-
-import dxr
 
 class Vcs(object):
     """A class representing an abstract notion of a version-control system.
@@ -84,9 +82,9 @@ class Vcs(object):
 class Mercurial(Vcs):
     def __init__(self, root):
         super(Mercurial, self).__init__(root, 'hg')
-        hgext = join(dirname(dxr.__file__), 'hgext', 'previous_revisions.py')
+        hgext = resource_filename('dxr', 'hgext/previous_revisions.py')
         with hglib.open(root,
-                        configs = ['extensions.previous_revisions=%s' % hgext]) as client:
+                        configs=['extensions.previous_revisions=%s' % hgext]) as client:
             tip = client.tip()
             self.revision = tip.node
             self.previous_revisions = self.find_previous_revisions(client)


### PR DESCRIPTION
When using setup.py install, the hg extension was not installed because it was not a Python package and it was not specified in the Manifest.
This patch adds the folder to the Manifest, and we refer to the filename in code using pkg_resources, so it will be extracted to a temporary cache directory if it's stuck in an archive.