### PR TITLE
Fix condition for whether to add path anchor.

### DIFF
--- a/dxr/static/templates/path_line.html
+++ b/dxr/static/templates/path_line.html
@@ -1,10 +1,10 @@
 {%- if not is_first_or_only -%}
 <span class="path-separator">/</span>
 {%- endif -%}
-{%- if not is_binary and not is_dir -%}
+{%- if not is_binary or is_dir -%}
 <a href="{{ url }}" {%- if is_dir %} data-path="{{ data_path }}" {% endif %}>
 {%- endif -%}
     {{ display_path }}
-{%- if not is_binary and not is_dir -%}
+{%- if not is_binary or is_dir -%}
 </a>
 {%- endif -%}


### PR DESCRIPTION
If it’s not binary, definitely add path anchor.
Otherwise, add the anchor if it is a directory.
i.e. not is_binary OR is_dir.