### PR TITLE
Fix closing extent on the call filter.

### DIFF
--- a/dxr/plugins/clang/condense.py
+++ b/dxr/plugins/clang/condense.py
@@ -152,9 +152,8 @@ def process_impl(parents, children, props):
 def process_call(props):
     _, call_start = _process_loc(props['callloc'])
     _, (call_end_row, call_end_col) = _process_loc(props['calllocend'])
-    if call_end_col > call_start.col + 1:
-        # The span coming out of the compiler includes the left paren. Stop that.
-        call_end_col -= 1
+    # The span coming out of the compiler excludes the right paren.
+    call_end_col += 1
     props['span'] = Extent(call_start,
                            Position(row=call_end_row, col=call_end_col))
     props['calleeloc'] = _process_loc(props['calleeloc'])  # for Jump To

--- a/dxr/plugins/clang/needles.py
+++ b/dxr/plugins/clang/needles.py
@@ -193,7 +193,7 @@ def caller_needles(condensed, overriddens):
 
     """
     for needle in qualified_needles(condensed, 'call'):
-         yield needle
+        yield needle
     for call in condensed['call']:
         if call['calltype'] == 'virtual':
             for needle_from_base_method in needles_from_graph(

--- a/dxr/plugins/clang/tests/test_callers.py
+++ b/dxr/plugins/clang/tests/test_callers.py
@@ -11,7 +11,7 @@ class DirectCallTests(SingleFileTestCase):
         {
         }
 
-        void called_once()
+        void called_once(int a)
         {
         }
 
@@ -22,7 +22,7 @@ class DirectCallTests(SingleFileTestCase):
         void call_two()
         {
             called_twice();
-            called_once();
+            called_once(5);
         }
 
         int main()
@@ -36,15 +36,16 @@ class DirectCallTests(SingleFileTestCase):
         self.found_nothing('callers:orphan')
 
     def test_one_caller(self):
-        self.found_line_eq('callers:called_once', '<b>called_once</b>();')
+        """Make sure that we highlight the entire call, including argument the list."""
+        self.found_line_eq('callers:called_once', '<b>called_once(5)</b>;')
 
     def test_qualified(self):
-        self.found_line_eq('+callers:called_once()', '<b>called_once</b>();')
+        self.found_line_eq('+callers:called_once(int)', '<b>called_once(5)</b>;')
 
     def test_two_callers(self):
         self.found_lines_eq('callers:called_twice', [
-            ('<b>called_twice</b>();', 16),
-            ('<b>called_twice</b>();', 22)])
+            ('<b>called_twice()</b>;', 16),
+            ('<b>called_twice()</b>;', 22)])
 
 
 class IndirectCallTests(SingleFileTestCase):
@@ -87,7 +88,7 @@ class IndirectCallTests(SingleFileTestCase):
         C++ does not automatically downcast things from base to derived types.
 
         """
-        self.found_line_eq('+callers:Base::foo()', '<b>b.foo</b>();')
+        self.found_line_eq('+callers:Base::foo()', '<b>b.foo()</b>;')
 
     def test_virtual_derived(self):
         """Make sure derived-class method invocations are found on derived and
@@ -102,10 +103,10 @@ class IndirectCallTests(SingleFileTestCase):
         # b could be a Base or a Derived. We have to look to the whole-program
         # analysis pass to tell; C++ happily upcasts.
         self.found_lines_eq('+callers:Derived::foo()', [
-            ('<b>b.foo</b>();', 20),
-            ('<b>d.foo</b>();', 26)])
+            ('<b>b.foo()</b>;', 20),
+            ('<b>d.foo()</b>;', 26)])
 
     def test_non_virtual(self):
         """Non-virtual methods should always resolve according to their ptr types."""
-        self.found_line_eq('+callers:Base::bar()', '<b>b.bar</b>();')
-        self.found_line_eq('+callers:Derived::bar()', '<b>d.bar</b>();')
+        self.found_line_eq('+callers:Base::bar()', '<b>b.bar()</b>;')
+        self.found_line_eq('+callers:Derived::bar()', '<b>d.bar()</b>;')

--- a/dxr/plugins/clang/tests/test_cross_file_callers/code/extern.c
+++ b/dxr/plugins/clang/tests/test_cross_file_callers/code/extern.c
@@ -1,3 +1,3 @@
-int another_file() {
+int another_file(int b) {
   return 5;
 }

--- a/dxr/plugins/clang/tests/test_cross_file_callers/code/main.cpp
+++ b/dxr/plugins/clang/tests/test_cross_file_callers/code/main.cpp
@@ -1,6 +1,7 @@
 #include "extern.c"
 
 int main(int argc, char* argv[]) {
-  int a = another_file();
+  int blah = 3;
+  int a = another_file(blah);
   return a;
 }

--- a/dxr/plugins/clang/tests/test_cross_file_callers/test_cross_file_callers.py
+++ b/dxr/plugins/clang/tests/test_cross_file_callers/test_cross_file_callers.py
@@ -11,6 +11,6 @@ class CrossFileCallerTests(DxrInstanceTestCase):
     def test_callers(self):
         """Make sure a "caller" needle is laid down at the callsite, pointing
         to the called function."""
-        self.found_line_eq('callers:another_file',
-                           u'int a = <b>another_file</b>();',
-                           4)
+        self.found_line_eq('callers:another_file(int)',
+                           u'int a = <b>another_file(blah)</b>;',
+                           5)


### PR DESCRIPTION
For call expressions, Clang gives us the span of the entire foo(x,y,z)
expression, except the closing parenthesis. Subtracting one from the
span ends up cutting off the last two character of the argument list and
the closing parenthesis. We manually add one back to get the right span.