### PR TITLE
Bring back flag to allow post-test interaction.

### DIFF
--- a/docs/source/development.rst
+++ b/docs/source/development.rst
@@ -148,9 +148,9 @@ DXR supports two kinds of integration tests:
    stores the code as a Python string within a subclass of
    ``SingleFileTestCase``. At test time, it instantiates the file on
    disk in a temp folder, builds it, and makes assertions about it. If
-   the ``should_delete_instance`` class variable is truthy (the default), it
-   then deletes the instance. If you want to examine the instance manually for
-   troubleshooting, set this to ``False``.
+   the ``stop_for_interaction`` class variable is falsy (the default), it
+   then deletes the index. If you want to browse the instance manually for
+   troubleshooting, set this to ``True``.
 
 2. A heavier sort of test: a folder containing one or more source trees and a
    DXR config file. These are useful for tests that require a multi-file tree

--- a/dxr/plugins/clang/tests/test_macros.py
+++ b/dxr/plugins/clang/tests/test_macros.py
@@ -116,7 +116,6 @@ class MacroArgumentFieldReferenceTests(SingleFileTestCase):
 
 
 class MacroArgumentDeclareTests(SingleFileTestCase):
-    should_delete_instance = False
 
     source = """
         #define ID2(x) x

--- a/dxr/testing.py
+++ b/dxr/testing.py
@@ -222,11 +222,9 @@ class SingleFileTestCase(TestCase):
     then kick off the usual build process, deleting the instance afterward.
 
     """
-    # Set this to False in a subclass to keep the generated instance around and
-    # print its path so you can examine it:
-    # Note: this is currently broken because no on-disk artifiact is actually
-    # created; everything goes into Elasticsearch directly.
-    should_delete_instance = True
+    # Set this to True in a subclass to keep the generated instance around and
+    # host it on port 8000 so you can examine it:
+    stop_for_interaction = False
 
     # Override this in a subclass to change the filename used for the
     # source file.
@@ -267,11 +265,12 @@ class SingleFileTestCase(TestCase):
 
     @classmethod
     def teardown_class(cls):
-        if cls.should_delete_instance:
-            cls._delete_es_indices()
-            rmtree(cls._config_dir_path)
-        else:
-            print 'Not deleting instance in %s.' % cls._config_dir_path
+        if cls.stop_for_interaction:
+            print "Pausing for interaction at 0.0.0.0:8000..."
+            make_app(cls.config()).run(host='0.0.0.0', port=8000)
+            print "Cleaning up indices..."
+        cls._delete_es_indices()
+        rmtree(cls._config_dir_path)
 
     def _source_for_query(self, s):
         return (s.replace('<b>', '')

--- a/tests/test_build_failure.py
+++ b/tests/test_build_failure.py
@@ -6,7 +6,6 @@ from dxr.testing import SingleFileTestCase
 
 class BuildFailureTests(SingleFileTestCase):
     source = r"""A bunch of garbage"""
-    should_delete_instance = False
 
     @classmethod
     def setup_class(cls):


### PR DESCRIPTION
Revive the flag should_delete_instance as stop_for_interaction, which
allows hosting a single-file test case after running tests for
interaction via web browser. Update the docs appropriately.