### PR TITLE
Do not build any vcs_cache in make_app.

### DIFF
--- a/dxr/indexers.py
+++ b/dxr/indexers.py
@@ -165,7 +165,7 @@ class FileToSkim(PluginConfig):
 
     """
     def __init__(self, path, contents, plugin_name, tree, file_properties=None,
-                 line_properties=None, vcs_cache=None):
+                 line_properties=None):
         """
         :arg path: The conceptual path to the file, relative to the tree's
             source folder. Such a file might not exist on disk. This is useful
@@ -194,7 +194,6 @@ class FileToSkim(PluginConfig):
         self.tree = tree
         self.file_properties = file_properties or {}
         self.line_properties = line_properties  # TODO: not clear what the default here should be. repeat([])?
-        self.vcs_cache = vcs_cache
 
     def is_interesting(self):
         """Return whether it's worthwhile to examine this file.

--- a/dxr/plugins/core.py
+++ b/dxr/plugins/core.py
@@ -414,12 +414,14 @@ class TreeToIndex(dxr.indexers.TreeToIndex):
         return vars
 
     def file_to_index(self, path, contents):
-        return FileToIndex(path, contents, self.plugin_name, self.tree)
+        return FileToIndex(path, contents, self.plugin_name, self.tree,
+                           self.vcs_cache.vcs_for_path(path))
 
 
 class FileToIndex(dxr.indexers.FileToIndex):
-    def __init__(self, path, contents, plugin_name, tree):
+    def __init__(self, path, contents, plugin_name, tree, vcs):
         super(FileToIndex, self).__init__(path, contents, plugin_name, tree)
+        self.vcs = vcs
 
     def needles(self):
         """Fill out path (and path.trigrams)."""
@@ -441,18 +443,6 @@ class FileToIndex(dxr.indexers.FileToIndex):
             yield [('number', number),
                    ('content', text)]
 
-    def is_interesting(self):
-        """Core plugin puts all files in the search index."""
-        return True
-
-
-class FileToSkim(dxr.indexers.FileToSkim):
-    def __init__(self, path, contents, plugin_name, tree, file_properties,
-                 line_properties, vcs_cache):
-        super(FileToSkim, self).__init__(path, contents, plugin_name, tree,
-                                         file_properties, line_properties, vcs_cache)
-        self.vcs = self.vcs_cache.vcs_for_path(path)
-
     def links(self):
         if self.vcs:
             vcs_relative_path = relpath(self.absolute_path(), self.vcs.get_root_dir())
@@ -464,6 +454,10 @@ class FileToSkim(dxr.indexers.FileToSkim):
                                                        path=self.path))])
         else:
             yield 5, 'Untracked file', []
+
+    def is_interesting(self):
+        """Core plugin puts all files in the search index."""
+        return True
 
 
 # Match file name and line number: filename:n. Strip leading slashes because


### PR DESCRIPTION
Make get_contents of Vcs a classmethod, and when we request a specific
revision just try to invoke each vcs to get that contents.
This address bug [1175137](https://bugzilla.mozilla.org/show_bug.cgi?id=1175137).