### PR TITLE
Add direct search for exact matches of filenames or trailing path seg…

### DIFF
--- a/dxr/plugins/__init__.py
+++ b/dxr/plugins/__init__.py
@@ -7,7 +7,7 @@ from os.path import join
 from ordereddict import OrderedDict
 from pkg_resources import iter_entry_points
 
-from dxr.filters import Filter
+from dxr.filters import Filter, LINE
 from dxr.indexers import TreeToIndex
 
 
@@ -177,15 +177,18 @@ def direct_searchers_from_namespace(namespace):
             if hasattr(v, 'direct_search_priority') and isfunction(v)]
 
 
-def direct_search(priority):
+def direct_search(priority, domain=LINE):
     """Mark a function as being a direct search provider.
 
     :arg priority: A priority to attach to the function. Direct searchers are
         called in order of increasing priority.
+    :arg domain: LINE if this searcher searches for individual lines, FILE if
+        it searches for entire files
 
     """
     def decorator(searcher):
         searcher.direct_search_priority = priority
+        searcher.domain = domain
         return searcher
     return decorator
 

--- a/dxr/plugins/clang/tests/test_direct.py
+++ b/dxr/plugins/clang/tests/test_direct.py
@@ -45,8 +45,8 @@ class TypeAndMethodTests(SingleFileTestCase):
         self.direct_result_eq('MemberFunction::member_function(int)', 16)
 
     def test_qualified_function_name_multiple_matches(self):
-        """Multiple matches on fully qualified function name should return
-        None."""
+        """Multiple matches on fully qualified function name should not yield
+        a direct result."""
         self.is_not_direct_result('MemberFunction::member_FUNCTION(int)')
 
     def test_qualified_type_name_insensitive(self):
@@ -107,7 +107,8 @@ class MacroTypedefTests(SingleFileTestCase):
         self.direct_result_eq('MACRO_NAME', 3)
 
     def test_macro_name_multiple_matches(self):
-        """Multiple matches on a macro name should return None."""
+        """Multiple matches on a macro name should not yield a direct
+        result."""
         self.is_not_direct_result('macro_NAME')
 
     def test_typedef_name_insensitive(self):
@@ -125,5 +126,6 @@ class MacroTypedefTests(SingleFileTestCase):
         self.direct_result_eq('MyTypeDef', 14)
 
     def test_typedef_name_multiple_matches(self):
-        """Multiple matches on a typedef name should return None."""
+        """Multiple matches on a typedef name should not yield a direct
+        result."""
         self.is_not_direct_result('myTypeDef')

--- a/dxr/plugins/clang/tests/test_direct.py
+++ b/dxr/plugins/clang/tests/test_direct.py
@@ -47,7 +47,7 @@ class TypeAndMethodTests(SingleFileTestCase):
     def test_qualified_function_name_multiple_matches(self):
         """Multiple matches on fully qualified function name should return
         None."""
-        self.direct_result_eq('MemberFunction::member_FUNCTION(int)', None)
+        self.is_not_direct_result('MemberFunction::member_FUNCTION(int)')
 
     def test_qualified_type_name_insensitive(self):
         """A unique, case-insensitive match on fully qualified type name
@@ -66,7 +66,7 @@ class TypeAndMethodTests(SingleFileTestCase):
     def test_qualified_type_name_multiple_matches(self):
         """Multiple case-insensitive prefix matches on fully qualified type
         name should not yield a direct result."""
-        self.direct_result_eq('MemberFunction::InnerCLASS', None)
+        self.is_not_direct_result('MemberFunction::InnerCLASS')
 
     def test_type_sensitive(self):
         """If the query is an exact match for a class, we should jump there."""
@@ -108,7 +108,7 @@ class MacroTypedefTests(SingleFileTestCase):
 
     def test_macro_name_multiple_matches(self):
         """Multiple matches on a macro name should return None."""
-        self.direct_result_eq('macro_NAME', None)
+        self.is_not_direct_result('macro_NAME')
 
     def test_typedef_name_insensitive(self):
         """A unique, case-insensitive match on a typedef name should take you
@@ -126,4 +126,4 @@ class MacroTypedefTests(SingleFileTestCase):
 
     def test_typedef_name_multiple_matches(self):
         """Multiple matches on a typedef name should return None."""
-        self.direct_result_eq('myTypeDef', None)
+        self.is_not_direct_result('myTypeDef')

--- a/dxr/query.py
+++ b/dxr/query.py
@@ -157,7 +157,8 @@ class Query(object):
         """Return a single search result that is an exact match for the query.
 
         If there is such a result, return a tuple of (path from root of tree,
-        line number). Otherwise, return None.
+        line number). Line number may be None to indicate the entire file
+        rather than any specific line. If no result is found, return just None.
 
         """
         term = self.single_term()
@@ -179,11 +180,12 @@ class Query(object):
                         },
                         'size': 2
                     },
-                    doc_type=LINE)['hits']['hits']
+                    doc_type=searcher.domain)['hits']['hits']
                 if len(results) == 1:
                     result = results[0]['_source']
                     # Everything is stored as arrays in ES. Pull it all out:
-                    return result['path'][0], result['number'][0]
+                    return (result['path'][0],
+                            result['number'][0] if searcher.domain == LINE else None)
                 elif len(results) > 1:
                     return None
 

--- a/tests/test_direct.py
+++ b/tests/test_direct.py
@@ -1,7 +1,7 @@
 from dxr.testing import SingleFileTestCase, MINIMAL_MAIN
 
 
-class MemberFunctionTests(SingleFileTestCase):
+class DirectSearchTests(SingleFileTestCase):
     source = """
         // What happen
         // Somebody set up us the bomb
@@ -15,3 +15,8 @@ class MemberFunctionTests(SingleFileTestCase):
         """A file name and line number should take you directly to that file
         and line number."""
         self.direct_result_eq('main.cpp:6', 6)
+
+    def test_file(self):
+        """A file name should take you directly to that file, without
+        highlighting a particular line."""
+        self.direct_result_eq('main.cpp', None)


### PR DESCRIPTION
…ments. Fixes bug 1171313.

* Introduce a new type of direct searcher than can return LINE-domain results.
* Add a new filename direct searcher that uses it.
* Switch test harness to use url_for() rather than hard-coding URLs.
* Change direct_result_eq(..., None) to mean "returns a FILE-domain direct result" rather than "doesn't return a direct result".