### PR TITLE
Fix bug 1177191, pass devnull as the stderr stream for get_contents.

### DIFF
--- a/dxr/vcs.py
+++ b/dxr/vcs.py
@@ -45,11 +45,11 @@ class Vcs(object):
         return type(self).__name__
 
     @classmethod
-    def invoke_vcs(cls, args, cwd):
+    def invoke_vcs(cls, args, **kwargs):
         """Return the result of invoking the VCS command on the repository,
-        with the current working directory set to the root directory.
+        with extra kwargs passed along to the Popen constructor.
         """
-        return subprocess.check_output([cls.command] + args, cwd=cwd)
+        return subprocess.check_output([cls.command] + args, **kwargs)
 
     def is_tracked(self, path):
         """Does the repository track this file?"""
@@ -72,7 +72,7 @@ class Vcs(object):
         return NotImplemented
 
     @classmethod
-    def get_contents(cls, path, revision):
+    def get_contents(cls, path, revision, stderr=None):
         """Return contents of file at specified path at given revision, where path is an
         absolute path."""
         return NotImplemented
@@ -96,7 +96,7 @@ class Mercurial(Vcs):
         self.upstream = self._construct_upstream_url()
 
     def _construct_upstream_url(self):
-        upstream = urlparse.urlparse(self.invoke_vcs(['paths', 'default'], self.root).strip())
+        upstream = urlparse.urlparse(self.invoke_vcs(['paths', 'default'], cwd=self.root).strip())
         recomb = list(upstream)
         if upstream.scheme == 'ssh':
             recomb[0] = 'http'
@@ -149,9 +149,9 @@ class Mercurial(Vcs):
         return self.upstream + 'filelog/' + self.revision + '/' + path
 
     @classmethod
-    def get_contents(cls, path, revision):
+    def get_contents(cls, path, revision, stderr=None):
         head, tail = split(path)
-        return cls.invoke_vcs(['cat', '-r', revision, tail], head)
+        return cls.invoke_vcs(['cat', '-r', revision, tail], cwd=head, stderr=stderr)
 
 
 class Git(Vcs):
@@ -160,12 +160,12 @@ class Git(Vcs):
     def __init__(self, root):
         super(Git, self).__init__(root)
         self.tracked_files = set(line for line in
-                                 self.invoke_vcs(['ls-files'], self.root).splitlines())
-        self.revision = self.invoke_vcs(['rev-parse', 'HEAD'], self.root).strip()
+                                 self.invoke_vcs(['ls-files'], cwd=self.root).splitlines())
+        self.revision = self.invoke_vcs(['rev-parse', 'HEAD'], cwd=self.root).strip()
         self.upstream = self._construct_upstream_url()
 
     def _construct_upstream_url(self):
-        source_urls = self.invoke_vcs(['remote', '-v'], self.root).split('\n')
+        source_urls = self.invoke_vcs(['remote', '-v'], cwd=self.root).split('\n')
         for src_url in source_urls:
             name, repo, _ = src_url.split()
             # TODO: Why do we assume origin is upstream?
@@ -211,9 +211,9 @@ class Git(Vcs):
         return self.upstream + "/commits/" + self.revision + "/" + path
 
     @classmethod
-    def get_contents(cls, path, revision):
+    def get_contents(cls, path, revision, stderr=None):
         head, tail = split(path)
-        return cls.invoke_vcs(['show', revision + ':' + tail], head)
+        return cls.invoke_vcs(['show', revision + ':' + tail], cwd=head, stderr=stderr)
 
 
 class Perforce(Vcs):
@@ -318,11 +318,12 @@ def tree_to_repos(tree):
 def file_contents_at_rev(abspath, revision):
     """Attempt to return the contents of a file at a specific revision."""
 
-    for cls in [Mercurial, Git]:
-        try:
-            return cls.get_contents(abspath, revision)
-        except subprocess.CalledProcessError:
-            continue
+    with open(os.devnull, 'w') as devnull:
+        for cls in [Mercurial, Git]:
+            try:
+                return cls.get_contents(abspath, revision, stderr=devnull)
+            except subprocess.CalledProcessError:
+                continue
     return None
 
 


### PR DESCRIPTION
I am not sure whether the [404's](https://dxr.allizom.org/rust/rev/6065bed37be55427ed0ac888b863a85696b28f9b/mk/llvm.mk) on the Rust tree are related to this.
ref: https://bugzilla.mozilla.org/show_bug.cgi?id=1177191