### PR TITLE
Fix bug 1178882, extra line breaks on copy.

### DIFF
--- a/dxr/static/templates/text_file.html
+++ b/dxr/static/templates/text_file.html
@@ -57,7 +57,7 @@
 <pre>
 {% for line, annotations in lines -%}
 <code id="line-{{ loop.index }}" aria-labelledby="{{ loop.index }}">{{ line }}</code>
-{% endfor -%}
+{%- endfor -%}
 </pre>
         </td>
       </tr>


### PR DESCRIPTION
Avoid inserting extra whitespace in the page by asking Jinja to strip
the template block.

Thanks to @potch for help in fixing this!

Funnily enough, Chrome was working correctly before this fix, and now copying there is broken (no line breaks are kept on copy).