### PR TITLE
Let searches for qualified but argless functions work

### DIFF
--- a/dxr/filters.py
+++ b/dxr/filters.py
@@ -3,6 +3,8 @@
 from functools import wraps
 from funcy import identity
 
+from dxr.utils import is_in
+
 
 # Domain constants:
 FILE = 'file'
@@ -233,4 +235,4 @@ class QualifiedNameFilterBase(NameFilterBase):
         """
         return ((not self._term['qualified'] and
                  super(QualifiedNameFilterBase, self)._should_be_highlit(entity))
-                or entity['qualname'] == self._term['arg'])
+                or is_in(self._term['arg'], entity['qualname']))

--- a/dxr/indexers.py
+++ b/dxr/indexers.py
@@ -20,7 +20,7 @@ STRING_PROPERTY = {
 }
 
 
-# An unanlyzed string property that points to a value that can be exact- or
+# An unanalyzed string property that points to a value that can be exact- or
 # prefix-matched against and carries start/end bounds for highlighting. Has
 # both a name and a qualname.
 QUALIFIED_FILE_NEEDLE = {
@@ -35,6 +35,9 @@ QUALIFIED_LINE_NEEDLE = {
     'type': 'object',
     'properties': {
         'name': STRING_PROPERTY,
+        # The clang plugin stores both type-distinguished and merely scoped
+        # names here: both "Thing::foo(int num)" and "Thing::foo". Thus, the
+        # value may be either a string or a list:
         'qualname': STRING_PROPERTY,
         'start': {
             'type': 'integer',

--- a/dxr/plugins/clang/needles.py
+++ b/dxr/plugins/clang/needles.py
@@ -74,7 +74,8 @@ def ref_needles(condensed,
                 subkind=None,
                 include_qualname=True,
                 include_typeless_qualname=False):
-    """Return needles for references to a certain kind of thing.
+    """Return needles for references to a certain kind of language construct,
+    e.g. functions, variables, or namespaces.
 
     References are assumed to have names and qualnames.
 
@@ -84,7 +85,8 @@ def ref_needles(condensed,
     """
     subkind = subkind or name
     return needles(condensed,
-                   name, suffix='_ref',
+                   name,
+                   suffix='_ref',
                    kind='ref',
                    subkind=subkind,
                    include_qualname=include_qualname,

--- a/dxr/plugins/clang/needles.py
+++ b/dxr/plugins/clang/needles.py
@@ -8,18 +8,13 @@ from dxr.indexers import (iterable_per_line, with_start_and_end,
                           split_into_lines, Extent, Position)
 
 
+# TODO: Use.
 def sig_needles(condensed):
     """Return needles ((c-sig, type), span)."""
     return ((('c-sig', str(o['type'])), o['span']) for o in
             condensed['function'])
 
 
-# def needles(condensed, inherit, graph):
-#     """Return all C plugin needles."""
-#
-#     return chain(
-#         sig_needles(condensed),
-#     )
 
 
 def needles(condensed, name, suffix='', kind=None, subkind=None, keys=('name', 'qualname')):
@@ -45,11 +40,6 @@ def needles(condensed, name, suffix='', kind=None, subkind=None, keys=('name', '
              dict((k, entity[k]) for k in keys),
              entity['span'])
             for entity in condensed[kind] if matches_subkind(entity))
-
-
-def qualified_needles(condensed, name, kind=None):
-    """Return needles for a top-level kind of thing that has a name and qualname."""
-    return needles(condensed, name, kind=kind)
 
 
 def ref_needles(condensed, name, subkind=None, keys=('name', 'qualname')):
@@ -192,7 +182,7 @@ def caller_needles(condensed, overriddens):
     base ones.
 
     """
-    for needle in qualified_needles(condensed, 'call'):
+    for needle in needles(condensed, 'call'):
         yield needle
     for call in condensed['call']:
         if call['calltype'] == 'virtual':
@@ -219,24 +209,24 @@ def inheritance_needles(condensed, parents, children):
 
 def all_needles(condensed, overrides, overriddens, parents, children):
     return iterable_per_line(with_start_and_end(split_into_lines(chain(
-            qualified_needles(condensed, 'function'),
+            needles(condensed, 'function'),
             ref_needles(condensed, 'function'),
 
             # Classes:
-            qualified_needles(condensed, 'type'),
+            needles(condensed, 'type'),
             ref_needles(condensed, 'type'),
 
             # Typedefs:
-            qualified_needles(condensed, 'type', kind='typedef'),
+            needles(condensed, 'type', kind='typedef'),
             ref_needles(condensed, 'type', subkind='typedef'),
 
-            qualified_needles(condensed, 'var', kind='variable'),
+            needles(condensed, 'var', kind='variable'),
             ref_needles(condensed, 'var', subkind='variable'),
 
-            qualified_needles(condensed, 'namespace'),
+            needles(condensed, 'namespace'),
             ref_needles(condensed, 'namespace'),
 
-            qualified_needles(condensed, 'namespace_alias'),
+            needles(condensed, 'namespace_alias'),
             ref_needles(condensed, 'namespace_alias'),
 
             macro_needles(condensed),

--- a/dxr/plugins/clang/tests/test_direct.py
+++ b/dxr/plugins/clang/tests/test_direct.py
@@ -44,6 +44,24 @@ class TypeAndMethodTests(SingleFileTestCase):
         """
         self.direct_result_eq('MemberFunction::member_function(int)', 16)
 
+    def test_scoped_function_name_insensitive(self):
+        """A unique, case-insensitive match on a scoped function name should
+        take you directly to the result.
+
+        A "scoped" function name is a fully qualified one without types.
+
+        """
+        self.direct_result_eq('MemberFunction::unique_member_FUNCTION', 20)
+
+    def test_scoped_function_name_sensitive(self):
+        """A unique, case-sensitive match on scoped function name should take
+        you directly to the result.
+
+        This should have precedence over any case-insensitive match.
+
+        """
+        self.direct_result_eq('MemberFunction::member_function', 16)
+
     def test_qualified_function_name_multiple_matches(self):
         """Multiple matches on fully qualified function name should not yield
         a direct result."""

--- a/dxr/plugins/clang/tests/test_functions.py
+++ b/dxr/plugins/clang/tests/test_functions.py
@@ -21,7 +21,7 @@ class DefinitionTests(SingleFileTestCase):
         }
 
         namespace Space {
-          void foo() {}
+          void foo(int a) {}
         }
         """
 
@@ -44,7 +44,13 @@ class DefinitionTests(SingleFileTestCase):
     def test_qualnames_unqualified(self):
         """Qualnames should be found when searching unqualified as well."""
         self.found_line_eq(
-            'function:Space::foo()', 'void <b>foo</b>() {}')
+            'function:Space::foo(int)', 'void <b>foo</b>(int a) {}')
+
+    def test_scoped(self):
+        """Functions with explicit scopes should be found even when types are
+        left off."""
+        self.found_line_eq(
+            'function:Space::foo', 'void <b>foo</b>(int a) {}')
 
     def test_qualnames_caseless(self):
         """Case-insensitive qualified searches should remain case-sensitive.
@@ -53,7 +59,7 @@ class DefinitionTests(SingleFileTestCase):
         this behavior and didn't expressly condemn it.
 
         """
-        self.found_nothing('+function:SPACE::FOO()', is_case_sensitive=False)
+        self.found_nothing('+function:SPACE::FOO(int)', is_case_sensitive=False)
 
 
 class TemplateClassMemberReferenceTests(SingleFileTestCase):

--- a/dxr/utils.py
+++ b/dxr/utils.py
@@ -236,3 +236,13 @@ def rmtree_if_exists(folder):
     except OSError as exc:
         if exc.errno != ENOENT:
             raise
+
+
+def is_in(needle, haystack):
+    """Compare needle against haystack or a list of haystacks.
+
+    If haystack is a list, return whether needle is in haystack. Otherwise,
+    return whether needle == haystack.
+
+    """
+    return (needle in haystack) if isinstance(haystack, list) else needle == haystack


### PR DESCRIPTION
Now we can search for Scoped::function rather than needing to say Scoped::function(int, char). Fix https://bugzilla.mozilla.org/show_bug.cgi?id=1171242