### PR TITLE
Restore same-symbol highlighting

### DIFF
--- a/dxr/app.py
+++ b/dxr/app.py
@@ -1,7 +1,7 @@
 from cStringIO import StringIO
 from datetime import datetime
 from functools import partial
-from itertools import chain, izip
+from itertools import chain, imap, izip
 from logging import StreamHandler
 import os
 from os import chdir
@@ -23,8 +23,9 @@ from dxr.es import (filtered_query, frozen_config, frozen_configs,
                     es_alias_or_not_found)
 from dxr.exceptions import BadTerm
 from dxr.filters import FILE, LINE
-from dxr.lines import (html_line, tags_per_line, triples_from_es_refs,
-                       triples_from_es_regions, finished_tags)
+from dxr.indexers import Ref
+from dxr.lines import (html_line, tags_per_line, triples_from_es_regionses,
+                       finished_tags)
 from dxr.mime import icon, is_image, is_text
 from dxr.plugins import plugins_named, all_plugins
 from dxr.query import Query, filter_menu_items
@@ -389,8 +390,10 @@ def _browse_file(tree, path, line_docs, file_doc, config, date=None, contents=No
                     if plugin in config.trees[tree].enabled_plugins
                     and plugin.file_to_skim]
         skim_links, refses, regionses, annotationses = skim_file(skimmers, len(line_docs))
-        index_refs = triples_from_es_refs(doc.get('refs', []) for doc in line_docs)
-        index_regions = triples_from_es_regions(doc.get('regions', []) for doc in line_docs)
+        index_refs = imap(Ref.es_to_triple,
+                          chain.from_iterable(doc.get('refs', [])
+                                              for doc in line_docs))
+        index_regions = triples_from_es_regionses(doc.get('regions', []) for doc in line_docs)
         tags = finished_tags(lines,
                              chain(chain.from_iterable(refses), index_refs),
                              chain(chain.from_iterable(regionses), index_regions))

--- a/dxr/app.py
+++ b/dxr/app.py
@@ -23,9 +23,8 @@ from dxr.es import (filtered_query, frozen_config, frozen_configs,
                     es_alias_or_not_found)
 from dxr.exceptions import BadTerm
 from dxr.filters import FILE, LINE
-from dxr.indexers import Ref
-from dxr.lines import (html_line, tags_per_line, triples_from_es_regionses,
-                       finished_tags)
+from dxr.indexers import Ref, Region
+from dxr.lines import html_line, tags_per_line, finished_tags
 from dxr.mime import icon, is_image, is_text
 from dxr.plugins import plugins_named, all_plugins
 from dxr.query import Query, filter_menu_items
@@ -393,7 +392,9 @@ def _browse_file(tree, path, line_docs, file_doc, config, date=None, contents=No
         index_refs = imap(Ref.es_to_triple,
                           chain.from_iterable(doc.get('refs', [])
                                               for doc in line_docs))
-        index_regions = triples_from_es_regionses(doc.get('regions', []) for doc in line_docs)
+        index_regions = imap(Region.es_to_triple,
+                             chain.from_iterable(doc.get('regions', [])
+                                                 for doc in line_docs))
         tags = finished_tags(lines,
                              chain(chain.from_iterable(refses), index_refs),
                              chain(chain.from_iterable(regionses), index_regions))

--- a/dxr/indexers.py
+++ b/dxr/indexers.py
@@ -225,7 +225,7 @@ class FileToSkim(PluginConfig):
 
         Yield an ordered list of extents and menu items::
 
-            (start, end, (menu, hover))
+            (start, end, (menu, hover, qualname))
 
         ``start`` and ``end`` are the bounds of a slice of a Unicode string
         holding the contents of the file. (``refs()`` will not be called for

--- a/dxr/indexers.py
+++ b/dxr/indexers.py
@@ -225,23 +225,11 @@ class FileToSkim(PluginConfig):
 
         Yield an ordered list of extents and menu items::
 
-            (start, end, (menu, hover, qualname))
+            (start, end, Ref)
 
         ``start`` and ``end`` are the bounds of a slice of a Unicode string
         holding the contents of the file. (``refs()`` will not be called for
         binary files.)
-
-        ``hover`` is the contents of the <a> tag's title attribute. (The first
-        one wins.)
-
-        ``menu`` is a list of mappings, each representing an item of the
-        context menu::
-
-            [{'html': 'description',
-              'title': 'longer description',
-              'href': 'URL',
-              'icon': 'extensionless name of a PNG from the icons folder'},
-             ...]
 
         """
         return []
@@ -404,6 +392,44 @@ class FileToIndex(FileToSkim):
 
         """
         return []
+
+
+class Ref(object):
+    """A context menu and other metadata attached to a run of text"""
+
+    sort_order = 1
+    __slots__ = ['menu', 'hover', 'qualname_hash']
+
+    def __init__(self, menu, hover=None, qualname=None, qualname_hash=None):
+        """Construct.
+
+        :arg hover: the contents of the <a> tag's title attribute. (The first
+            one wins.)
+        :arg menu: a list of mappings, each representing an item of the
+            context menu::
+
+                [{'html': 'description',
+                  'title': 'longer description',
+                  'href': 'URL',
+                  'icon': 'extensionless name of a PNG from the icons folder'},
+                 ...]
+        :arg qualname: The unique name of the symbol surrounded by this ref,
+            for highlighting
+        :arg qualname_hash: The hashed version of ``qualname``, which you can
+            pass instead of ``qualname`` if you like
+
+        """
+        self.menu = menu
+        self.hover = hover
+        self.qualname_hash = hash(qualname) if qualname else qualname_hash
+
+    def es(self):
+        ret = {'menuitems': self.menu}
+        if self.hover:
+            ret['hover'] = self.hover
+        if self.qualname_hash:
+            ret['qualname_hash'] = self.qualname_hash
+        return ret
 
 
 # Conveniences:

--- a/dxr/indexers.py
+++ b/dxr/indexers.py
@@ -1,6 +1,8 @@
 """Base classes and convenience functions for writing indexers and skimmers"""
 
+import cgi
 from collections import namedtuple
+import json
 from operator import itemgetter
 from os.path import join
 from warnings import warn
@@ -238,16 +240,14 @@ class FileToSkim(PluginConfig):
         """Yield instructions for syntax coloring and other inline formatting
         of code.
 
-        Yield an ordered list of extents and CSS classes::
+        Yield an ordered list of extents and CSS classes (encapsulated in
+        Regions)::
 
-            (start, end, class)
+            (start, end, Region)
 
         ``start`` and ``end`` are the bounds of a slice of a Unicode string
         holding the contents of the file. (``regions()`` will not be called
         for binary files.)
-
-        We'll probably store them in elasticsearch as a list of explicit
-        objects, like {start: 5, end: 18, class: k}.
 
         """
         return []
@@ -434,7 +434,7 @@ class Ref(object):
 
     @classmethod
     def es_to_triple(cls, es_ref):
-        """Convert ES-dwelling refs representation to a (start, end, Ref)
+        """Convert ES-dwelling ref representation to a (start, end, Ref)
         triple."""
         payload = es_ref['payload']
         return (es_ref['start'],
@@ -442,6 +442,51 @@ class Ref(object):
                 cls(payload['menuitems'],
                     hover=payload.get('hover'),
                     qualname_hash=payload.get('qualname_hash')))
+
+    def opener(self):
+        menu = cgi.escape(json.dumps(self.menu), True)
+        if self.hover:
+            title = ' title="' + cgi.escape(self.hover, True) + '"'
+        else:
+            title = ''
+        if self.qualname_hash is not None:
+            cls = ' class="tok%i"' % self.qualname_hash
+        else:
+            cls = ''
+        return u'<a data-menu="%s"%s%s>' % (menu, title, cls)
+
+    def closer(self):
+        return u'</a>'
+
+
+class Region(object):
+    """A <span> tag with a CSS class, wrapped around a run of text"""
+
+    sort_order = 2  # Sort Regions innermost, as it doesn't matter if we split
+                    # them.
+    __slots__ = ['css_class']
+
+    def __init__(self, css_class):
+        self.css_class = css_class
+
+    def es(self):
+        return self.css_class
+
+    @classmethod
+    def es_to_triple(cls, es_region):
+        """Convert ES-dwelling region representation to a (start, end, Region)
+        triple."""
+        return es_region['start'], es_region['end'], cls(es_region['payload'])
+
+    def opener(self):
+        return u'<span class="%s">' % cgi.escape(self.css_class, True)
+
+    def closer(self):
+        return u'</span>'
+
+    def __repr__(self):
+        """Return a nice representation for debugging."""
+        return 'Region("%s")' % self.css_class
 
 
 # Conveniences:

--- a/dxr/indexers.py
+++ b/dxr/indexers.py
@@ -413,10 +413,11 @@ class Ref(object):
                   'href': 'URL',
                   'icon': 'extensionless name of a PNG from the icons folder'},
                  ...]
-        :arg qualname: The unique name of the symbol surrounded by this ref,
-            for highlighting
+        :arg qualname: A unique identifier for the symbol surrounded by this
+            ref, for highlighting
         :arg qualname_hash: The hashed version of ``qualname``, which you can
-            pass instead of ``qualname`` if you like
+            pass instead of ``qualname`` if you have access to the
+            already-hashed version
 
         """
         self.menu = menu
@@ -427,9 +428,20 @@ class Ref(object):
         ret = {'menuitems': self.menu}
         if self.hover:
             ret['hover'] = self.hover
-        if self.qualname_hash:
+        if self.qualname_hash is not None:  # could be 0
             ret['qualname_hash'] = self.qualname_hash
         return ret
+
+    @classmethod
+    def es_to_triple(cls, es_ref):
+        """Convert ES-dwelling refs representation to a (start, end, Ref)
+        triple."""
+        payload = es_ref['payload']
+        return (es_ref['start'],
+                es_ref['end'],
+                cls(payload['menuitems'],
+                    hover=payload.get('hover'),
+                    qualname_hash=payload.get('qualname_hash')))
 
 
 # Conveniences:

--- a/dxr/lines.py
+++ b/dxr/lines.py
@@ -380,20 +380,7 @@ def es_lines(tags):
     # yield here to catch remnants.
 
 
-def triples_from_es_refs(es_refs):
-    """Convert list of lists of es refs per lines to (start, end, payload) triples.
-
-    """
-    for item in chain.from_iterable(es_refs):
-        payload = item['payload']
-        yield (item['start'],
-               item['end'],
-               Ref(payload['menuitems'],
-                   hover=payload.get('hover'),
-                   qualname_hash=payload.get('qualname_hash')))
-
-
-def triples_from_es_regions(es_regions):
+def triples_from_es_regionses(es_regions):
     """Convert list of lists es regions to (start, end, payload) triples.
 
     """

--- a/dxr/plugins/buglink/__init__.py
+++ b/dxr/plugins/buglink/__init__.py
@@ -16,7 +16,7 @@ class FileToIndex(dxr.indexers.FileToIndex):
                 'html': cgi.escape("Bug %s" % bug),
                 'title': "Find this bug in %s" % self.plugin_config.name,
                 'href': self.plugin_config.url % bug,
-                'icon': 'buglink'}], None)
+                'icon': 'buglink'}], None, None)
 
 
 plugin = Plugin(

--- a/dxr/plugins/buglink/__init__.py
+++ b/dxr/plugins/buglink/__init__.py
@@ -5,6 +5,7 @@ import re
 from schema import Optional, Use
 
 import dxr.indexers
+from dxr.indexers import Ref
 from dxr.plugins import Plugin, AdHocTreeToIndex
 
 
@@ -12,11 +13,11 @@ class FileToIndex(dxr.indexers.FileToIndex):
     def refs(self):
         for m in self.plugin_config.regex.finditer(self.contents):
             bug = m.group(1)
-            yield m.start(0), m.end(0), ([{
+            yield m.start(0), m.end(0), Ref([{
                 'html': cgi.escape("Bug %s" % bug),
                 'title': "Find this bug in %s" % self.plugin_config.name,
                 'href': self.plugin_config.url % bug,
-                'icon': 'buglink'}], None, None)
+                'icon': 'buglink'}])
 
 
 plugin = Plugin(

--- a/dxr/plugins/clang/indexers.py
+++ b/dxr/plugins/clang/indexers.py
@@ -149,7 +149,7 @@ class FileToIndex(FileToIndexBase):
 
                 yield (self.char_offset(start.row, start.col),
                        self.char_offset(end.row, end.col),
-                       (menu, tooltip(prop)))
+                       (menu, tooltip(prop), prop.get('qualname')))
 
     def links(self):
         """Yield a section for each class, type, enum, etc., as well as one

--- a/dxr/plugins/clang/indexers.py
+++ b/dxr/plugins/clang/indexers.py
@@ -11,7 +11,7 @@ from funcy import (merge, imap, group_by, is_mapping, repeat,
 from dxr.filters import LINE
 from dxr.indexers import (FileToIndex as FileToIndexBase,
                           TreeToIndex as TreeToIndexBase,
-                          QUALIFIED_LINE_NEEDLE, unsparsify, FuncSig)
+                          QUALIFIED_LINE_NEEDLE, unsparsify, FuncSig, Ref)
 from dxr.plugins.clang.condense import condense_file, condense_global
 from dxr.plugins.clang.menus import (function_menu, variable_menu, type_menu,
                                      namespace_menu, namespace_alias_menu,
@@ -149,7 +149,7 @@ class FileToIndex(FileToIndexBase):
 
                 yield (self.char_offset(start.row, start.col),
                        self.char_offset(end.row, end.col),
-                       (menu, tooltip(prop), prop.get('qualname')))
+                       Ref(menu, hover=tooltip(prop), qualname=prop.get('qualname')))
 
     def links(self):
         """Yield a section for each class, type, enum, etc., as well as one

--- a/dxr/plugins/core.py
+++ b/dxr/plugins/core.py
@@ -171,6 +171,12 @@ mappings = {
                             }
                         },
                         'hover': UNINDEXED_STRING,
+                        # Hash of qualname of the symbol we're hanging the
+                        # menu off of, if it is a symbol and we can come up
+                        # with a qualname. This powers the highlighting of
+                        # other occurrences of the symbol when you pull up the
+                        # context menu.
+                        'qualname_hash': UNINDEXED_INT
                     }
                 }
             },

--- a/dxr/plugins/pygmentize.py
+++ b/dxr/plugins/pygmentize.py
@@ -6,6 +6,7 @@ from pygments.token import Token, Comment
 from pygments.util import ClassNotFound
 
 import dxr.indexers
+from dxr.indexers import Region
 
 
 token_classes = {Token.Comment.Preproc: 'p'}
@@ -86,7 +87,7 @@ def _regions_for_contents(lexer, contents):
     for index, token, text in lexer.get_tokens_unprocessed(contents):
         cls = token_classes.get(token)
         if cls:
-            yield index, index + len(text), cls
+            yield index, index + len(text), Region(cls)
 
 
 class FileToIndex(dxr.indexers.FileToIndex):

--- a/dxr/plugins/python/indexers.py
+++ b/dxr/plugins/python/indexers.py
@@ -9,7 +9,7 @@ from dxr.indexers import (Extent, FileToIndex as FileToIndexBase,
                           iterable_per_line, Position, split_into_lines,
                           TreeToIndex as TreeToIndexBase,
                           QUALIFIED_FILE_NEEDLE, QUALIFIED_LINE_NEEDLE,
-                          with_start_and_end)
+                          with_start_and_end, Ref)
 from dxr.plugins.python.analysis import TreeAnalysis
 from dxr.plugins.python.menus import class_menu
 from dxr.plugins.python.utils import (ClassFunctionVisitorMixin,
@@ -169,7 +169,7 @@ class IndexingNodeVisitor(ast.NodeVisitor, ClassFunctionVisitorMixin):
         self.refs.append((
             self.file_to_index.char_offset(*start),
             self.file_to_index.char_offset(*end),
-            (menu, None, None),
+            Ref(menu),
         ))
 
 

--- a/dxr/plugins/python/indexers.py
+++ b/dxr/plugins/python/indexers.py
@@ -169,7 +169,7 @@ class IndexingNodeVisitor(ast.NodeVisitor, ClassFunctionVisitorMixin):
         self.refs.append((
             self.file_to_index.char_offset(*start),
             self.file_to_index.char_offset(*end),
-            (menu, None),
+            (menu, None, None),
         ))
 
 

--- a/dxr/plugins/rust/menu.py
+++ b/dxr/plugins/rust/menu.py
@@ -127,7 +127,7 @@ def function_menu(tree, datum, tree_config):
                 'icon':   'method'
             })
 
-    return (menu, None)
+    return menu, None, None
 
 
 def function_ref_menu(tree, datum, tree_config):
@@ -155,7 +155,7 @@ def function_ref_menu(tree, datum, tree_config):
         name = fn_decl['qualname']
 
     # FIXME(#12) should have type, not name for title
-    return (menu, name)
+    return menu, name, None
 
 
 def variable_menu_generic(tree, datum, tree_config):
@@ -171,7 +171,7 @@ def variable_menu(tree, datum, tree_config):
         typ = datum['type']
     else:
         print "no type for variable", datum['qualname']
-    return (menu, truncate_value("", typ))
+    return menu, truncate_value("", typ), None
 
 
 def variable_ref_menu(tree, datum, tree_config):
@@ -184,7 +184,7 @@ def variable_ref_menu(tree, datum, tree_config):
             typ = var['type']
         else:
             print "no type for variable ref", var['qualname']
-        return (menu, truncate_value(typ, var['value']))
+        return menu, truncate_value(typ, var['value']), None
 
     # TODO what is the culprit here?
     #print "variable ref missing def"
@@ -219,7 +219,7 @@ def type_menu_generic(tree, datum, tree_config):
     return menu
 
 def type_menu(tree, datum, tree_config):
-    return (type_menu_generic(tree, datum, tree_config), None)
+    return type_menu_generic(tree, datum, tree_config), None, None
 
 def type_ref_menu(tree, datum, tree_config):
     if datum['refid'] and datum['refid'] in tree.data.types:
@@ -231,7 +231,7 @@ def type_ref_menu(tree, datum, tree_config):
             title = typ['value']
         else:
             print "no value for", typ['kind'], typ['qualname']
-        return (menu, truncate_value("", title))
+        return menu, truncate_value("", title), None
 
     return None
 
@@ -251,7 +251,7 @@ def module_menu(tree, datum, tree_config):
     menu = module_menu_generic(tree, datum, tree_config)
     if datum['def_file'] != datum['file_name']:
         add_jump_definition_to_line(tree, tree_config, menu, datum['def_file'], 1, "Jump to module defintion")
-    return (menu, None)
+    return menu, None, None
 
 
 def module_ref_menu(tree, datum, tree_config):
@@ -293,7 +293,7 @@ def module_ref_menu(tree, datum, tree_config):
                 else:
                     add_jump_definition_to_line(tree, tree_config, menu, mod['def_file'], 1, "Jump to module defintion")
                     add_jump_definition(tree, tree_config, menu, mod, "Jump to module declaration")
-            return (menu, None)
+            return menu, None, None
 
         # types masquerading as modules
         if datum['refid'] in tree.data.types:
@@ -305,7 +305,7 @@ def module_ref_menu(tree, datum, tree_config):
                 title = typ['value']
             else:
                 print "no value for", typ['kind'], typ['qualname']
-            return (menu, truncate_value("", title))
+            return menu, truncate_value("", title), None
 
     return None
 
@@ -324,7 +324,7 @@ def module_alias_menu(tree, datum, tree_config):
             menu = []
             add_find_references(tree_config, menu, datum['qualname'], "module-alias-ref", "alias")
             add_jump_definition_to_line(tree, tree_config, menu, mod['def_file'], 1, "Jump to module defintion")
-            return (menu, None)
+            return menu, None, None
 
     # 'module' aliases to types
     if datum['refid'] and datum['refid'] in tree.data.types:
@@ -333,7 +333,7 @@ def module_alias_menu(tree, datum, tree_config):
             menu = []
             add_find_references(tree_config, menu, datum['qualname'], "type-ref", "alias")
             add_jump_definition(tree, tree_config, menu, typ, "Jump to type declaration")
-            return (menu, None)
+            return menu, None, None
 
     # 'module' aliases to variables
     if datum['refid'] and datum['refid'] in tree.data.variables:
@@ -342,7 +342,7 @@ def module_alias_menu(tree, datum, tree_config):
             menu = []
             add_find_references(tree_config, menu, datum['qualname'], "var-ref", "alias")
             add_jump_definition(tree, tree_config, menu, var, "Jump to variable declaration")
-            return (menu, None)
+            return menu, None, None
 
     # 'module' aliases to functions
     if datum['refid'] and datum['refid'] in tree.data.functions:
@@ -351,7 +351,7 @@ def module_alias_menu(tree, datum, tree_config):
             menu = []
             add_find_references(tree_config, menu, datum['qualname'], "function-ref", "alias")
             add_jump_definition(tree, tree_config, menu, fn, "Jump to function declaration")
-            return (menu, None)
+            return menu, None, None
 
     # extern crates to known local crates
     if 'location' in datum and datum['location'] and datum['location'] in tree.crates_by_name:
@@ -359,7 +359,7 @@ def module_alias_menu(tree, datum, tree_config):
         menu = []
         add_find_references(tree_config, menu, datum['qualname'], "module-alias-ref", "alias")
         add_jump_definition_to_line(tree, tree_config, menu, crate['file_name'], 1, "Jump to crate")
-        return (menu, None)
+        return menu, None, None
 
     # extern crates to standard library crates
     if 'location' in datum and datum['location'] and datum['location'] in tree.locations:
@@ -367,7 +367,7 @@ def module_alias_menu(tree, datum, tree_config):
         menu = []
         add_find_references(tree_config, menu, datum['qualname'], "module-alias-ref", "alias")
         std_lib_links(tree_config, menu, urls)
-        return (menu, None)
+        return menu, None, None
 
     # other references to standard library items
     if datum['refid'] in tree.data.unknowns:
@@ -376,14 +376,12 @@ def module_alias_menu(tree, datum, tree_config):
         menu = []
         add_find_references(tree_config, menu, datum['qualname'], "module-alias-ref", "alias")
         std_lib_links(tree_config, menu, urls)
-        return (menu, None)
+        return menu, None, None
 
     # extern mods to unknown local crates
     menu = []
     add_find_references(tree_config, menu, datum['qualname'], "module-alias-ref", "alias")
-    return (menu, None)
-
-    return None
+    return menu, None, None
 
 
 def unknown_ref_menu(tree, datum, tree_config):
@@ -394,7 +392,7 @@ def unknown_ref_menu(tree, datum, tree_config):
         if unknown['crate'] in tree.locations:
             urls = tree.locations[unknown['crate']]
             std_lib_links(tree_config, menu, urls)
-        return (menu, None)
+        return menu, None, None
 
     print "unknown unknown!"
 

--- a/dxr/plugins/urllink.py
+++ b/dxr/plugins/urllink.py
@@ -15,4 +15,4 @@ class FileToIndex(dxr.indexers.FileToIndex):
                 'html': 'Follow link',
                 'title': 'Visit %s' % url,
                 'href': url,
-                'icon': 'external_link'}], None)
+                'icon': 'external_link'}], None, None)

--- a/dxr/plugins/urllink.py
+++ b/dxr/plugins/urllink.py
@@ -1,6 +1,7 @@
 import re
 
 import dxr.indexers
+from dxr.indexers import Ref
 
 
 # From http://stackoverflow.com/a/1547940
@@ -11,8 +12,8 @@ class FileToIndex(dxr.indexers.FileToIndex):
     def refs(self):
         for m in url_re.finditer(self.contents):
             url = m.group(0)
-            yield m.start(0), m.end(0), ([{
+            yield m.start(0), m.end(0), Ref([{
                 'html': 'Follow link',
                 'title': 'Visit %s' % url,
                 'href': url,
-                'icon': 'external_link'}], None, None)
+                'icon': 'external_link'}])

--- a/dxr/static/js/context_menu.js
+++ b/dxr/static/js/context_menu.js
@@ -18,8 +18,8 @@ $(function() {
         // First remove all highlighting
         fileContainer.find('mark a').unwrap();
 
-        // Only add highlights if the currentNode is not undefined or null and,
-        // is an anchor link as synbols will always be links.
+        // Only add highlights if the currentNode is not undefined or null and
+        // is an anchor link, as symbols will always be links.
         if (currentNode && currentNode[0].tagName === 'A') {
             fileContainer.find('.' + currentNode.attr('class')).wrap('<mark />');
         }

--- a/tests/test_lines.py
+++ b/tests/test_lines.py
@@ -8,11 +8,12 @@ from warnings import catch_warnings
 from more_itertools import first
 from nose.tools import eq_
 
-from dxr.utils import cumulative_sum
+from dxr.indexers import Ref
 from dxr.lines import (line_boundaries, remove_overlapping_refs, Region, LINE,
                        Ref, balanced_tags, finished_tags, tag_boundaries,
                        html_line, nesting_order, balanced_tags_with_empties,
                        es_lines, tags_per_line)
+from dxr.utils import cumulative_sum
 
 
 def test_line_boundaries():
@@ -67,9 +68,11 @@ def spaced_tags(tags):
     representations."""
     segments = []
     for point, is_start, payload in tags:
-        segments.append(' ' * point + ('<%s%s>' % ('' if is_start else '/',
-                                                   'L' if payload is LINE else
-                                                        payload.payload)))
+        segments.append(' ' * point + ('<%s%s>' %
+            ('' if is_start else '/',
+            'L' if payload is LINE else
+                 (payload.payload if isinstance(payload, Region)
+                  else payload.menu))))
     return '\n'.join(segments)
 
 
@@ -259,12 +262,12 @@ class IntegrationTests(TestCase):
 
     def test_split_anchor_avoidance(self):
         """Don't split anchor tags when we can avoid it."""
-        eq_(text_to_html_lines('this that', [(0, 9, ({}, '', None))], [(0, 4, 'k')]),
+        eq_(text_to_html_lines('this that', [(0, 9, Ref({}))], [(0, 4, 'k')]),
             [u'<a data-menu="{}"><span class="k">this</span> that</a>'])
 
     def test_split_anchor_across_lines(self):
         """Support unavoidable splits of an anchor across lines."""
-        eq_(text_to_html_lines('this\nthat', refs=[(0, 9, ({}, '', None))]),
+        eq_(text_to_html_lines('this\nthat', refs=[(0, 9, Ref({}))]),
             [u'<a data-menu="{}">this</a>', u'<a data-menu="{}">that</a>'])
 
     def test_horrors(self):

--- a/tests/test_lines.py
+++ b/tests/test_lines.py
@@ -71,7 +71,7 @@ def spaced_tags(tags):
         segments.append(' ' * point + ('<%s%s>' %
             ('' if is_start else '/',
             'L' if payload is LINE else
-                 (payload.payload if isinstance(payload, Region)
+                 (payload.css_class if isinstance(payload, Region)
                   else payload.menu))))
     return '\n'.join(segments)
 
@@ -222,7 +222,7 @@ class BalancedTagTests(TestCase):
 
 def test_tag_boundaries():
     """Sanity-check ``tag_boundaries()``."""
-    eq_(str(list(tag_boundaries([], [(0, 3, 'a'), (3, 5, 'b')]))),
+    eq_(str(list(tag_boundaries([(0, 3, Region('a')), (3, 5, Region('b'))]))),
         '[(0, True, Region("a")), (3, False, Region("a")), '
         '(3, True, Region("b")), (5, False, Region("b"))]')
 
@@ -257,12 +257,13 @@ class IntegrationTests(TestCase):
     def test_simple(self):
         """Sanity-check the combination of finished_tags, es_lines and
         html_line, which constitutes an end-to-end run of the pipeline."""
-        eq_(text_to_html_lines('hello', regions=[(0, 3, 'a'), (3, 5, 'b')]),
+        eq_(text_to_html_lines('hello', regions=[(0, 3, Region('a')),
+                                                 (3, 5, Region('b'))]),
             [u'<span class="a">hel</span><span class="b">lo</span>'])
 
     def test_split_anchor_avoidance(self):
         """Don't split anchor tags when we can avoid it."""
-        eq_(text_to_html_lines('this that', [(0, 9, Ref({}))], [(0, 4, 'k')]),
+        eq_(text_to_html_lines('this that', [(0, 9, Ref({}))], [(0, 4, Region('k'))]),
             [u'<a data-menu="{}"><span class="k">this</span> that</a>'])
 
     def test_split_anchor_across_lines(self):
@@ -277,10 +278,10 @@ class IntegrationTests(TestCase):
         # span of text is within the right spans. We don't care what order the
         # span tags are in.
         eq_(text_to_html_lines('this&that',
-                               regions=[(0, 9, 'a'), (1, 8, 'b'),
-                                        (4, 7, 'c'), (3, 4, 'd'),
-                                        (3, 5, 'e'), (0, 4, 'm'),
-                                        (5, 9, 'n')]),
+                               regions=[(0, 9, Region('a')), (1, 8, Region('b')),
+                                        (4, 7, Region('c')), (3, 4, Region('d')),
+                                        (3, 5, Region('e')), (0, 4, Region('m')),
+                                        (5, 9, Region('n'))]),
             [u'<span class="a"><span class="m">t<span class="b">hi<span class="d"><span class="e">s</span></span></span></span><span class="b"><span class="e"><span class="c">&amp;</span></span><span class="c"><span class="n">th</span></span><span class="n">a</span></span><span class="n">t</span></span>'])
 
     def test_empty_tag_boundaries(self):
@@ -291,4 +292,4 @@ class IntegrationTests(TestCase):
 
         """
         text_to_html_lines('hello!',
-                           regions=[(3, 3, 'a'), (3, 5, 'b')])
+                           regions=[(3, 3, Region('a')), (3, 5, Region('b'))])

--- a/tests/test_lines.py
+++ b/tests/test_lines.py
@@ -259,12 +259,12 @@ class IntegrationTests(TestCase):
 
     def test_split_anchor_avoidance(self):
         """Don't split anchor tags when we can avoid it."""
-        eq_(text_to_html_lines('this that', [(0, 9, ({}, ''))], [(0, 4, 'k')]),
+        eq_(text_to_html_lines('this that', [(0, 9, ({}, '', None))], [(0, 4, 'k')]),
             [u'<a data-menu="{}"><span class="k">this</span> that</a>'])
 
     def test_split_anchor_across_lines(self):
         """Support unavoidable splits of an anchor across lines."""
-        eq_(text_to_html_lines('this\nthat', refs=[(0, 9, ({}, ''))]),
+        eq_(text_to_html_lines('this\nthat', refs=[(0, 9, ({}, '', None))]),
             [u'<a data-menu="{}">this</a>', u'<a data-menu="{}">that</a>'])
 
     def test_horrors(self):


### PR DESCRIPTION
Fixes https://bugzilla.mozilla.org/show_bug.cgi?id=1123877

While we're at it, clean up the API and implementation. regions() and refs() now return Region and Ref classes which will be extensible in the future as we add things (like we've added `hover` and `qualname_hash` to refs).