### PR TITLE
Fix alignment between line and code columns.

### DIFF
--- a/dxr/lines.py
+++ b/dxr/lines.py
@@ -371,7 +371,7 @@ def html_line(text, tags, bof_offset):
         for pos, is_start, payload in tags:
             # Convert from file-based position to line-based position.
             pos -= bof_offset
-            yield cgi.escape(text[up_to:pos].strip(u'\r\n'))
+            yield cgi.escape(text[up_to:pos])
             up_to = pos
             if not is_start:  # It's a closer. Most common.
                 yield payload.closer()

--- a/tests/test_lines.py
+++ b/tests/test_lines.py
@@ -269,7 +269,7 @@ class IntegrationTests(TestCase):
     def test_split_anchor_across_lines(self):
         """Support unavoidable splits of an anchor across lines."""
         eq_(text_to_html_lines('this\nthat', refs=[(0, 9, Ref({}))]),
-            [u'<a data-menu="{}">this</a>', u'<a data-menu="{}">that</a>'])
+            [u'<a data-menu="{}">this\n</a>', u'<a data-menu="{}">that</a>'])
 
     def test_horrors(self):
         """Untangle a circus of interleaved tags, tags that start where others

--- a/tests/test_vcs_git/test_vcs_git.py
+++ b/tests/test_vcs_git/test_vcs_git.py
@@ -39,7 +39,7 @@ class GitTests(DxrInstanceTestCaseMakeFirst):
         """Check that the pygmentize FileToSkim correctly colors a file from permalink."""
         client = self.client()
         response = client.get('/code/rev/cb339834998124cb8165aa35ed4635c51b6ac5c2/main.c')
-        ok_('<span class="c">// Hello World Example</span>' in response.data)
+        ok_('<span class="c">// Hello World Example\n</span>' in response.data)
         # Query it again to test that the Vcs cache functions.
         response = client.get('/code/rev/cb339834998124cb8165aa35ed4635c51b6ac5c2/main.c')
-        ok_('<span class="c">// Hello World Example</span>' in response.data)
+        ok_('<span class="c">// Hello World Example\n</span>' in response.data)


### PR DESCRIPTION
We stop stripping empty lines in multi-line regions,
especially prevent in Python docstrings.

Example of the issue: https://dxr.allizom.org/mozilla-central/source/python/mozbuild/mozbuild/frontend/context.py#1218
Here the highlighted line number is about a hundred lines below the highlighted line of source code.