### PR TITLE
Fix bug 1185687, stop showing symlinks in search results.

### DIFF
--- a/dxr/build.py
+++ b/dxr/build.py
@@ -459,8 +459,10 @@ def index_file(tree, tree_indexers, path, es, index):
             raise
 
     rel_path = relpath(path, tree.source_folder)
+    is_text = isinstance(contents, unicode)
+    is_link = islink(path)
     # Index by line if the contents are text and the path is not a symlink.
-    index_by_line = isinstance(contents, unicode) and not islink(path)
+    index_by_line = is_text and not is_link
     if index_by_line:
         lines = contents.splitlines(True)
         num_lines = len(lines)
@@ -475,7 +477,8 @@ def index_file(tree, tree_indexers, path, es, index):
         if file_to_index.is_interesting():
             # Per-file stuff:
             append_update(needles, file_to_index.needles())
-            linkses.append(file_to_index.links())
+            if not is_link:
+                linkses.append(file_to_index.links())
 
             # Per-line stuff:
             if index_by_line:

--- a/dxr/build.py
+++ b/dxr/build.py
@@ -459,8 +459,9 @@ def index_file(tree, tree_indexers, path, es, index):
             raise
 
     rel_path = relpath(path, tree.source_folder)
-    is_text = isinstance(contents, unicode)
-    if is_text:
+    # Index by line if the contents are text and the path is not a symlink.
+    index_by_line = isinstance(contents, unicode) and not islink(path)
+    if index_by_line:
         lines = contents.splitlines(True)
         num_lines = len(lines)
         needles_by_line = [{} for _ in xrange(num_lines)]
@@ -477,7 +478,7 @@ def index_file(tree, tree_indexers, path, es, index):
             linkses.append(file_to_index.links())
 
             # Per-line stuff:
-            if is_text:
+            if index_by_line:
                 refses.append(file_to_index.refs())
                 regionses.append(file_to_index.regions())
                 append_update_by_line(needles_by_line,
@@ -517,9 +518,8 @@ def index_file(tree, tree_indexers, path, es, index):
             doc['links'] = links
         yield es.index_op(doc, doc_type=FILE)
 
-        # Index all the lines. If it's an empty file (no lines), don't bother
-        # ES. It hates empty dicts.
-        if is_text and needles_by_line:
+        # Index all the lines.
+        if index_by_line:
             for total, annotations_for_this_line, tags in izip(
                     needles_by_line,
                     annotations_by_line,

--- a/dxr/indexers.py
+++ b/dxr/indexers.py
@@ -215,7 +215,7 @@ class FileToSkim(PluginConfig):
         called because views of symlinks redirect to the original file.
 
         """
-        return self.contains_text() and not islink(self.absolute_path())
+        return self.contains_text() and not self.is_link()
 
     def links(self):
         """Return an iterable of links for the navigation pane::
@@ -308,6 +308,15 @@ class FileToSkim(PluginConfig):
 
         """
         return join(self.tree.source_folder, self.path)
+
+    def is_link(self):
+        """Return whether the file is a symlink.
+
+        Note: symlinks are never displayed in file browsing; a request for a symlink redirects
+        to its target.
+
+        """
+        return islink(self.absolute_path())
 
     # Private methods:
 

--- a/dxr/indexers.py
+++ b/dxr/indexers.py
@@ -210,6 +210,9 @@ class FileToSkim(PluginConfig):
         :meth:`~dxr.indexers.FileToSkim.refs()`, etc.
 
         The default implementation selects only text files that are not symlinks.
+        Note: even if a plugin decides that symlinks are interesting, it should
+        remember that links, refs, regions and by-line annotations will not be
+        called because views of symlinks redirect to the original file.
 
         """
         return self.contains_text() and not islink(self.absolute_path())
@@ -392,6 +395,10 @@ class FileToIndex(FileToSkim):
         unique values will be retained using an elasticsearch array. Values
         may be dicts, in which case common keys get merged by
         :func:`~dxr.utils.append_update()`.
+
+        This method is not called on symlink files, to maintain the illusion
+        that they do not have contents, seeing as they cannot be viewed in
+        file browsing.
 
         """
         return []

--- a/dxr/indexers.py
+++ b/dxr/indexers.py
@@ -4,7 +4,7 @@ import cgi
 from collections import namedtuple
 import json
 from operator import itemgetter
-from os.path import join
+from os.path import join, islink
 from warnings import warn
 
 from funcy import group_by, decorator, imapcat
@@ -209,10 +209,10 @@ class FileToSkim(PluginConfig):
         :meth:`~dxr.indexers.FileToSkim.links()`,
         :meth:`~dxr.indexers.FileToSkim.refs()`, etc.
 
-        The default implementation selects only text files.
+        The default implementation selects only text files that are not symlinks.
 
         """
-        return self.contains_text()
+        return self.contains_text() and not islink(self.absolute_path())
 
     def links(self):
         """Return an iterable of links for the navigation pane::

--- a/dxr/plugins/core.py
+++ b/dxr/plugins/core.py
@@ -2,7 +2,7 @@
 
 from base64 import b64encode
 from itertools import chain
-from os.path import relpath, splitext
+from os.path import relpath, splitext, islink, realpath
 import re
 
 from flask import url_for
@@ -59,6 +59,11 @@ mappings = {
             'path': PATH_MAPPING,
 
             'ext': EXT_MAPPING,
+
+            'link': {  # the target path if this FILE is a symlink
+                'type': 'string',
+                'index': 'not_analyzed'
+            },
 
             # Folder listings query by folder and then display filename, size,
             # and mod date.
@@ -433,6 +438,9 @@ class FileToIndex(dxr.indexers.FileToIndex):
 
     def needles(self):
         """Fill out path (and path.trigrams)."""
+        if islink(self.absolute_path()):
+            # realpath will keep following symlinks until it gets to the 'real' thing.
+            yield 'link', relpath(realpath(self.absolute_path()), self.tree.source_folder)
         yield 'path', self.path
         extension = splitext(self.path)[1]
         if extension:

--- a/dxr/plugins/core.py
+++ b/dxr/plugins/core.py
@@ -438,7 +438,7 @@ class FileToIndex(dxr.indexers.FileToIndex):
 
     def needles(self):
         """Fill out path (and path.trigrams)."""
-        if islink(self.absolute_path()):
+        if self.is_link():
             # realpath will keep following symlinks until it gets to the 'real' thing.
             yield 'link', relpath(realpath(self.absolute_path()), self.tree.source_folder)
         yield 'path', self.path

--- a/dxr/plugins/python/indexers.py
+++ b/dxr/plugins/python/indexers.py
@@ -1,7 +1,8 @@
 import ast
 import token
 import tokenize
-from StringIO import StringIO
+from os.path import islink
+from cStringIO import StringIO
 
 from dxr.build import unignored
 from dxr.filters import FILE, LINE
@@ -301,4 +302,4 @@ def is_interesting(path):
     analyze.
 
     """
-    return path.endswith('.py')
+    return path.endswith('.py') and not islink(path)

--- a/dxr/query.py
+++ b/dxr/query.py
@@ -140,6 +140,8 @@ class Query(object):
             # Don't show folders yet in search results. I don't think the JS
             # is able to handle them.
             ors.append({'term': {'is_folder': False}})
+            # Filter out all FILE docs who are links.
+            ors.append({'not': {'exists': {'field': 'link'}}})
 
         if ors:
             query = {

--- a/tests/test_symlink/code/README.mkd
+++ b/tests/test_symlink/code/README.mkd
@@ -1,0 +1,1 @@
+This file should be indexed happily.

--- a/tests/test_symlink/code/link.mkd
+++ b/tests/test_symlink/code/link.mkd
@@ -1,0 +1,1 @@
+README.mkd

--- a/tests/test_symlink/dxr.config
+++ b/tests/test_symlink/dxr.config
@@ -1,0 +1,13 @@
+[DXR]
+enabled_plugins     = pygmentize clang python
+es_index            = dxr_test_{format}_{tree}_{unique}
+es_alias            = dxr_test_{format}_{tree}
+es_catalog_index    = dxr_test_catalog
+
+[code]
+source_folder       = code
+build_command       =
+clean_command       =
+
+    [[python]]
+    python_path     = ./

--- a/tests/test_symlink/test_symlink.py
+++ b/tests/test_symlink/test_symlink.py
@@ -1,0 +1,36 @@
+from nose.tools import eq_, ok_
+
+from dxr.testing import DxrInstanceTestCase
+
+
+class SymlinkTests(DxrInstanceTestCase):
+    def test_follows_link(self):
+        """Test that a symlink listed in a browsing view will actually point to the real target.
+
+        """
+        response = self.client().get('/code/source/')
+        # Make sure the browse view actually shows the symlink...
+        ok_('link.mkd' in response.data)
+        # ...but links to the real file instead.
+        ok_('<a href="/code/source/link.mkd"' not in response.data)
+
+    def test_file_search(self):
+        """Make sure that searching for path:<symlink name> does not return the symlink.
+
+        """
+        self.found_files_eq('path:mkd', ['README.mkd'])
+
+    def test_line_search(self):
+        """Make sure that searching for contents within the real file does not return duplicates
+        in the symlink.
+
+        """
+        self.found_files_eq('happily', ['README.mkd'])
+
+    def test_redirect(self):
+        """Make sure that a direct link to a symlink redirects to the real file.
+
+        """
+        response = self.client().get('/code/source/link.mkd')
+        eq_(response.status_code, 302)
+        ok_(response.headers['Location'].endswith('/code/source/README.mkd'))


### PR DESCRIPTION
New behaviors:
We do not call the by lines processing for symlinks at index time.
Symlinks do not appear in search results (lines and files).
A symlink in folder browsing will have its href set to the real target.
A direct link to symlink will redirect to its real target.