### PR TITLE
Include more menu refs in the Python plugin.

### DIFF
--- a/dxr/plugins/python/filters.py
+++ b/dxr/plugins/python/filters.py
@@ -30,6 +30,12 @@ class FunctionFilter(_PyFilter):
     description = Markup('Function or method definition: <code>function:foo</code>')
 
 
+class FunctionRefFilter(_PyFilter):
+    name = 'function-ref'
+    is_reference = True
+    description = Markup('Function or method reference: <code>function-ref:foo</code>')
+
+
 class DerivedFilter(_QualifiedPyFilter):
     name = 'derived'
     description = Markup('Subclasses of a class: <code>derived:SomeSuperclass</code>')
@@ -42,7 +48,6 @@ class BasesFilter(_QualifiedPyFilter):
 
 class CallersFilter(_PyFilter):
     name = 'callers'
-    is_reference = True
     description = Markup('Calls to the given function: <code>callers:some_function</code>')
 
 

--- a/dxr/plugins/python/menus.py
+++ b/dxr/plugins/python/menus.py
@@ -13,3 +13,23 @@ def class_menu(tree, qualname):
          'href': search_url(tree, '+bases:' + qualname),
          'icon': 'type'},
     ]
+
+
+def function_ref_menu(tree, name):
+    """Generate menu for function references."""
+    return {
+        'html': 'Find references',
+        'title': 'Find references to this function',
+        'href': search_url(tree, 'ref:' + name),
+        'icon': 'method'
+    }
+
+
+def function_id_menu(tree, name):
+    """Generate menu for a search for function definition."""
+    return {
+        'html': 'Find definition',
+        'title': 'Find definition of this function',
+        'href': search_url(tree, 'id:' + name),
+        'icon': 'method'
+    }

--- a/dxr/plugins/python/tests/test_functions/code/main.py
+++ b/dxr/plugins/python/tests/test_functions/code/main.py
@@ -1,6 +1,6 @@
 
 def foo():
-    pass
+    bar()
 
 def bar():
     pass

--- a/dxr/plugins/python/tests/test_functions/test_functions.py
+++ b/dxr/plugins/python/tests/test_functions/test_functions.py
@@ -1,4 +1,6 @@
-from dxr.testing import DxrInstanceTestCase
+from dxr.testing import DxrInstanceTestCase, menu_on
+
+SEARCH = '/code/search?q=%s%%3A%s'
 
 
 class FunctionDefTests(DxrInstanceTestCase):
@@ -16,3 +18,20 @@ class FunctionDefTests(DxrInstanceTestCase):
         self.found_lines_eq('function:bar',
                             [("def <b>bar</b>():", 5),
                              ("def <b>bar</b>(self):", 10)])
+
+    def test_function_ref(self):
+        self.found_line_eq('function-ref:bar', "<b>bar</b>()", 3)
+
+    def test_function_caller_menu(self):
+        page = self.source_page("main.py")
+        menu_on(page, 'bar', {
+            'html': 'Find definition',
+            'href': SEARCH % ('id', 'bar')
+        })
+
+    def test_function_def_menu(self):
+        page = self.source_page("main.py")
+        menu_on(page, 'foo', {
+            'html': 'Find references',
+            'href': SEARCH % ('ref', 'foo')
+        })


### PR DESCRIPTION
Playing around with the Python plugin, I didn't even realize that we had many function filters until I checked the ES mapping. I think that putting ref menus on things makes them more discoverable, so here I add refs for function definitions and function calls.

Add refs to find function usages and definitions to call sites and definitions.
Use id: and ref: filters in the calls because Python’s AST does not
differentiate between class instantiation and function calls — both are Calls.