### PR TITLE
Make es_index per tree, fixes bug 1177113.

### DIFF
--- a/dxr/build.py
+++ b/dxr/build.py
@@ -219,13 +219,10 @@ def index_tree(tree, es, verbose=False):
                      tree.enabled_plugins if p.tree_to_index]
     try:
         if not skip_indexing:
-            # Make a new index with a semi-random name, having the tree name
-            # and format version in it. TODO: The prefix should come out of
-            # the tree config, falling back to the global config:
-            # dxr_hot_prod_{tree}_{whatever}.
-            index = config.es_index.format(format=FORMAT,
-                                           tree=tree.name,
-                                           unique=uuid1())
+            # Substitute the format, tree name, and uuid into the index identifier.
+            index = tree.es_index.format(format=FORMAT,
+                                         tree=tree.name,
+                                         unique=uuid1())
             create_index_and_wait(
                 es,
                 index,

--- a/dxr/config.py
+++ b/dxr/config.py
@@ -114,6 +114,7 @@ class Config(DotSection):
                 Optional('google_analytics_key', default=''): basestring,
                 Optional('es_hosts', default='http://127.0.0.1:9200/'):
                     WhitespaceList,
+                # A semi-random name, having the tree name and format version in it.
                 Optional('es_index', default='dxr_{format}_{tree}_{unique}'):
                     basestring,
                 Optional('es_alias', default='dxr_{format}_{tree}'):
@@ -204,6 +205,7 @@ class TreeConfig(DotSectionWrapper):
             Optional('description', default=''): basestring,
             Optional('disabled_plugins', default=plugin_list('')): Plugins,
             Optional('enabled_plugins', default=plugin_list('*')): Plugins,
+            Optional('es_index', default=config.es_index): basestring,
             Optional('es_shards', default=5):
                 Use(int, error='"es_shards" must be an integer.'),
             Optional('ignore_patterns',

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -28,6 +28,27 @@ def test_enabled_star():
     ok_('urllink' in (p.name for p in config.trees['some_tree'].enabled_plugins))
 
 
+def test_es_index():
+    """Make sure that we can override es_index on a per-tree level.
+
+    """
+    config = Config("""
+        [DXR]
+        es_index = test_index_{tree}
+        enabled_plugins =
+
+        [some_tree]
+        source_folder = /some/path
+        es_index = some_tree_index
+
+        [another_tree]
+        source_folder = /some/path
+        """)
+    eq_(config.es_index, 'test_index_{tree}')
+    eq_(config.trees['some_tree'].es_index, 'some_tree_index')
+    eq_(config.trees['another_tree'].es_index, 'test_index_{tree}')
+
+
 def test_enabled_plugins():
     """Make sure enabled_plugins tolerates arbitrary whitespace between items,
     maintains its order, and includes the core plugin. Make sure a plugin


### PR DESCRIPTION
If es_index is provided for a tree, use that;
otherwise default to the original format.

https://bugzilla.mozilla.org/show_bug.cgi?id=1177113