### PR TITLE
Keep core plugin from double-contributing. Fixes bug 1191537.

### DIFF
--- a/dxr/app.py
+++ b/dxr/app.py
@@ -26,7 +26,7 @@ from dxr.filters import FILE, LINE
 from dxr.indexers import Ref, Region
 from dxr.lines import html_line, tags_per_line, finished_tags
 from dxr.mime import icon, is_image, is_text
-from dxr.plugins import plugins_named, all_plugins
+from dxr.plugins import plugins_named
 from dxr.query import Query, filter_menu_items
 from dxr.utils import (non_negative_int, decode_es_datetime, DXR_BLUEPRINT,
                        format_number, append_update, append_by_line, cumulative_sum)
@@ -384,13 +384,12 @@ def _browse_file(tree, path, line_docs, file_doc, config, date=None, contents=No
         # file_to_skim class.
         skimmers = [plugin.file_to_skim(path,
                                         contents,
-                                        name,
+                                        plugin.name,
                                         config.trees[tree],
                                         file_doc,
                                         line_docs)
-                    for name, plugin in all_plugins().iteritems()
-                    if plugin in config.trees[tree].enabled_plugins
-                    and plugin.file_to_skim]
+                    for plugin in config.trees[tree].enabled_plugins
+                    if plugin.file_to_skim]
         skim_links, refses, regionses, annotationses = skim_file(skimmers, len(line_docs))
         index_refs = imap(Ref.es_to_triple,
                           chain.from_iterable(doc.get('refs', [])

--- a/dxr/config.py
+++ b/dxr/config.py
@@ -17,7 +17,7 @@ from pkg_resources import resource_string
 from schema import Schema, Optional, Use, And, Schema, SchemaError
 
 from dxr.exceptions import ConfigError
-from dxr.plugins import all_plugins
+from dxr.plugins import all_plugins_but_core, core_plugin
 from dxr.utils import cd, if_raises
 
 
@@ -160,7 +160,7 @@ class Config(DotSection):
                 # Then explicitly enable anything that isn't explicitly
                 # disabled:
                 self._section['enabled_plugins'] = [
-                        p for p in all_plugins().values()
+                        p for p in all_plugins_but_core().values()
                         if p not in self.disabled_plugins]
 
             # Now that enabled_plugins and the other keys that TreeConfig
@@ -239,7 +239,7 @@ class TreeConfig(DotSectionWrapper):
         if tree['enabled_plugins'].is_all:
             tree['enabled_plugins'] = [p for p in config.enabled_plugins
                                        if p not in tree['disabled_plugins']]
-        tree['enabled_plugins'].insert(0, all_plugins()['core'])
+        tree['enabled_plugins'].insert(0, core_plugin())
 
         # Split ignores into paths and filenames:
         tree['ignore_paths'] = [i for i in tree['ignore_patterns']
@@ -257,11 +257,10 @@ class TreeConfig(DotSectionWrapper):
             if all(isinstance(k, Optional) for k in p.config_schema.iterkeys()))
         plugin_schema = Schema(merge(
             dict((Optional(name) if plugin in enableds_with_all_optional_config
-                                 or plugin not in tree['enabled_plugins']
-                  else name,
+                                    or plugin not in tree['enabled_plugins']
+                                 else name,
                   plugin.config_schema)
-                 for name, plugin in all_plugins().iteritems()
-                 if name != 'core'),
+                 for name, plugin in all_plugins_but_core().iteritems()),
             # And whatever isn't a plugin section, that we don't care about:
             {object: object}))
         # Insert empty missing sections for enabled plugins with entirely
@@ -294,12 +293,14 @@ def plugin_list(value):
     """Turn a space-delimited series of plugin names into a ListAndAll of
     Plugins.
 
+    Never return the core plugin.
+
     """
     if not isinstance(value, basestring):
         raise SchemaError('"%s" is neither * nor a whitespace-delimited list '
                           'of plugin names.' % (value,))
 
-    plugins = all_plugins()
+    plugins = all_plugins_but_core()
     names = value.strip().split()
     is_all = names == ['*']
     if is_all:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -28,7 +28,11 @@ def test_enabled_star():
             [[xpidl]]
             header_path = /somewhere
         """)
-    ok_('urllink' in (p.name for p in config.trees['some_tree'].enabled_plugins))
+    enabled_plugins = config.trees['some_tree'].enabled_plugins
+    plugin_names = [p.name for p in enabled_plugins]
+    ok_('urllink' in plugin_names)
+    eq_('core', plugin_names[0])
+    ok_('core' not in plugin_names[1:])
 
 
 def test_es_index():


### PR DESCRIPTION
core would get included in the frozen config's enabled_plugins, and then TreeConfig would happily re-add core again at request time. We no longer freeze 'core' as part of an index's catalog entry.

all_plugins() no longer returns core, and neither does plugins_named() (which has been renamed to provide a reminder). core is no longer part of Config's enabled_plugins, either. The only place core comes from now is a TreeConfig's enabled_plugins attr.

Also, make skimmers run in the order that plugins are specified in the config file.