### PR TITLE
Fix crashes in Rust plugin.

### DIFF
--- a/dxr/plugins/rust/__init__.py
+++ b/dxr/plugins/rust/__init__.py
@@ -192,6 +192,9 @@ class FileToIndex(indexers.FileToIndex):
             if datum['id'] not in inheritance:
                 continue
             for s in inheritance[datum['id']]:
+                if s not in all_types:
+                    continue
+
                 t = {
                     'qualname': all_types[s]['qualname'],
                     'name': all_types[s]['name']


### PR DESCRIPTION
This is a stop gap fix, the real fix is in the compiler and I'm working on it, in the meantime this stops crashes during indexing so at least we'll have an index, even if some links are incomplete.