### PR TITLE
Display SVGs as XML, and add link to view as image.

### DIFF
--- a/dxr/app.py
+++ b/dxr/app.py
@@ -24,7 +24,7 @@ from dxr.es import (filtered_query, frozen_config, frozen_configs,
 from dxr.exceptions import BadTerm
 from dxr.filters import FILE, LINE
 from dxr.lines import html_line, tags_per_line, finished_tags, Ref, Region
-from dxr.mime import icon, is_image, is_text
+from dxr.mime import icon, is_binary_image, is_text, is_indexable_image
 from dxr.plugins import plugins_named
 from dxr.query import Query, filter_menu_items
 from dxr.utils import (non_negative_int, decode_es_datetime, DXR_BLUEPRINT,
@@ -419,7 +419,7 @@ def _browse_file(tree, path, line_docs, file_doc, config, date=None, contents=No
 
     common = _build_common_file_template(tree, path, date, config)
     links = file_doc.get('links', [])
-    if is_image(path):
+    if is_binary_image(path):
         return render_template(
             'image_file.html',
             **common)

--- a/dxr/app.py
+++ b/dxr/app.py
@@ -465,6 +465,7 @@ def _browse_file(tree, path, line_docs, file_doc, config, date=None, contents=No
                 'is_text': True,
                 'sections': sidebar_links(links + skim_links)}))
 
+
 @dxr_blueprint.route('/<tree>/rev/<revision>/<path:path>')
 def rev(tree, revision, path):
     """Display a page showing the file at path at specified revision by
@@ -485,6 +486,7 @@ def rev(tree, revision, path):
                             contents=contents)
     else:
         raise NotFound
+
 
 def _linked_pathname(path, tree_name):
     """Return a list of (server-relative URL, subtree name) tuples that can be

--- a/dxr/build.py
+++ b/dxr/build.py
@@ -31,7 +31,7 @@ from dxr.es import UNINDEXED_STRING, TREE, create_index_and_wait
 from dxr.exceptions import BuildError
 from dxr.filters import LINE, FILE
 from dxr.lines import es_lines, finished_tags
-from dxr.mime import is_text, icon, is_image
+from dxr.mime import is_text, icon
 from dxr.query import filter_menu_items
 from dxr.utils import (open_log, deep_update, append_update,
                        append_update_by_line, append_by_line, bucket)

--- a/dxr/mime.py
+++ b/dxr/mime.py
@@ -4,17 +4,18 @@ from os.path import splitext
 def icon(path):
     """Return the basename (no extension) of the icon file to use for a path."""
     root, ext = splitext(path)
-    return ext_map.get(ext[1:], 'unknown')
+    return ext_map.get(ext[1:].lower(), 'unknown')
 
 
 def is_text(data):
     # Simple stupid test that apparently works rather well :)
     return '\0' not in data
 
+
 def is_image(path):
     """Determine whether the path is an image."""
     _, ext = splitext(path)
-    return ext_map.get(ext[1:], False) == 'image'
+    return ext_map.get(ext[1:].lower(), False) == 'image'
 
 
 # File extension known as this point
@@ -66,6 +67,5 @@ ext_map = {
     "jpg":        'image',
     "jpeg":       'image',
     "png":        'image',
-    "gif":        'image',
-    "svg":        'image'
+    "gif":        'image'
 }

--- a/dxr/mime.py
+++ b/dxr/mime.py
@@ -4,7 +4,7 @@ from os.path import splitext
 def icon(path):
     """Return the basename (no extension) of the icon file to use for a path."""
     root, ext = splitext(path)
-    return ext_map.get(ext[1:].lower(), 'unknown')
+    return ext_map.get(ext[1:], 'unknown')
 
 
 def is_text(data):
@@ -12,10 +12,14 @@ def is_text(data):
     return '\0' not in data
 
 
-def is_image(path):
-    """Determine whether the path is an image."""
-    _, ext = splitext(path)
-    return ext_map.get(ext[1:].lower(), False) == 'image'
+def is_binary_image(path):
+    """Determine whether the path is a binary image."""
+    return icon(path) == 'image'
+
+
+def is_indexable_image(path):
+    """Determine whether the path is an image with indexable (text) contents."""
+    return icon(path) in {'svg'}
 
 
 # File extension known as this point
@@ -32,6 +36,7 @@ ext_map = {
     "c":          'c',
     "xul":        'ui',
     "svg":        'svg',
+    "SVG":        'svg',
     "in":         'build',
     "idl":        'conf',
     "java":       'java',

--- a/dxr/plugins/core.py
+++ b/dxr/plugins/core.py
@@ -436,7 +436,7 @@ class FileToIndex(dxr.indexers.FileToIndex):
             # realpath will keep following symlinks until it gets to the 'real' thing.
             yield 'link', relpath(realpath(self.absolute_path()), self.tree.source_folder)
         yield 'path', self.path
-        extension = splitext(self.path)[1].lower()
+        extension = splitext(self.path)[1]
         if extension:
             yield 'ext', extension[1:]  # skip the period
         # Remark: We store both the indexed contents and the raw data of

--- a/dxr/plugins/pygmentize.py
+++ b/dxr/plugins/pygmentize.py
@@ -79,11 +79,8 @@ def _lexer_for_filename(filename):
 
             # Also we can syntax highlight XUL as XML, and IDL/WebIDL as CPP
             lexer = get_lexer_for_filename(
-                'dummy.cpp' if filename.endswith('.h')
-                               or filename.endswith('.idl')
-                               or filename.endswith('.webidl')
-                else 'dummy.xml' if filename.endswith('.xul')
-                                    or filename.endswith('.svg')
+                'dummy.cpp' if filename.endswith(('.h', '.idl', '.webidl'))
+                else 'dummy.xml' if filename.endswith(('.xul', '.svg'))
                 else filename)
         except ClassNotFound:
             return None

--- a/dxr/plugins/pygmentize.py
+++ b/dxr/plugins/pygmentize.py
@@ -83,6 +83,7 @@ def _lexer_for_filename(filename):
                                or filename.endswith('.idl')
                                or filename.endswith('.webidl')
                 else 'dummy.xml' if filename.endswith('.xul')
+                                    or filename.endswith('.svg')
                 else filename)
         except ClassNotFound:
             return None

--- a/tests/test_binary_files/test_binary_files.py
+++ b/tests/test_binary_files/test_binary_files.py
@@ -31,13 +31,20 @@ class BinaryFileTests(DxrInstanceTestCase):
         ok_('href="/code/source/Green%20circle.jpg" class="icon image too_fat"' in response.data)
 
     def test_svg(self):
-        """Make sure we show the source of the svg, but allow way to reach its image."""
+        """Make sure we show the source of the svg, but allow a way to reach its image."""
         response = self.client().get('/code/source/yellow_circle.svg')
         ok_('href="/code/raw/yellow_circle.svg"' in response.data)
         response = self.client().get('/code/raw/yellow_circle.svg')
         ok_(response.status_code, 200)
 
-    def test_some_bytes(self):
+    def test_some_bytes_visible(self):
+        """We want some_bytes to show in the folder index, but without its own page."""
+        response = self.client().get('/code/source/')
+        ok_('some_bytes' in response.data)
+        response = self.client().get('/code/source/some_bytes')
+        ok_(response.status_code, 404)
+
+    def test_some_bytes_not_searchable(self):
         """We want some_bytes to show on search page, but not be clickable."""
         response = self.client().get('/code/search?q=path%3Asome_bytes&redirect=true')
         ok_('some_bytes' in response.data)

--- a/tests/test_binary_files/test_binary_files.py
+++ b/tests/test_binary_files/test_binary_files.py
@@ -31,18 +31,11 @@ class BinaryFileTests(DxrInstanceTestCase):
         ok_('href="/code/source/Green%20circle.jpg" class="icon image too_fat"' in response.data)
 
     def test_svg(self):
-        """Make sure we show the svg."""
+        """Make sure we show the source of the svg, but allow way to reach its image."""
         response = self.client().get('/code/source/yellow_circle.svg')
-        ok_('src="/code/raw/yellow_circle.svg"' in response.data)
+        ok_('href="/code/raw/yellow_circle.svg"' in response.data)
         response = self.client().get('/code/raw/yellow_circle.svg')
         ok_(response.status_code, 200)
-
-    def test_some_bytes(self):
-        """We want some_bytes to show in the folder index, but without its own page."""
-        response = self.client().get('/code/source/')
-        ok_('some_bytes' in response.data)
-        response = self.client().get('/code/source/some_bytes')
-        ok_(response.status_code, 404)
 
     def test_some_bytes(self):
         """We want some_bytes to show on search page, but not be clickable."""


### PR DESCRIPTION
Fixes bug 1202598. https://bugzilla.mozilla.org/show_bug.cgi?id=1202598

Also normalize extension to lowercase when looking up in the extension map, so that .svg and .SVG are treated the same.