### PR TITLE
Removed the called-by filter.

### DIFF
--- a/dxr/plugins/clang/tests/test_callers.py
+++ b/dxr/plugins/clang/tests/test_callers.py
@@ -1,4 +1,4 @@
-"""Tests for searches using callers and called-by"""
+"""Tests for searches using callers"""
 
 from dxr.testing import SingleFileTestCase, MINIMAL_MAIN
 

--- a/dxr/plugins/python/indexers.py
+++ b/dxr/plugins/python/indexers.py
@@ -32,7 +32,6 @@ mappings = {
             'py_derived': QUALIFIED_LINE_NEEDLE,
             'py_bases': QUALIFIED_LINE_NEEDLE,
             'py_callers': QUALIFIED_LINE_NEEDLE,
-            'py_called_by': QUALIFIED_LINE_NEEDLE,
             'py_overrides': QUALIFIED_LINE_NEEDLE,
             'py_overridden': QUALIFIED_LINE_NEEDLE,
         },
@@ -92,14 +91,14 @@ class IndexingNodeVisitor(ast.NodeVisitor, ClassFunctionVisitorMixin):
         start, end = self.file_to_index.get_node_start_end(node)
         self.yield_needle('py_function', node.name, start, end)
 
-        # Index function calls within this function for the callers: and
-        # called-by filters.
+        # Index function calls within this function for the callers: filter.
         self.function_call_stack.append([])
         super(IndexingNodeVisitor, self).visit_FunctionDef(node)
         call_needles = self.function_call_stack.pop()
         for name, call_start, call_end in call_needles:
+            # TODO: py_callers should be all calls, not just ones that
+            # take place within a function.
             self.yield_needle('py_callers', name, start, end)
-            self.yield_needle('py_called_by', node.name, call_start, call_end)
 
     def visit_Call(self, node):
         # Save this call if we're currently tracking function calls.

--- a/dxr/plugins/rust/__init__.py
+++ b/dxr/plugins/rust/__init__.py
@@ -108,7 +108,6 @@ class FileToIndex(indexers.FileToIndex):
             self.fn_impls_needles(),
             self.inherit_needles(self.tree_index.super_traits, 'derived'),
             self.inherit_needles(self.tree_index.sub_traits, 'bases'),
-            self.call_needles(self.tree_index.callers, 'called_by'),
             self.call_needles(self.tree_index.callees, 'callers'),
         ))))
 
@@ -1055,7 +1054,6 @@ mappings = {
             'rust_bases': QUALIFIED_LINE_NEEDLE,
             'rust_derived': QUALIFIED_LINE_NEEDLE,
             'rust_callers': QUALIFIED_LINE_NEEDLE,
-            'rust_called_by': QUALIFIED_LINE_NEEDLE,
         }
     }
 }

--- a/dxr/plugins/rust/filters.py
+++ b/dxr/plugins/rust/filters.py
@@ -20,10 +20,6 @@ class CallersFilter(_QualifiedNameFilter):
     is_reference = True
     description = 'Function callers'
 
-class CalledByFilter(_QualifiedNameFilter):
-    name = 'called-by'
-    description = 'Functions called by this function'
-
 class FnImplsFilter(_QualifiedNameFilter):
     name = 'fn-impls'
     is_identifier = True

--- a/dxr/plugins/rust/menu.py
+++ b/dxr/plugins/rust/menu.py
@@ -78,12 +78,8 @@ def std_lib_links_menu((doc_url, src_url, dxr_url), extra_text=""):
 
 def call_menu(qualname, tree):
     return [{'html': "Find callers",
-             'title': "Find functions that call this function",
+             'title': "Find calls of this function",
              'href': search_url(tree, "+callers:%s" % quote(qualname)),
-             'icon': 'method'},
-            {'html': "Find callees",  # TODO: Probably useless. Remove.
-             'title': "Find functions that are called by this function",
-             'href': search_url(tree, "+called-by:%s" % quote(qualname)),
              'icon': 'method'}]
 
 


### PR DESCRIPTION
Support had already been removed, this just cleans up the last
vestiges.  See #399.