### PR TITLE
Fix bug 1195855, prevent error on some Rust ref: searches.

### DIFF
--- a/dxr/filters.py
+++ b/dxr/filters.py
@@ -196,7 +196,9 @@ class NameFilterBase(Filter):
         """
         maybe_lower = (identity if self._term['case_sensitive'] else
                        unicode.lower)
-        return maybe_lower(entity['name']) == maybe_lower(self._term['arg'])
+        return ('name' in entity
+                and isinstance(entity['name'], unicode)
+                and maybe_lower(entity['name']) == maybe_lower(self._term['arg']))
 
     def highlight_content(self, result):
         """Highlight any structural entity whose name matches the term."""

--- a/dxr/plugins/rust/tests/test_ref_filters/code/krate.rs
+++ b/dxr/plugins/rust/tests/test_ref_filters/code/krate.rs
@@ -1,0 +1,3 @@
+#![ crate_name = "krate" ]
+#![ crate_type = "lib" ]
+

--- a/dxr/plugins/rust/tests/test_ref_filters/code/main.rs
+++ b/dxr/plugins/rust/tests/test_ref_filters/code/main.rs
@@ -1,0 +1,13 @@
+#![crate_name="test"]
+
+extern crate krate;
+// The 'name' needle of internal crates like 'std' is an integer.
+use std::io;
+
+fn foo() {
+    println!("Hello world");
+}
+
+fn main() {
+    foo();
+}

--- a/dxr/plugins/rust/tests/test_ref_filters/code/makefile
+++ b/dxr/plugins/rust/tests/test_ref_filters/code/makefile
@@ -1,0 +1,7 @@
+all: code
+krate: krate.rs
+	$(RUSTC) $< 
+code: main.rs krate
+	$(RUSTC) $< -o $@ -L$(@D)
+clean:
+	rm -rf code *.so

--- a/dxr/plugins/rust/tests/test_ref_filters/dxr.config
+++ b/dxr/plugins/rust/tests/test_ref_filters/dxr.config
@@ -1,0 +1,12 @@
+[DXR]
+enabled_plugins     = pygmentize rust
+disabled_plugins    = clang
+es_index            = dxr_{format}_{tree}_{unique}
+es_alias            = dxr_{format}_{tree}
+es_catalog_index    = dxr_catalog
+
+[code]
+source_folder=code
+object_folder=code
+build_command=make clean; make -j $jobs
+

--- a/dxr/plugins/rust/tests/test_ref_filters/test_ref_filters.py
+++ b/dxr/plugins/rust/tests/test_ref_filters/test_ref_filters.py
@@ -1,0 +1,19 @@
+from nose import SkipTest
+
+from dxr.testing import DxrInstanceTestCase
+
+class RefFilterTests(DxrInstanceTestCase):
+    """Rust plugin does some funny stuff with its needles, e.g. 'name' being an
+    integer or not being present, so make sure DXR does not break.
+    """
+
+    def test_normal_name_ref(self):
+        # Regular name ref, a string.
+        self.found_line_eq('ref:krate', 'extern crate <b>krate</b>;', 3)
+
+    def test_integer_name_ref(self):
+        # 'name' of the needle is an integer.
+        self.found_line_eq('ref:std', 'use <b>std</b>::io;', 5)
+
+    def test_empty_name_ref(self):
+        raise SkipTest("TOOD: construct a test case to find a needle without 'name'")


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1195855.
It looks like for crates in rustc, the 'name' field of the needle is an integer, which breaks maybe_lower of filter highlighting. For example, consider the query https://dxr.mozilla.org/rust/search?q=ref:std

It also seems that in some cases the 'name' field of the needle is not even present, which seems to be the case for searches such as https://dxr.mozilla.org/rust/search?q=ref:test
However I haven't had any luck constructing a minimal test case for this part of the bug.
@nrc any ideas?

The fix simply makes sure that 'name' exists and is a string.
