### PR TITLE
Make make responsible for installing python requirements. Fixes bug #…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ dxr-temp-*
 /node_modules/nunjucks
 /docs/build
 .npm_installed
+.peep_installed

--- a/dxr/cli/deploy.py
+++ b/dxr/cli/deploy.py
@@ -201,18 +201,16 @@ class Deployment(object):
                     run('git fsck --no-dangling')
 
                     # Install stuff, using the new copy of peep from the checkout:
-                    python = join(new_build_path, VENV_NAME, 'bin', 'python')
-                    run('{python} ./peep.py install -r requirements.txt',
-                        python=python)
+                    venv = join(new_build_path, VENV_NAME)
+                    run('VIRTUAL_ENV={venv} make requirements', venv=venv)
                     # Compile nunjucks templates and cachebust static assets:
                     run('make static &> /dev/null')
-                    # Quiet the complaint about there being no matches for *.so:
-                    run('{python} setup.py install 2>/dev/null', python=python)
+                    run('{pip} install --no-deps -e .',
+                        pip=join(venv, 'bin', 'pip'))
 
                 # After installing, you always have to re-run this, even if we
                 # were reusing a venv:
-                run('virtualenv --relocatable {venv}',
-                    venv=join(new_build_path, VENV_NAME))
+                run('virtualenv --relocatable {venv}', venv=venv)
 
                 run('chmod 755 .')  # mkdtemp uses a very conservative mask.
         except Exception:

--- a/makefile
+++ b/makefile
@@ -1,6 +1,6 @@
 # Things you should consider running:
 
-all: static plugins
+all: requirements static plugins
 
 test: all
 	python setup.py test
@@ -24,6 +24,9 @@ static: dxr/static_manifest
 
 # Private things:
 
+# Install Python requirements:
+requirements: .peep_installed
+
 plugins:
 	$(MAKE) -C dxr/plugins/clang
 
@@ -36,6 +39,11 @@ dxr/static_unhashed/js/templates.js: dxr/templates/nunjucks/*.html \
 # that file:
 .npm_installed: package.json lockdown.json
 	npm install
+	touch $@
+
+# Install requirements in current virtualenv:
+.peep_installed: requirements.txt
+	$$VIRTUAL_ENV/bin/python peep.py install -r requirements.txt
 	touch $@
 
 # Static-file cachebusting:
@@ -87,4 +95,4 @@ dxr/static_manifest: $(CSS_TEMPS) dxr/build/leaf_manifest dxr/build/css_manifest
 	
 	cat dxr/build/leaf_manifest dxr/build/css_manifest > $@
 
-.PHONY: all test clean static_clean static templates plugins
+.PHONY: all test clean static_clean static requirements plugins

--- a/vagrant_provision.sh
+++ b/vagrant_provision.sh
@@ -35,8 +35,8 @@ sudo -H -u vagrant -s -- <<THEEND
 virtualenv $VENV
 source $VENV/bin/activate
 cd ~vagrant/dxr
-./peep.py install -r requirements.txt
-python setup.py develop
+pip install --no-deps -e .
+# make will install the requirements when the user runs it.
 pip install pdbpp nose-progressive Sphinx==1.3.1
 THEEND
 # Activate the virtualenv all the time:


### PR DESCRIPTION
…1060463.

This gives contribs who are new to Python a fighting chance to get their requirements updated without bothering me: when they run make.

For now, uninstalling the Python requirements isn't included in `make clean`. Development may or may not take place inside the vagrant box, and, if it isn't, wiping out somebody's venv (hopefully it's a venv!) would be surprising.

Also...
* Modernize setup.py develop call to a pip call.
* Remove a stray reference to the deleted "templates" make target.
* Requirements no longer get installed during vagrant provisioning. They'll get installed when make is run.