### PR TITLE
Get Escape key handling working again.

### DIFF
--- a/dxr/static_unhashed/js/utils.js
+++ b/dxr/static_unhashed/js/utils.js
@@ -9,7 +9,7 @@ function onEsc(func) {
         // so, we check both.
         var keyPressed = event.key || event.keyCode;
         // esc key pressed.
-        if (keyPressed === 27 || keyPressed === 'Esc')
+        if (keyPressed === 27 || keyPressed === 'Escape' || keyPressed === 'Esc')
             func();
         else
             return true;


### PR DESCRIPTION
Re-fix Bug 1153726 by updating the event key value for Escape for
recent versions of gecko: https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/key