### PR TITLE
Adjust pop-up event handling.

### DIFF
--- a/dxr/static_unhashed/js/dxr.js
+++ b/dxr/static_unhashed/js/dxr.js
@@ -455,22 +455,22 @@ $(function() {
 
     // Toggle the help box when the help icon is clicked, and hide it when
     // anything outside of the box is clicked.
-    var helpIcon = $('.help-icon'),
-        helpMsg = helpIcon.find('.help-msg');
 
-    $(document.documentElement).on('click', '.help-icon', function(e) {
-        if ($(e.target).is(':not(.help-icon *)')) {
-            helpIcon.toggleClass('open');
-            helpMsg.toggle();
-        }
-    });
+    $(document.documentElement)
+        .on('click', '.help-icon', function(e) {
+            if ($(e.target).is(':not(.help-icon *)')) {
+                var helpIcon = $('.help-icon'),
+                    helpMsg = helpIcon.find('.help-msg');
 
-    $(document.documentElement).on('click', function(e) {
-        if ($(e.target).is(':not(.help-icon, .help-icon *)')) {
-            helpIcon.removeClass('open');
-            helpMsg.hide();
-        }
-    });
+                helpIcon.toggleClass('open');
+                helpMsg.toggle();
+            }
+        })
+        .on('mousedown', function(e) {
+            if ($(e.target).is(':not(.help-icon, .help-icon *)')) {
+                hideHelp();
+            }
+        });
 
 
     /**

--- a/dxr/static_unhashed/js/filter.js
+++ b/dxr/static_unhashed/js/filter.js
@@ -17,7 +17,6 @@ $(function() {
 
     // Show/Hide the options
     trigger.click(function(event) {
-        event.stopPropagation();
 
         var optionsContainer = $('.sf-select-options');
         var expanded = optionsContainer.attr('aria-expanded');
@@ -32,14 +31,22 @@ $(function() {
         }
     });
 
+    // Hide the options if anything outside the options or trigger box is
+    // clicked.
+    $(document.documentElement).on('mousedown', function(event) {
+        if ($(event.target).is(':not(.sf-select-trigger, ' +
+                                    '.sf-select-options, .sf-select-options *)')) {
+            $('.sf-select-options').hide();
+        }
+    });
+
     options.on('click', 'a', function(event) {
         event.stopPropagation();
 
         appendFilter($(this).data('value'));
 
-        hideOptions();
+        $('.sf-select-options').hide();
     });
 
-    window.addEventListener('click', hideOptions, false);
-    onEsc(hideOptions);
+    onEsc(hideOptionsAndHelp);
 });

--- a/dxr/static_unhashed/js/tree-selector.js
+++ b/dxr/static_unhashed/js/tree-selector.js
@@ -20,7 +20,6 @@ $(function() {
 
     // Show/Hide the options
     contentContainer.on('click', '.ts-select-trigger', function(event) {
-        event.stopPropagation();
 
         var optionsFilter = $('.options-filter');
         var optionsContainer = $('.tree-selector').find('.select-options');
@@ -41,15 +40,23 @@ $(function() {
         }
     });
 
+    // Hide the options if anything outside the options or trigger box is
+    // clicked.
+    $(document.documentElement).on('mousedown', function(event) {
+        if ($(event.target).is(':not(.ts-select-trigger, ' +
+                                    '.select-options, .select-options *)')) {
+            $('.select-options').hide();
+        }
+    });
+
     options.on('click', 'a', function(event) {
         event.stopPropagation();
         setSelectedItem($(this));
         // Set the value of the relevant hidden type element to
         // the selected value.
         $('#ts-value').val($(this).text());
-        hideOptions();
+        $('.select-options').hide();
     });
 
-    window.addEventListener('click', hideOptions, false);
-    onEsc(hideOptions);
+    onEsc(hideOptionsAndHelp);
 });

--- a/dxr/static_unhashed/js/utils.js
+++ b/dxr/static_unhashed/js/utils.js
@@ -52,11 +52,24 @@ String.prototype.regexLastIndexOf = function(regex, startpos) {
 };
 
 /**
- * Close all the pretend pop-up menus.
+ * Hide the Help pop-up.
  */
-function hideOptions() {
+function hideHelp() {
+
+    var helpIcon = $('.help-icon'),
+        helpMsg = helpIcon.find('.help-msg');
+
+    helpIcon.removeClass('open');
+    helpMsg.hide();
+}
+
+/**
+ * Close options and help pop-ups.
+ */
+function hideOptionsAndHelp() {
     // Because the tree selector can be injected by a JS
     // template, we need to use the selector directly here,
     // as the element will not exist on DOM ready.
     $('.select-options, .sf-select-options').hide();
+    hideHelp();
 }


### PR DESCRIPTION
This changes three things:
1) A right or middle click on the tree selector (or filter) menu
   no longer dismisses the menu;
2) As a side effect, Bug 965666 is fixed (opening a menu or help or
   the context menu closes any other open pop-up).
3) The Help menu now closes on Escape.