### PR TITLE
Remove case sensitivity checkbox.

### DIFF
--- a/dxr/app.py
+++ b/dxr/app.py
@@ -135,21 +135,19 @@ def search(tree):
     query_text = req.get('q', '')
     offset = non_negative_int(req.get('offset'), 0)
     limit = min(non_negative_int(req.get('limit'), 100), 1000)
-    is_case_sensitive = req.get('case') == 'true'
 
     # Make a Query:
     query = Query(partial(current_app.es.search,
                           index=frozen['es_alias']),
                   query_text,
-                  plugins_named(frozen['enabled_plugins']),
-                  is_case_sensitive=is_case_sensitive)
+                  plugins_named(frozen['enabled_plugins']))
 
     # Fire off one of the two search routines:
     searcher = _search_json if _request_wants_json() else _search_html
-    return searcher(query, tree, query_text, is_case_sensitive, offset, limit, config)
+    return searcher(query, tree, query_text, offset, limit, config)
 
 
-def _search_json(query, tree, query_text, is_case_sensitive, offset, limit, config):
+def _search_json(query, tree, query_text, offset, limit, config):
     """Try a "direct search" (for exact identifier matches, etc.). If we have a direct hit,
     then return {redirect: hit location}.If that doesn't work, fall back to a normal search
     and return the results as JSON."""
@@ -165,8 +163,6 @@ def _search_json(query, tree, query_text, is_case_sensitive, offset, limit, conf
                 'path': path,
                 'from': query_text
             }
-            if is_case_sensitive:
-                params['case'] = 'true'
             return jsonify({'redirect': url_for('.browse', _anchor=line, **params)})
     try:
         count_and_results = query.results(offset, limit)
@@ -185,10 +181,10 @@ def _search_json(query, tree, query_text, is_case_sensitive, offset, limit, conf
         'results': results,
         'result_count': count_and_results['result_count'],
         'result_count_formatted': format_number(count_and_results['result_count']),
-        'tree_tuples': _tree_tuples(query_text, is_case_sensitive)})
+        'tree_tuples': _tree_tuples(query_text)})
 
 
-def _search_html(query, tree, query_text, is_case_sensitive, offset, limit, config):
+def _search_html(query, tree, query_text, offset, limit, config):
     """Return the rendered template for search.html.
 
     """
@@ -200,7 +196,6 @@ def _search_html(query, tree, query_text, is_case_sensitive, offset, limit, conf
                 plugins_named(frozen['enabled_plugins'])),
             'generated_date': frozen['generated_date'],
             'google_analytics_key': config.google_analytics_key,
-            'is_case_sensitive': is_case_sensitive,
             'query': query_text,
             'search_url': url_for('.search',
                                   tree=tree,
@@ -208,19 +203,18 @@ def _search_html(query, tree, query_text, is_case_sensitive, offset, limit, conf
                                   redirect='false'),
             'top_of_tree': url_for('.browse', tree=tree),
             'tree': tree,
-            'tree_tuples': _tree_tuples(query_text, is_case_sensitive),
+            'tree_tuples': _tree_tuples(query_text),
             'www_root': config.www_root}
 
     return render_template('search.html', **template_vars)
 
 
-def _tree_tuples(query_text, is_case_sensitive):
+def _tree_tuples(query_text):
     """Return a list of rendering info for Switch Tree menu items."""
     return [(f['name'],
              url_for('.search',
                      tree=f['name'],
-                     q=query_text,
-                     **({'case': 'true'} if is_case_sensitive else {})),
+                     q=query_text),
              f['description'])
             for f in frozen_configs()]
 

--- a/dxr/plugins/clang/tests/test_functions.py
+++ b/dxr/plugins/clang/tests/test_functions.py
@@ -27,19 +27,14 @@ class DefinitionTests(CSingleFileTestCase):
 
     def test_names(self):
         """Try searching for function names case-sensitively."""
-        self.found_line_eq(
-            'function:main', 'int <b>main</b>(int argc, char* argv[]) {')
-        self.found_line_eq(
-            'function:getHello', 'const char* <b>getHello</b>() {')
-        self.found_nothing(
-            'function:getHELLO')
+        self.found_line_eq('function:getHello', 'const char* <b>getHello</b>() {')
+        self.found_nothing('function:getHELLO')
 
     def test_names_caseless(self):
         """Try searching for function names case-insensitively."""
         self.found_line_eq(
-            'function:MAIN',
-            'int <b>main</b>(int argc, char* argv[]) {',
-            is_case_sensitive=False)
+            'function:main',
+            'int <b>main</b>(int argc, char* argv[]) {')
 
     def test_qualnames_unqualified(self):
         """Qualnames should be found when searching unqualified as well."""
@@ -59,7 +54,7 @@ class DefinitionTests(CSingleFileTestCase):
         this behavior and didn't expressly condemn it.
 
         """
-        self.found_nothing('+function:SPACE::FOO(int)', is_case_sensitive=False)
+        self.found_nothing('+function:SPACE::FOO(int)')
 
 
 class TemplateClassMemberReferenceTests(CSingleFileTestCase):

--- a/dxr/plugins/python/tests/test_functions/test_functions.py
+++ b/dxr/plugins/python/tests/test_functions/test_functions.py
@@ -5,10 +5,6 @@ class FunctionDefTests(DxrInstanceTestCase):
     def test_simple_function(self):
         self.found_line_eq('function:foo', "def <b>foo</b>():", 2)
 
-    def test_case_insensitive(self):
-        self.found_line_eq('function:FOO', "def <b>foo</b>():", 2,
-                           is_case_sensitive=False)
-
     def test_methods_are_functions_too(self):
         self.found_line_eq('function:baz', "def <b>baz</b>(self):", 13)
 

--- a/dxr/plugins/rust/tests/test_data/test_data_types.py
+++ b/dxr/plugins/rust/tests/test_data/test_data_types.py
@@ -72,27 +72,27 @@ class DataTypesTests(RustDxrInstanceTestCase):
         #                      ("<b>EnumFields</b>::Nested(SomeFields { field1, field2 }) => {}", 43)])
 
     def test_struct_name_case_insensitive(self):
-        self.found_line_eq('type:nofields', "struct <b>NoFields</b>;", 6, is_case_sensitive=False)
-        self.found_line_eq('type:SOMEFIELDS', "struct <b>SomeFields</b> {", 8, is_case_sensitive=False)
-        self.found_line_eq('type:sfAlias', "type <b>SFAlias</b> = SomeFields;", 13, is_case_sensitive=False)
-        self.found_line_eq('type:ENUMfielDs', "enum <b>EnumFields</b> {", 15, is_case_sensitive=False)
+        self.found_line_eq('type:nofields', "struct <b>NoFields</b>;", 6)
+        self.found_line_eq('type:somefields', "struct <b>SomeFields</b> {", 8)
+        self.found_line_eq('type:sfalias', "type <b>SFAlias</b> = SomeFields;", 13)
+        self.found_line_eq('type:enumfields', "enum <b>EnumFields</b> {", 15)
 
     # FIXME qualname/case insensitive
     def test_struct_qual_name_case_insensitive(self):
         pass
-        #self.found_line_eq('+type:test::NOFIELDS', "struct <b>NoFields</b>;", 6, is_case_sensitive=False)
-        #self.found_line_eq('+type:TEST::somefieldS', "struct <b>SomeFields</b> {", 8, is_case_sensitive=False)
-        #self.found_line_eq('+type:test::sfalias', "type <b>SFAlias</b> = SomeFields;", 13, is_case_sensitive=False)
-        #self.found_line_eq('+type:tESt::enumFIELDS', "enum <b>EnumFields</b> {", 15, is_case_sensitive=False)
+        #self.found_line_eq('+type:test::NOFIELDS', "struct <b>NoFields</b>;", 6)
+        #self.found_line_eq('+type:TEST::somefieldS', "struct <b>SomeFields</b> {", 8)
+        #self.found_line_eq('+type:test::sfalias', "type <b>SFAlias</b> = SomeFields;", 13)
+        #self.found_line_eq('+type:tESt::enumFIELDS', "enum <b>EnumFields</b> {", 15)
 
     def test_struct_ref_case_insensitive(self):
-        self.found_lines_eq('type-ref:Nofields',
+        self.found_lines_eq('type-ref:nofields',
                             [("field2: <b>NoFields</b>,", 10),
                              ("field2: <b>NoFields</b> },", 19),
                              ("let _a = <b>NoFields</b>;", 24),
                              ("let b = SomeFields { field1: 42, field2: <b>NoFields</b> };", 26),
-                             ("let c = SFAlias { field1: 42, field2: <b>NoFields</b> };", 32)], is_case_sensitive=False)
-        self.found_lines_eq('type-ref:SomeFields',
+                             ("let c = SFAlias { field1: 42, field2: <b>NoFields</b> };", 32)])
+        self.found_lines_eq('type-ref:somefields',
                             [("type SFAlias = <b>SomeFields</b>;", 13),
                              ("Nested(<b>SomeFields</b>),", 20),
                              ("let b = <b>SomeFields</b> { field1: 42, field2: NoFields };", 26),
@@ -100,7 +100,7 @@ class DataTypesTests(RustDxrInstanceTestCase):
                              #("let <b>SomeFields</b> { field1: b1, field2: b2 } = b;", 29),
                              #("let <b>SomeFields</b> { field1, field2 } = b;", 30),
                              ("let c = <b>SFAlias</b> { field1: 42, field2: NoFields };", 32),
-                             ("EnumFields::Nested(<b>SomeFields</b> { field1, field2 }) =&gt; {}", 43)], is_case_sensitive=False)
+                             ("EnumFields::Nested(<b>SomeFields</b> { field1, field2 }) =&gt; {}", 43)])
         # TODO not handling aliases
         #self.found_lines_eq('type-ref:SFAlias',
         #                    [("let c = <b>SFAlias</b> { field1: 42, field2: NoFields };", 32),
@@ -122,7 +122,7 @@ class DataTypesTests(RustDxrInstanceTestCase):
         #                      ("field2: <b>NoFields</b> },", 19),
         #                      ("let _a = <b>NoFields</b>;", 24),
         #                      ("let b = SomeFields { field1: 42, field2: <b>NoFields</b> };", 26),
-        #                      ("let c = SFAlias { field1: 42, field2: <b>NoFields</b> };", 32)], is_case_sensitive=False)
+        #                      ("let c = SFAlias { field1: 42, field2: <b>NoFields</b> };", 32)])
         # self.found_lines_eq('+type-ref:test::SOMEFIELDS',
         #                     [("type SFAlias = <b>SomeFields</b>;", 13),
         #                      ("Nested(<b>SomeFields</b>),", 20),
@@ -131,7 +131,7 @@ class DataTypesTests(RustDxrInstanceTestCase):
         #                      #("let <b>SomeFields</b> { field1: b1, field2: b2 } = b;", 29),
         #                      #("let <b>SomeFields</b> { field1, field2 } = b;", 30),
         #                      ("let c = <b>SFAlias</b> { field1: 42, field2: NoFields };", 32),
-        #                      ("EnumFields::Nested(<b>SomeFields</b> { field1, field2 }) =&gt; {}", 43)], is_case_sensitive=False)
+        #                      ("EnumFields::Nested(<b>SomeFields</b> { field1, field2 }) =&gt; {}", 43)])
         # TODO not handling aliases
         #self.found_lines_eq('+type-ref:test::SFAlias',
         #                    [("let c = <b>SFAlias</b> { field1: 42, field2: NoFields };", 32),

--- a/dxr/plugins/rust/tests/test_data/test_fields.py
+++ b/dxr/plugins/rust/tests/test_data/test_fields.py
@@ -80,12 +80,12 @@ class FieldsTests(RustDxrInstanceTestCase):
 
     # TODO case insensitive
     def test_qual_field_case_insensitive(self):
-        self.found_line_eq('+var:test::SomeFields::field1', "<b>field1</b>: i32,", 9, is_case_sensitive=False)
-        self.found_line_eq('+var:test::SomeFields::field2', "<b>field2</b>: NoFields,", 10, is_case_sensitive=False)
+        self.found_line_eq('+var:test::SomeFields::field1', "<b>field1</b>: i32,", 9)
+        self.found_line_eq('+var:test::SomeFields::field2', "<b>field2</b>: NoFields,", 10)
 
     def test_qual_enum_field_case_insensitive(self):
-        self.found_line_eq('+var:test::EnumFields::Struct::field1', "Struct{ <b>field1</b>: i32,", 18, is_case_sensitive=False)
-        self.found_line_eq('+var:test::EnumFields::Struct::field2', "<b>field2</b>: NoFields },", 19, is_case_sensitive=False)
+        self.found_line_eq('+var:test::EnumFields::Struct::field1', "Struct{ <b>field1</b>: i32,", 18)
+        self.found_line_eq('+var:test::EnumFields::Struct::field2', "<b>field2</b>: NoFields },", 19)
 
     def test_field_case_insensitive(self):
         # Note the apparent field refs here, these are actually new variables
@@ -95,13 +95,13 @@ class FieldsTests(RustDxrInstanceTestCase):
                                            ("let SomeFields { <b>field1</b>, field2 } = b;", 30),
                                            ("let SFAlias { <b>field1</b>, field2 } = c;", 36),
                                            ("EnumFields::Struct{ <b>field1</b>, field2 } =&gt; {}", 42),
-                                           ("EnumFields::Nested(SomeFields { <b>field1</b>, field2 }) =&gt; {}", 43)], is_case_sensitive=False)
+                                           ("EnumFields::Nested(SomeFields { <b>field1</b>, field2 }) =&gt; {}", 43)])
         self.found_lines_eq('var:field2', [("<b>field2</b>: NoFields,", 10),
                                            ("<b>field2</b>: NoFields },", 19),
                                            ("let SomeFields { field1, <b>field2</b> } = b;", 30),
                                            ("let SFAlias { field1, <b>field2</b> } = c;", 36),
                                            ("EnumFields::Struct{ field1, <b>field2</b> } =&gt; {}", 42),
-                                           ("EnumFields::Nested(SomeFields { field1, <b>field2</b> }) =&gt; {}", 43)], is_case_sensitive=False)
+                                           ("EnumFields::Nested(SomeFields { field1, <b>field2</b> }) =&gt; {}", 43)])
 
     def test_qual_field_ref_case_insensitive(self):
         self.found_lines_eq('+var-ref:test::SomeFields::field1',
@@ -113,7 +113,7 @@ class FieldsTests(RustDxrInstanceTestCase):
                              ("let _ = c.<b>field1</b>;", 33),
                              ("let SFAlias { <b>field1</b>: c1, field2: c2 } = c;", 35),
                              ("let SFAlias { <b>field1</b>, field2 } = c;", 36),
-                             ("EnumFields::Nested(SomeFields { <b>field1</b>, field2 }) =&gt; {}", 43)], is_case_sensitive=False)
+                             ("EnumFields::Nested(SomeFields { <b>field1</b>, field2 }) =&gt; {}", 43)])
 
         self.found_lines_eq('+var-ref:test::SomeFields::field2',
                             [("let b = SomeFields { field1: 42, <b>field2</b>: NoFields };", 26),
@@ -124,11 +124,11 @@ class FieldsTests(RustDxrInstanceTestCase):
                              ("let _ = c.<b>field2</b>;", 34),
                              ("let SFAlias { field1: c1, <b>field2</b>: c2 } = c;", 35),
                              ("let SFAlias { field1, <b>field2</b> } = c;", 36),
-                             ("EnumFields::Nested(SomeFields { field1, <b>field2</b> }) =&gt; {}", 43)], is_case_sensitive=False)
+                             ("EnumFields::Nested(SomeFields { field1, <b>field2</b> }) =&gt; {}", 43)])
 
     def test_qual_enum_field_ref_case_insensitive(self):
-        self.found_line_eq('+var-ref:test::EnumFields::Struct::field1', "EnumFields::Struct{ <b>field1</b>, field2 } =&gt; {}", 42, is_case_sensitive=False)
-        self.found_line_eq('+var-ref:test::EnumFields::Struct::field2', "EnumFields::Struct{ field1, <b>field2</b> } =&gt; {}", 42, is_case_sensitive=False)
+        self.found_line_eq('+var-ref:test::EnumFields::Struct::field1', "EnumFields::Struct{ <b>field1</b>, field2 } =&gt; {}", 42)
+        self.found_line_eq('+var-ref:test::EnumFields::Struct::field2', "EnumFields::Struct{ field1, <b>field2</b> } =&gt; {}", 42)
 
     def test_field_ref_case_insensitive(self):
         raise SkipTest('probably due to errors in rustc')
@@ -142,7 +142,7 @@ class FieldsTests(RustDxrInstanceTestCase):
                              ("let SFAlias { <b>field1</b>: c1, field2: c2 } = c;", 35),
                              ("let SFAlias { <b>field1</b>, field2 } = c;", 36),
                              ("EnumFields::Struct{ <b>field1</b>, field2 } =&gt; {}", 42),
-                             ("EnumFields::Nested(SomeFields { <b>field1</b>, field2 }) =&gt; {}", 43)], is_case_sensitive=False)
+                             ("EnumFields::Nested(SomeFields { <b>field1</b>, field2 }) =&gt; {}", 43)])
         self.found_lines_eq('var-ref:field2',
                             [("let b = SomeFields { field1: 42, <b>field2</b>: NoFields };", 26),
                              ("let _ = b.<b>field2</b>;", 28),
@@ -153,4 +153,4 @@ class FieldsTests(RustDxrInstanceTestCase):
                              ("let SFAlias { field1: c1, <b>field2</b>: c2 } = c;", 35),
                              ("let SFAlias { field1, <b>field2</b> } = c;", 36),
                              ("EnumFields::Struct{ field1, <b>field2</b> } =&gt; {}", 42),
-                             ("EnumFields::Nested(SomeFields { field1, <b>field2</b> }) =&gt; {}", 43)], is_case_sensitive=False)
+                             ("EnumFields::Nested(SomeFields { field1, <b>field2</b> }) =&gt; {}", 43)])

--- a/dxr/plugins/rust/tests/test_fns/test_fns.py
+++ b/dxr/plugins/rust/tests/test_fns/test_fns.py
@@ -4,10 +4,6 @@ class FunctionTests(RustDxrInstanceTestCase):
     def test_simple_function(self):
         self.found_line_eq('function:foo', "fn <b>foo</b>() {", 3)
 
-    def test_case_insensitive(self):
-        self.found_line_eq('function:FOO', "fn <b>foo</b>() {", 3,
-                           is_case_sensitive=False)
-
     def test_methods_are_functions_too(self):
         # Test a method in an inherant impl.
         self.found_line_eq('function:baz', "fn <b>baz</b>(&amp;self) {}", 10)
@@ -47,8 +43,7 @@ class FunctionTests(RustDxrInstanceTestCase):
 
     # FIXME this fails, but test::foo works, so I think qualname searches with case insensitive is broken
     #def test_case_insensitive_qual(self):
-    #    self.found_line_eq('+function:TEST::FOO', "fn <b>foo</b>() {", 3,
-    #                       is_case_sensitive=False)
+    #    self.found_line_eq('+function:TEST::FOO', "fn <b>foo</b>() {", 3)
 
     # FIXME should be test::<Baz>::baz
     def test_methods_are_functions_too_qual(self):

--- a/dxr/plugins/rust/tests/test_traits/test_generics.py
+++ b/dxr/plugins/rust/tests/test_traits/test_generics.py
@@ -19,20 +19,20 @@ class GenericsTests(RustDxrInstanceTestCase):
 
     def test_generic_def_case_insensitive(self):
         # FIXME(#23) perhaps better not to need the scope id for type variables
-        self.found_line_eq('type:x$23', "fn foo&lt;<b>X</b>: Foo&gt;(x: &amp;X) {}", 11, is_case_sensitive = False)
+        self.found_line_eq('type:x$23', "fn foo&lt;<b>X</b>: Foo&gt;(x: &amp;X) {}", 11)
 
     def test_generic_ref_case_insensitive(self):
         # FIXME(#23) perhaps better not to need the scope id for type variables
-        self.found_line_eq('type-ref:x$23', "fn foo&lt;X: Foo&gt;(x: &amp;<b>X</b>) {}", 11, is_case_sensitive = False)
+        self.found_line_eq('type-ref:x$23', "fn foo&lt;X: Foo&gt;(x: &amp;<b>X</b>) {}", 11)
 
     def test_generic_def_qual_case_insensitive(self):
         # FIXME(#23) perhaps better not to need the scope id for type variables
-        # self.found_line_eq('+type:TEST::Foo::X$25', "fn foo&lt;<b>X</b>: Foo&gt;(x: &amp;X) {}", 11, is_case_sensitive = False)
+        # self.found_line_eq('+type:TEST::Foo::X$25', "fn foo&lt;<b>X</b>: Foo&gt;(x: &amp;X) {}", 11)
         # TODO qualname/case sensitivity bug
         pass
 
     def test_generic_ref_qual_case_insensitive(self):
         # FIXME(#23) perhaps better not to need the scope id for type variables
-        # self.found_line_eq('+type-ref:test::foo::x$25', "fn foo&lt;X: Foo&gt;(x: &amp;<b>X</b>) {}", 11, is_case_sensitive = False)
+        # self.found_line_eq('+type-ref:test::foo::x$25', "fn foo&lt;X: Foo&gt;(x: &amp;<b>X</b>) {}", 11)
         # TODO qualname/case sensitivity bug
         pass

--- a/dxr/static_unhashed/css/dxr.css
+++ b/dxr/static_unhashed/css/dxr.css
@@ -315,13 +315,6 @@ mark {
     flex: 9;
     position: relative;
 }
-.case {
-    -webkit-flex: 1;
-    flex: 1;
-    padding: 0 1rem;
-    min-width: 9rem;
-    align-self: center;
-}
 .basic_search {
     position: absolute;
     top: 80%;

--- a/dxr/static_unhashed/css/forms.css
+++ b/dxr/static_unhashed/css/forms.css
@@ -27,6 +27,3 @@ input[type="text"] {
     padding-right: 8rem;
     transition: padding-right .2s;
 }
-.checkbox_case {
-    margin: .5em;
-}

--- a/dxr/static_unhashed/js/context_menu.js
+++ b/dxr/static_unhashed/js/context_menu.js
@@ -120,7 +120,7 @@ $(function() {
 
             // If the regex did not find a start index, start from index 0
             if (startIndex === -1) {
-                start = 0;
+                startIndex = 0;
             }
 
             // If the regex did not find an end index, end at the position
@@ -145,7 +145,7 @@ $(function() {
             var contextMenu = {},
                 menuItems = [{
                     html: 'Search for the substring <strong>' + htmlEscape(word) + '</strong>',
-                    href: dxr.wwwRoot + "/" + encodeURIComponent(dxr.tree) + "/search?q=" + encodeURIComponent(word) + "&case=true",
+                    href: dxr.wwwRoot + "/" + encodeURIComponent(dxr.tree) + "/search?q=" + encodeURIComponent(word),
                     icon: 'search'
                 }];
 

--- a/dxr/static_unhashed/js/dxr.js
+++ b/dxr/static_unhashed/js/dxr.js
@@ -83,15 +83,6 @@ $(function() {
     }
 
     /**
-     * If the `case` param is in the URL, returns its boolean value. Otherwise,
-     * returns null.
-     */
-    function caseFromUrl() {
-        var match = /[?&]?case=([^&]+)/.exec(location.search);
-        return match ? (match[1] === 'true') : null;
-    }
-
-    /**
      * Represents the path line displayed next to the file path label on individual document pages.
      * Also handles population of the path lines template in the correct format.
      *
@@ -130,7 +121,6 @@ $(function() {
     var searchForm = $('#basic_search'),
         queryField = $('#query'),
         query = null,
-        caseSensitiveBox = $('#case'),
         contentContainer = $('#content'),
         waiter = null,
         historyWaiter = null,
@@ -147,14 +137,9 @@ $(function() {
     var fromQuery = /[?&]?from=([^&]+)/.exec(location.search);
     if (fromQuery !== null) {
         // Offer the user the option to see all the results instead.
-        var viewResultsTxt = 'Showing a direct result. <a href="{{ url }}">Show all results instead.</a>',
-            isCaseSensitive = caseFromUrl();
+        var viewResultsTxt = 'Showing a direct result. <a href="{{ url }}">Show all results instead.</a>';
 
         var searchUrl = constants.data('search') + '?q=' + fromQuery[1];
-        if (isCaseSensitive !== null) {
-            searchUrl += '&case=' + isCaseSensitive;
-        }
-
         queryField.val(decodeURIComponent(fromQuery[1]));
         showBubble('info', viewResultsTxt.replace('{{ url }}', searchUrl));
     }
@@ -167,17 +152,15 @@ $(function() {
      * Return the full Ajax URL for search.
      *
      * @param {string} query - The query string
-     * @param {bool} isCaseSensitive - Whether the query should be case-sensitive
      * @param {int} limit - The number of results to return.
      * @param {int} offset - The cursor position
      * @param {bool} redirect - Whether to redirect.
      */
-    function buildAjaxURL(query, isCaseSensitive, limit, offset, redirect) {
+    function buildAjaxURL(query, limit, offset, redirect) {
         var search = dxr.searchUrl;
         var params = {};
         params.q = query;
         params.redirect = redirect;
-        params['case'] = isCaseSensitive;
         params.limit = limit;
         params.offset = offset;
 
@@ -218,7 +201,7 @@ $(function() {
                 previousDataLimit = defaultDataLimit;
 
                 // Resubmit query for the next set of results, making sure redirect is turned off.
-                var requestUrl = buildAjaxURL(query, caseSensitiveBox.prop('checked'), defaultDataLimit, dataOffset, false);
+                var requestUrl = buildAjaxURL(query, defaultDataLimit, dataOffset, false);
                 doQuery(false, requestUrl, true);
             }
         }
@@ -249,14 +232,6 @@ $(function() {
     }
 
     /**
-     * Saves checkbox checked property to localStorage and invokes queryNow function.
-     */
-    function updateLocalStorageAndQueryNow(){
-       localStorage.setItem('caseSensitive', $('#case').prop('checked'));
-       queryNow();
-    }
-
-    /**
      * Clears any existing query timer and queries immediately.
      */
     function queryNow(redirect) {
@@ -275,8 +250,7 @@ $(function() {
         data.top_of_tree = dxr.wwwRoot + '/' + data.tree + '/source/';
 
         var params = {
-            q: data.query,
-            case: data.is_case_sensitive
+            q: data.query
         };
         data.query_string = $.param(params);
 
@@ -348,9 +322,13 @@ $(function() {
             limit = Math.floor((window.innerHeight / lineHeight) + 25);
 
         redirect = redirect || false;
+<<<<<<< HEAD:dxr/static_unhashed/js/dxr.js
         // Turn into a boolean if it was undefined.
         appendResults = !!appendResults;
         queryString = queryString || buildAjaxURL(query, caseSensitiveBox.prop('checked'), limit, 0, redirect);
+=======
+        queryString = queryString || buildAjaxURL(query, limit, 0, redirect);
+>>>>>>> d88f040... Remove case sensitivity checkbox.:dxr/static/js/dxr.js
         function oneMoreRequest() {
             if (requestsInFlight === 0) {
                 $('#search-box').addClass('in-progress');
@@ -440,20 +418,6 @@ $(function() {
         event.preventDefault();
         queryNow(true);
     });
-
-    // Update the search when the case-sensitive box is toggled, canceling any pending query:
-    caseSensitiveBox.on('change', updateLocalStorageAndQueryNow);
-
-
-    var urlCaseSensitive = caseFromUrl();
-    if (urlCaseSensitive !== null) {
-        // Any case-sensitivity specification in the URL overrides what was in localStorage:
-        localStorage.setItem('caseSensitive', urlCaseSensitive);
-    } else {
-        // Restore checkbox state from localStorage:
-        caseSensitiveBox.prop('checked', 'true' === localStorage.getItem('caseSensitive'));
-    }
-
 
     // Toggle the help box when the help icon is clicked, and hide it when
     // anything outside of the box is clicked.

--- a/dxr/templates/layout.html
+++ b/dxr/templates/layout.html
@@ -63,12 +63,6 @@
                           </ul>
                         </div>
                     </div>
-
-                    <div class="elem_container case">
-                        <label for="case">
-                            <input type="checkbox" name="case" id="case" class="checkbox_case" value="true" accesskey="c"{% if is_case_sensitive %} checked{% endif %} /><span class="access-key">C</span>ase-sensitive
-                        </label>
-                    </div>
                 </div>
             </fieldset>
 

--- a/dxr/testing.py
+++ b/dxr/testing.py
@@ -88,20 +88,17 @@ class TestCase(unittest.TestCase):
         """Return the text of a source page."""
         return self.client().get('/code/source/%s' % path).data
 
-    def found_files(self, query, is_case_sensitive=True):
+    def found_files(self, query):
         """Return the set of paths of files found by a search query."""
         return set(result['path'] for result in
-                   self.search_results(query,
-                                       is_case_sensitive=is_case_sensitive))
+                   self.search_results(query))
 
-    def found_files_eq(self, query, filenames, is_case_sensitive=True):
+    def found_files_eq(self, query, filenames):
         """Assert that executing the search ``query`` finds the paths
         ``filenames``."""
-        eq_(self.found_files(query,
-                             is_case_sensitive=is_case_sensitive),
-            set(filenames))
+        eq_(self.found_files(query), set(filenames))
 
-    def found_line_eq(self, query, content, line, is_case_sensitive=True):
+    def found_line_eq(self, query, content, line):
         """Assert that a query returns a single file and single matching line
         and that its line number and content are as expected, modulo leading
         and trailing whitespace.
@@ -111,15 +108,12 @@ class TestCase(unittest.TestCase):
         zillion dereferences in your test.
 
         """
-        self.found_lines_eq(query,
-                            [(content, line)],
-                            is_case_sensitive=is_case_sensitive)
+        self.found_lines_eq(query, [(content, line)])
 
-    def found_lines_eq(self, query, expected_lines, is_case_sensitive=True):
+    def found_lines_eq(self, query, expected_lines):
         """Assert that a query returns a single file and that the highlighted
         lines are as expected, modulo leading and trailing whitespace."""
-        results = self.search_results(query,
-                                      is_case_sensitive=is_case_sensitive)
+        results = self.search_results(query)
         num_results = len(results)
         eq_(num_results, 1, msg='Query passed to found_lines_eq() returned '
                                  '%s files, not one.' % num_results)
@@ -127,23 +121,21 @@ class TestCase(unittest.TestCase):
         eq_([(line['line'].strip(), line['line_number']) for line in lines],
             expected_lines)
 
-    def found_nothing(self, query, is_case_sensitive=True):
+    def found_nothing(self, query):
         """Assert that a query returns no hits."""
-        results = self.search_results(query,
-                                      is_case_sensitive=is_case_sensitive)
+        results = self.search_results(query)
         eq_(results, [])
 
-    def search_response(self, query, is_case_sensitive=True):
+    def search_response(self, query):
         """Return the raw response of a JSON search query."""
         return self.client().get(
             self.url_for('.search',
                          tree='code',
                          q=query,
-                         redirect='false',
-                         case='true' if is_case_sensitive else 'false'),
+                         redirect='false'),
             headers={'Accept': 'application/json'})
 
-    def direct_result_eq(self, query, path, line_number, is_case_sensitive=True):
+    def direct_result_eq(self, query, path, line_number):
         """Assert that a direct result exists and takes the user to the given
         path at the given line number.
 
@@ -154,8 +146,7 @@ class TestCase(unittest.TestCase):
             self.url_for('.search',
                          tree='code',
                          q=query,
-                         redirect='true',
-                         case='true' if is_case_sensitive else 'false'),
+                         redirect='true'),
             headers={'Accept': 'application/json'})
         eq_(response.status_code, 200)
         try:
@@ -169,7 +160,7 @@ class TestCase(unittest.TestCase):
             ok_('#' not in location)
         else:
             # Location is something like
-            # /code/source/main.cpp?from=main.cpp:6&case=true#6.
+            # /code/source/main.cpp?from=main.cpp:6#6.
             eq_(int(location[location.index('#') + 1:]), line_number)
 
     def is_not_direct_result(self, query):
@@ -179,13 +170,12 @@ class TestCase(unittest.TestCase):
             self.url_for('.search',
                          tree='code',
                          q=query,
-                         redirect='true',
-                         case='true'),
+                         redirect='true'),
             headers={'Accept': 'application/json'})
         eq_(response.status_code, 200)
         ok_('redirect' not in json.loads(response.data))
 
-    def search_results(self, query, is_case_sensitive=True):
+    def search_results(self, query):
         """Return the raw results of a JSON search query.
 
         Example::
@@ -204,8 +194,7 @@ class TestCase(unittest.TestCase):
           ]
 
         """
-        response = self.search_response(query,
-                                        is_case_sensitive=is_case_sensitive)
+        response = self.search_response(query)
         return json.loads(response.data)['results']
 
     def clang_at_least(self, version):
@@ -341,7 +330,7 @@ class SingleFileTestCase(TestCase):
                 0,
                 self.source.index(self._source_for_query(content))) + 1
 
-    def found_line_eq(self, query, content, line=None, is_case_sensitive=True):
+    def found_line_eq(self, query, content, line=None):
         """A specialization of ``found_line_eq`` that computes the line number
         if not given
 
@@ -353,9 +342,9 @@ class SingleFileTestCase(TestCase):
         if not line:
             line = self._guess_line(content)
         super(SingleFileTestCase, self).found_line_eq(
-                query, content, line, is_case_sensitive=is_case_sensitive)
+                query, content, line)
 
-    def found_lines_eq(self, query, expected_lines, is_case_sensitive=True):
+    def found_lines_eq(self, query, expected_lines):
         """A specialization of ``found_lines_eq`` that computes the line
         numbers if not given
 
@@ -374,15 +363,13 @@ class SingleFileTestCase(TestCase):
             return line
 
         expected_pairs = map(to_pair, expected_lines)
-        super(SingleFileTestCase, self).found_lines_eq(
-                query, expected_pairs, is_case_sensitive=is_case_sensitive)
+        super(SingleFileTestCase, self).found_lines_eq(query, expected_pairs)
 
     def direct_result_eq(self, query, line_number, is_case_sensitive=True):
         return super(SingleFileTestCase, self).direct_result_eq(
             query,
             self.source_filename,
-            line_number,
-            is_case_sensitive=is_case_sensitive)
+            line_number)
 
 
 def _make_file(path, filename, contents):

--- a/tests/test_basic/test_basic.py
+++ b/tests/test_basic/test_basic.py
@@ -30,11 +30,8 @@ class BasicTests(DxrInstanceTestCase):
         This tests trilite's substr-extents query type.
 
         """
-        self.found_files_eq('really',
-                            ['README.mkd'],
-                            is_case_sensitive=True)
-        self.found_nothing('REALLY',
-                           is_case_sensitive=True)
+        self.found_files_eq('really', ['README.mkd'])
+        self.found_nothing('REALLY')
 
     def test_case_insensitive(self):
         """Test case-insensitive free-text searching without extents.
@@ -44,8 +41,7 @@ class BasicTests(DxrInstanceTestCase):
         This tests trilite's isubstr query type.
 
         """
-        results = self.search_results(
-            'path:makefile -CODE', is_case_sensitive=False)
+        results = self.search_results('path:makefile -code')
         eq_(results,
             [{"path": "makefile",
               "lines": [
@@ -62,9 +58,7 @@ class BasicTests(DxrInstanceTestCase):
         This tests trilite's isubstr-extents query type.
 
         """
-        self.found_files_eq('MAIN',
-                            ['main.c', 'makefile'],
-                            is_case_sensitive=False)
+        self.found_files_eq('main', ['main.c', 'makefile'])
 
     def test_index(self):
         """Make sure the index controller redirects."""

--- a/tests/test_query_parser.py
+++ b/tests/test_query_parser.py
@@ -114,7 +114,7 @@ class VisitorTests(TestCase):
             [{'arg': 'Snork',
               'name': 'type',
               'not': False,
-              'case_sensitive': False,
+              'case_sensitive': True,
               'qualified': True}])
 
     def test_unclosed_quotes(self):

--- a/tests/test_strings.py
+++ b/tests/test_strings.py
@@ -67,15 +67,13 @@ class RegexpTests(SingleFileTestCase):
 
     def test_case_sensitive(self):
         self.found_line_eq('regexp:" ?The ?"',
-                           '//<b> The </b>paddle-shaped tail is a dead giveaway.',
-                           is_case_sensitive=True)
+                           '//<b> The </b>paddle-shaped tail is a dead giveaway.')
 
     def test_case_insensitive(self):
         self.found_lines_eq(
             'regexp:sha[a-z]+d',
             [('// The paddle-<b>shaped</b> tail is a dead giveaway.', 2),
-             ("// We know it's you, <b>Shahad</b>.", 3)],
-            is_case_sensitive=False)
+             ("// We know it's you, <b>Shahad</b>.", 3)])
 
 
 


### PR DESCRIPTION
Remark: the previous PR, #460 targeted the 'es' branch, but that has since merged into 'master.' So I have to open a new PR. The contents should be the same.

If any text is uppercase, then assume case sensitive. Otherwise, assume it’s insensitive. Use an @ sigil in front of a text term to force case sensitive. This also gives us per-term case sensitivity.

Notes from 11/3:
- Create a 'case' operator modifier, and consider turning '+' and '-' into operators too (qual, not).
My initial idea is to expand the grammar to differentiate between "operators" (var, ref, id, etc.) which affect the *filter query* and "modifiers" (not, qual, case) which affect the *search term* itself.