### PR TITLE
Fix a bug which causes field and variable references to be self-links

### DIFF
--- a/dxr/plugins/rust/refs.py
+++ b/dxr/plugins/rust/refs.py
@@ -153,7 +153,7 @@ class VariableRefRef(_RustRef):
             else:
                 warn("no type for variable ref %s" % (var['qualname'],))
             self.hover = truncate_value(typ, var['value'])
-            return trim_dict(datum, ['file_line', 'file_name', 'qualname'])
+            return trim_dict(var, ['file_line', 'file_name', 'qualname'])
         # TODO what is the culprit here?
         # print "variable ref missing def"
 

--- a/dxr/plugins/rust/tests/__init__.py
+++ b/dxr/plugins/rust/tests/__init__.py
@@ -1,0 +1,14 @@
+from dxr.testing import SingleFileTestCase
+
+class RustSingleFileTestCase(SingleFileTestCase):
+    """Test case suited to testing the Rust plugin."""
+    source_filename = 'mod.rs'
+
+    @classmethod
+    def config_input(cls, config_dir_path):
+        config = super(RustSingleFileTestCase, cls).config_input(config_dir_path)
+
+        config['DXR']['enabled_plugins'] = 'pygmentize rust'
+        config['code']['build_command'] = '$RUSTC mod.rs'
+
+        return config

--- a/dxr/plugins/rust/tests/test_var_menus.py
+++ b/dxr/plugins/rust/tests/test_var_menus.py
@@ -1,0 +1,17 @@
+from dxr.plugins.rust.tests import RustSingleFileTestCase
+from dxr.testing import menu_on
+
+class VarMenuTests(RustSingleFileTestCase):
+    source = """
+    fn main() {
+        let _ = FOO;
+    }
+    const FOO: i32 = 42;
+    """
+
+    def test_const_link(self):
+        """ test that the link to defintion works properly """
+        menu_on(self.source_page('mod.rs'),
+                'FOO',
+                {'html': 'Jump to definition',
+                         'href': '/code/source/mod.rs#5'})


### PR DESCRIPTION
Can we test this? It only manifests when you click 'jump to definition' on a variable's menu.