### PR TITLE
Quadruple the speed of long page renders. Fixes bug #1216266.

### DIFF
--- a/dxr/app.py
+++ b/dxr/app.py
@@ -103,6 +103,10 @@ def make_app(config):
     app.register_blueprint(dxr_blueprint, url_prefix=config.www_root)
     HashedStatics(app=app)
 
+    # The url_prefix we pass when registering the blueprint is not stored
+    # anywhere. This saves gymnastics in our custom URL builders to get it back:
+    app.dxr_www_root = config.www_root
+
     # Log to Apache's error log in production:
     app.logger.addHandler(StreamHandler(stderr))
 

--- a/dxr/plugins/clang/menus.py
+++ b/dxr/plugins/clang/menus.py
@@ -2,11 +2,9 @@
 
 from os.path import basename
 
-from flask import url_for
-
 from dxr.app import DXR_BLUEPRINT
 from dxr.lines import Ref
-from dxr.utils import search_url, BROWSE
+from dxr.utils import browse_file_url, search_url
 
 
 def quote(qualname):
@@ -54,7 +52,7 @@ class _RefWithDefinition(_ClangRef):
         else:
             menu = [{'html': "Jump to definition",
                      'title': "Jump to the definition in '%s'" % basename(path),
-                     'href': url_for(BROWSE, tree=self.tree.name, path=path, _anchor=row),
+                     'href': browse_file_url(self.tree.name, path, _anchor=row),
                      'icon': 'jump'}]
         menu.extend(self._more_menu_items(self.menu_data[2:]))
         return menu
@@ -95,9 +93,7 @@ class IncludeRef(_ClangRef):
         # won't build pages for.
         yield {'html': 'Jump to file',
                'title': 'Jump to what is included here.',
-               'href': url_for(BROWSE,
-                               tree=self.tree.name,
-                               path=self.menu_data),
+               'href': browse_file_url(self.tree.name, self.menu_data),
                'icon': 'jump'}
 
 
@@ -114,7 +110,7 @@ class MacroRef(_RefWithDefinition):
 
     def _more_menu_items(self, (macro_name,)):
         yield {'html': 'Find references',
-               'href': search_url(self.tree, '+macro-ref:%s' % macro_name),
+               'href': search_url(self.tree.name, '+macro-ref:%s' % macro_name),
                'title': 'Find references to macros with this name',
                'icon': 'reference'}
 
@@ -130,24 +126,24 @@ class TypeRef(_QualnameRef):
         """Return menu for type reference."""
         yield {'html': "Find declarations",
                'title': "Find declarations of this class",
-               'href': search_url(self.tree, "+type-decl:%s" % quote(qualname)),
+               'href': search_url(self.tree.name, "+type-decl:%s" % quote(qualname)),
                'icon': 'reference'}
         if kind == 'class' or kind == 'struct':
             yield {'html': "Find subclasses",
                    'title': "Find subclasses of this class",
-                   'href': search_url(self.tree, "+derived:%s" % quote(qualname)),
+                   'href': search_url(self.tree.name, "+derived:%s" % quote(qualname)),
                    'icon': 'type'}
             yield {'html': "Find base classes",
                    'title': "Find base classes of this class",
-                   'href': search_url(self.tree, "+bases:%s" % quote(qualname)),
+                   'href': search_url(self.tree.name, "+bases:%s" % quote(qualname)),
                    'icon': 'type'}
         yield {'html': "Find members",
                'title': "Find members of this class",
-               'href': search_url(self.tree, "+member:%s" % quote(qualname)),
+               'href': search_url(self.tree.name, "+member:%s" % quote(qualname)),
                'icon': 'members'}
         yield {'html': "Find references",
                'title': "Find references to this class",
-               'href': search_url(self.tree, "+type-ref:%s" % quote(qualname)),
+               'href': search_url(self.tree.name, "+type-ref:%s" % quote(qualname)),
                'icon': 'reference'}
 
 
@@ -155,7 +151,7 @@ class TypedefRef(_QualnameRef):
     def _more_menu_items(self, (qualname,)):
         yield {'html': "Find references",
                'title': "Find references to this typedef",
-               'href': search_url(self.tree, "+type-ref:%s" % quote(qualname)),
+               'href': search_url(self.tree.name, "+type-ref:%s" % quote(qualname)),
                'icon': 'reference'}
 
 
@@ -163,11 +159,11 @@ class VariableRef(_QualnameRef):
     def _more_menu_items(self, (qualname,)):
         yield {'html': "Find declarations",
                'title': "Find declarations of this variable",
-               'href': search_url(self.tree, "+var-decl:%s" % quote(qualname)),
+               'href': search_url(self.tree.name, "+var-decl:%s" % quote(qualname)),
                'icon': 'reference'}
         yield {'html': "Find references",
                'title': "Find reference to this variable",
-               'href': search_url(self.tree, "+var-ref:%s" % quote(qualname)),
+               'href': search_url(self.tree.name, "+var-ref:%s" % quote(qualname)),
                'icon': 'field'}
 
 
@@ -175,11 +171,11 @@ class NamespaceRef(_QualnameRef):
     def _more_menu_items(self, (qualname,)):
         yield {'html': "Find definitions",
                'title': "Find definitions of this namespace",
-               'href': search_url(self.tree, "+namespace:%s" % quote(qualname)),
+               'href': search_url(self.tree.name, "+namespace:%s" % quote(qualname)),
                'icon': 'jump'}
         yield {'html': "Find references",
                'title': "Find references to this namespace",
-               'href': search_url(self.tree, "+namespace-ref:%s" % quote(qualname)),
+               'href': search_url(self.tree.name, "+namespace-ref:%s" % quote(qualname)),
                'icon': 'reference'}
 
 
@@ -188,7 +184,7 @@ class NamespaceAliasRef(_QualnameRef):
         """Build menu for a namespace."""
         yield {'html': "Find references",
                'title': "Find references to this namespace alias",
-               'href': search_url(self.tree, "+namespace-alias-ref:%s" % quote(qualname)),
+               'href': search_url(self.tree.name, "+namespace-alias-ref:%s" % quote(qualname)),
                'icon': 'reference'}
 
 
@@ -202,22 +198,22 @@ class FunctionRef(_RefWithDefinition):
     def _more_menu_items(self, (qualname, is_virtual)):
         yield {'html': "Find declarations",
                'title': "Find declarations of this function",
-               'href': search_url(self.tree, "+function-decl:%s" % quote(qualname)),
+               'href': search_url(self.tree.name, "+function-decl:%s" % quote(qualname)),
                'icon': 'reference'}
         yield {'html': "Find callers",
                'title': "Find functions that call this function",
-               'href': search_url(self.tree, "+callers:%s" % quote(qualname)),
+               'href': search_url(self.tree.name, "+callers:%s" % quote(qualname)),
                'icon': 'method'}
         yield {'html': "Find references",
                'title': "Find references to this function",
-               'href': search_url(self.tree, "+function-ref:%s" % quote(qualname)),
+               'href': search_url(self.tree.name, "+function-ref:%s" % quote(qualname)),
                'icon': 'reference'}
         if is_virtual:
             yield {'html': "Find overridden",
                    'title': "Find functions that this function overrides",
-                   'href': search_url(self.tree, "+overridden:%s" % quote(qualname)),
+                   'href': search_url(self.tree.name, "+overridden:%s" % quote(qualname)),
                    'icon': 'method'}
             yield {'html': "Find overrides",
                    'title': "Find overrides of this function",
-                   'href': search_url(self.tree, "+overrides:%s" % quote(qualname)),
+                   'href': search_url(self.tree.name, "+overrides:%s" % quote(qualname)),
                    'icon': 'method'}

--- a/dxr/plugins/python/menus.py
+++ b/dxr/plugins/python/menus.py
@@ -13,9 +13,9 @@ class ClassRef(Ref, _PythonPluginAttr):
         qualname = self.menu_data
         yield {'html': 'Find subclasses',
                'title': 'Find subclasses of this class',
-               'href': search_url(self.tree, '+derived:' + qualname),
+               'href': search_url(self.tree.name, '+derived:' + qualname),
                'icon': 'type'}
         yield {'html': 'Find base classes',
                'title': 'Find base classes of this class',
-               'href': search_url(self.tree, '+bases:' + qualname),
+               'href': search_url(self.tree.name, '+bases:' + qualname),
                'icon': 'type'}

--- a/dxr/plugins/rust/menu.py
+++ b/dxr/plugins/rust/menu.py
@@ -2,9 +2,7 @@ import os
 from functools import partial
 from warnings import warn
 
-from flask import url_for
-
-from dxr.utils import BROWSE, search_url
+from dxr.utils import browse_file_url, search_url
 
 
 def quote(qualname):
@@ -46,7 +44,7 @@ def find_references_menu_item(tree_config, qualname, filter_name, kind):
     """
     return {'html':   "Find references",
             'title':  "Find references to this " + kind,
-            'href':   search_url(tree_config, "+" + filter_name + ":%s" % quote(qualname)),
+            'href':   search_url(tree_config.name, "+" + filter_name + ":%s" % quote(qualname)),
             'icon':   'reference'}
 
 
@@ -79,7 +77,7 @@ def std_lib_links_menu((doc_url, src_url, dxr_url), extra_text=""):
 def call_menu(qualname, tree):
     return [{'html': "Find callers",
              'title': "Find calls of this function",
-             'href': search_url(tree, "+callers:%s" % quote(qualname)),
+             'href': search_url(tree.name, "+callers:%s" % quote(qualname)),
              'icon': 'method'}]
 
 
@@ -97,7 +95,7 @@ def jump_to_target_menu_item(tree_config, path, row, target_name):
     return {'html': 'Jump to %s' % target_name,
             'title': "Jump to %s in '%s'" % (target_name,
                                              os.path.basename(path)),
-            'href': url_for(BROWSE, tree=tree_config.name, path=path, _anchor=row),
+            'href': browse_file_url(tree_config.name, path, _anchor=row),
             'icon': 'jump'}
 
 def jump_to_target_from_decl(menu_maker, tree, decl):
@@ -128,7 +126,7 @@ jump_to_function_declaration_menu_item = partial(jump_to_target_menu_item, targe
 def trait_impl_menu_item(tree_config, qualname, count):
     return {'html': "Find implementations (%d)" % count,
             'title': "Find implementations of this trait method",
-            'href': search_url(tree_config, "+fn-impls:%s" % quote(qualname)),
+            'href': search_url(tree_config.name, "+fn-impls:%s" % quote(qualname)),
             'icon': 'method'}
 
 
@@ -140,16 +138,16 @@ def type_menu(tree_config, kind, qualname):
     if kind == 'trait':
         yield {'html': "Find sub-traits",
                'title': "Find sub-traits of this trait",
-               'href': search_url(tree_config, "+derived:%s" % quote(qualname)),
+               'href': search_url(tree_config.name, "+derived:%s" % quote(qualname)),
                'icon': 'type'}
         yield {'html': "Find super-traits",
                'title': "Find super-traits of this trait",
-               'href': search_url(tree_config, "+bases:%s" % quote(qualname)),
+               'href': search_url(tree_config.name, "+bases:%s" % quote(qualname)),
                'icon': 'type'}
     if kind == 'struct' or kind == 'enum' or kind == 'trait':
         yield {'html': "Find impls",
                'title': "Find impls which involve this " + kind,
-               'href': search_url(tree_config, "+impl:%s" % quote(qualname)),
+               'href': search_url(tree_config.name, "+impl:%s" % quote(qualname)),
                'icon': 'reference'}
 
 
@@ -164,7 +162,7 @@ def generic_type_menu(datum, tree_config):
 def use_items_menu_item(tree_config, qualname):
     return {'html': "Find use items",
             'title': "Find instances of this module in 'use' items",
-            'href': search_url(tree_config, "+module-use:%s" % quote(qualname)),
+            'href': search_url(tree_config.name, "+module-use:%s" % quote(qualname)),
             'icon': 'reference'}
 
 

--- a/dxr/plugins/xpidl/menus.py
+++ b/dxr/plugins/xpidl/menus.py
@@ -9,7 +9,7 @@ def filtered_search_menu(tree, term, html, title, filter_name, icon):
     return {
         'html': html,
         'title': title,
-        'href': search_url(tree, '%s:%s' % (filter_name, term)),
+        'href': search_url(tree.name, '%s:%s' % (filter_name, term)),
         'icon': icon
     }
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,9 +1,14 @@
+# -*- coding: utf-8 -*-
+
 from unittest import TestCase
 from datetime import datetime
 
 from nose.tools import eq_, assert_raises
 
-from dxr.utils import deep_update, append_update, append_update_by_line, append_by_line, glob_to_regex, decode_es_datetime
+from dxr.testing import TestCase
+from dxr.utils import (DXR_BLUEPRINT, append_update, append_update_by_line,
+                       append_by_line, browse_file_url, decode_es_datetime,
+                       deep_update, glob_to_regex, search_url)
 
 
 class DeepUpdateTests(TestCase):
@@ -99,3 +104,25 @@ def test_decode_es_datetime():
     eq_(datetime(1992, 6, 27, 0, 0), decode_es_datetime("1992-06-27T00:00:00"))
     eq_(datetime(1992, 6, 27, 0, 0, 0), decode_es_datetime("1992-06-27T00:00:00.0"))
 
+
+class UrlBuilderTests(TestCase):
+    """Tests for the speed-optimized URL builders"""
+
+    def test_tests(self):
+        """Make sure these tests keep up with the canonical URLs."""
+        eq_(self.url_for(DXR_BLUEPRINT + '.browse', tree='TREE', path='THE/PATH'),
+            '/TREE/source/THE/PATH')
+        eq_(self.url_for(DXR_BLUEPRINT + '.search', tree='TREE', q='QUERY'),
+            '/TREE/search?q=QUERY')
+
+    def test_browse_file_url(self):
+        """Test unicode of various widths, slashes, and spaces."""
+        with self.app().test_request_context():
+            eq_(browse_file_url(u'tr éé', u'ev il:päthß/ªre/bes†', _anchor=4),
+                '/tr%20%C3%A9%C3%A9/source/ev%20il%3Ap%C3%A4th%C3%9F/%C2%AAre/bes%E2%80%A0#4')
+
+    def test_search_url(self):
+        """Test unicode of various widths, slashes, and spaces."""
+        with self.app().test_request_context():
+            eq_(search_url(u'tr éé', u'ev il:searcheß/ªre/bes†'),
+            '/tr%20%C3%A9%C3%A9/search?q=ev+il%3Asearche%C3%9F%2F%C2%AAre%2Fbes%E2%80%A0')


### PR DESCRIPTION
Replace url_for() with simple, specialized implementations for tight loops. Leave it alone elsewhere, because I still trust the Flask version more.

Flask's url_for() does a lot of fancy adapter stuff. And then fully 1/3 of its run time is Werkzeug's custom impl of url_quote(), which iterates over each char in every substituted value and encodes them individually. I'm not sure what the advantage of that is: perhaps something Python-3-specific.

For the record, the alternative gymnastics for getting the blueprint's url_prefix was current_app.url_map._rules_by_endpoint['dxr_blueprint.index'][0].rule[:-1]. Just tacking a global onto the app was less likely to break, I judged.

I looked into using various methods to hook url_for() so I could still use it everywhere but specialize it in certain cases. The proper hooks weren't there, and using the improper ones (like overriding the Rule class) would bring in so much complexity as to not be worth the more uniform API.

TestCase is no longer abstract. Now it can serve for tests that need no build step: only an application context. Remove the calling order dependency between url_for() and client().

Stop passing entire TreeConfigs into the URL builders; they don't need them.