### PR TITLE
Move the remaining C++-specific assumptions out of dxr.testing.

### DIFF
--- a/dxr/plugins/clang/tests/__init__.py
+++ b/dxr/plugins/clang/tests/__init__.py
@@ -1,1 +1,21 @@
-"""Tests specific to the clang plugin"""
+from dxr.testing import SingleFileTestCase
+
+
+class CSingleFileTestCase(SingleFileTestCase):
+    source_filename = 'main.cpp'
+
+    @classmethod
+    def config_input(cls, config_dir_path):
+        input = super(CSingleFileTestCase, cls).config_input(config_dir_path)
+        input['DXR']['enabled_plugins'] = 'pygmentize clang'
+        input['code']['build_command'] = '$CXX -o main main.cpp'
+        return input
+
+
+# Tests that don't otherwise need a main() can append this one just to get
+# their code to compile:
+MINIMAL_MAIN = """
+    int main(int argc, char* argv[]) {
+        return 0;
+    }
+    """

--- a/dxr/plugins/clang/tests/test_callers.py
+++ b/dxr/plugins/clang/tests/test_callers.py
@@ -1,9 +1,9 @@
 """Tests for searches using callers"""
 
-from dxr.testing import SingleFileTestCase, MINIMAL_MAIN
+from dxr.plugins.clang.tests import CSingleFileTestCase, MINIMAL_MAIN
 
 
-class DirectCallTests(SingleFileTestCase):
+class DirectCallTests(CSingleFileTestCase):
     """Tests for searches involving direct calls"""
 
     source = r"""
@@ -48,7 +48,7 @@ class DirectCallTests(SingleFileTestCase):
             ('<b>called_twice()</b>;', 22)])
 
 
-class IndirectCallTests(SingleFileTestCase):
+class IndirectCallTests(CSingleFileTestCase):
     """Tests for searches involving indirect (virtual) calls"""
 
     source = r"""

--- a/dxr/plugins/clang/tests/test_decl.py
+++ b/dxr/plugins/clang/tests/test_decl.py
@@ -1,9 +1,9 @@
 """Tests for searches for declarations"""
 
-from dxr.testing import SingleFileTestCase, MINIMAL_MAIN
+from dxr.plugins.clang.tests import CSingleFileTestCase, MINIMAL_MAIN
 
 
-class TypeDeclarationTests(SingleFileTestCase):
+class TypeDeclarationTests(CSingleFileTestCase):
     """Tests for declarations of types"""
 
     source = r"""
@@ -19,7 +19,7 @@ class TypeDeclarationTests(SingleFileTestCase):
             'type-decl:MyClass', 'class <b>MyClass</b>;')
 
 
-class FunctionDeclarationTests(SingleFileTestCase):
+class FunctionDeclarationTests(CSingleFileTestCase):
     """Tests for declarations of functions"""
 
     source = r"""
@@ -35,7 +35,7 @@ class FunctionDeclarationTests(SingleFileTestCase):
             'function-decl:foo', 'void <b>foo</b>();')
 
 
-class VariableDeclarationTests(SingleFileTestCase):
+class VariableDeclarationTests(CSingleFileTestCase):
     """Tests for declarations of variables"""
 
     source = r"""

--- a/dxr/plugins/clang/tests/test_direct.py
+++ b/dxr/plugins/clang/tests/test_direct.py
@@ -1,12 +1,12 @@
 import os.path
 
 from dxr.query import Query
-from dxr.testing import SingleFileTestCase, MINIMAL_MAIN
+from dxr.plugins.clang.tests import CSingleFileTestCase, MINIMAL_MAIN
 
 from nose.tools import eq_
 
 
-class TypeAndMethodTests(SingleFileTestCase):
+class TypeAndMethodTests(CSingleFileTestCase):
     source = """
         class MemberFunction {
             public:
@@ -91,7 +91,7 @@ class TypeAndMethodTests(SingleFileTestCase):
         self.direct_result_eq('MemberFunction', 2)
 
 
-class MacroTypedefTests(SingleFileTestCase):
+class MacroTypedefTests(CSingleFileTestCase):
     source = """
         #ifndef MACRO_NAME
         #define MACRO_NAME(arg1, arg2) 0

--- a/dxr/plugins/clang/tests/test_functions.py
+++ b/dxr/plugins/clang/tests/test_functions.py
@@ -2,10 +2,10 @@
 
 from nose import SkipTest
 
-from dxr.testing import SingleFileTestCase, MINIMAL_MAIN
+from dxr.plugins.clang.tests import CSingleFileTestCase, MINIMAL_MAIN
 
 
-class DefinitionTests(SingleFileTestCase):
+class DefinitionTests(CSingleFileTestCase):
     """Tests for finding where functions are defined"""
 
     source = r"""
@@ -62,7 +62,7 @@ class DefinitionTests(SingleFileTestCase):
         self.found_nothing('+function:SPACE::FOO(int)', is_case_sensitive=False)
 
 
-class TemplateClassMemberReferenceTests(SingleFileTestCase):
+class TemplateClassMemberReferenceTests(CSingleFileTestCase):
     """Tests for finding out where member functions of a template class are referenced or declared"""
 
     source = r"""
@@ -100,7 +100,7 @@ class TemplateClassMemberReferenceTests(SingleFileTestCase):
                             [('Foo&lt;int&gt;().<b>bar</b>();', 16)])
 
 
-class ConstTests(SingleFileTestCase):
+class ConstTests(CSingleFileTestCase):
     source = """
         class ConstOverload
         {
@@ -125,7 +125,7 @@ class ConstTests(SingleFileTestCase):
                             'void ConstOverload::<b>foo</b>() const {')
 
 
-class PrototypeParamTests(SingleFileTestCase):
+class PrototypeParamTests(CSingleFileTestCase):
     source = """
         int prototype_parameter_function(int prototype_parameter);
 

--- a/dxr/plugins/clang/tests/test_inheritance.py
+++ b/dxr/plugins/clang/tests/test_inheritance.py
@@ -1,9 +1,9 @@
 """Tests for queries about superclasses and subclasses"""
 
-from dxr.testing import SingleFileTestCase, MINIMAL_MAIN
+from dxr.plugins.clang.tests import CSingleFileTestCase, MINIMAL_MAIN
 
 
-class InheritanceTests(SingleFileTestCase):
+class InheritanceTests(CSingleFileTestCase):
     source = r"""
         class A {
         };

--- a/dxr/plugins/clang/tests/test_macros.py
+++ b/dxr/plugins/clang/tests/test_macros.py
@@ -1,7 +1,7 @@
-from dxr.testing import SingleFileTestCase, MINIMAL_MAIN
+from dxr.plugins.clang.tests import CSingleFileTestCase, MINIMAL_MAIN
 
 
-class MacroTests(SingleFileTestCase):
+class MacroTests(CSingleFileTestCase):
     """Tests for ``macro`` queries"""
 
     source = """
@@ -19,7 +19,7 @@ class MacroTests(SingleFileTestCase):
         self.found_line_eq('macro:ADD', '#define <b>ADD</b>(x, y) ((x) + (y))')
 
 
-class MacroRefTests(SingleFileTestCase):
+class MacroRefTests(CSingleFileTestCase):
     """Tests for ``+macro-ref`` queries"""
 
     source = """
@@ -56,7 +56,7 @@ class MacroRefTests(SingleFileTestCase):
             ('#undef <b>MACRO</b>', 13)])
 
 
-class MacroArgumentReferenceTests(SingleFileTestCase):
+class MacroArgumentReferenceTests(CSingleFileTestCase):
     source = """
         #define ID2(x) (x)
         #define ID(x) ID2(x)
@@ -82,7 +82,7 @@ class MacroArgumentReferenceTests(SingleFileTestCase):
             ('ADD(x, <b>y</b>);', 12)])
 
 
-class MacroArgumentFieldReferenceTests(SingleFileTestCase):
+class MacroArgumentFieldReferenceTests(CSingleFileTestCase):
     source = """
         #define ID2(x) (x)
         #define ID(x) ID2(x)
@@ -115,7 +115,7 @@ class MacroArgumentFieldReferenceTests(SingleFileTestCase):
             ('FIELD(foo, <b>bar</b>);', 18)])
 
 
-class MacroArgumentDeclareTests(SingleFileTestCase):
+class MacroArgumentDeclareTests(CSingleFileTestCase):
 
     source = """
         #define ID2(x) x

--- a/dxr/plugins/clang/tests/test_members.py
+++ b/dxr/plugins/clang/tests/test_members.py
@@ -1,7 +1,7 @@
-from dxr.testing import SingleFileTestCase, MINIMAL_MAIN
+from dxr.plugins.clang.tests import CSingleFileTestCase, MINIMAL_MAIN
 
 
-class MemberVariableTests(SingleFileTestCase):
+class MemberVariableTests(CSingleFileTestCase):
     source = """
         class MemberVariable {
             public:
@@ -16,7 +16,7 @@ class MemberVariableTests(SingleFileTestCase):
                            'int <b>member_variable</b>;')
 
 
-class MemberVariableCtorTests(SingleFileTestCase):
+class MemberVariableCtorTests(CSingleFileTestCase):
     """Members that do not have an explicit initializer on the constructor
     should not show the constructor as having a reference to that member.
     There's no convenient place in the source to use for the extents for such
@@ -44,7 +44,7 @@ class MemberVariableCtorTests(SingleFileTestCase):
         self.found_line_eq('+var-ref:Foo::baz', 'Foo() : <b>baz</b>(0) {}')
 
 
-class MemberFunctionTests(SingleFileTestCase):
+class MemberFunctionTests(CSingleFileTestCase):
     source = """
         class MemberFunction {
             public:
@@ -62,7 +62,7 @@ class MemberFunctionTests(SingleFileTestCase):
                            u'void MemberFunction::<b>member_function</b>() {')
 
 
-class StaticMemberTests(SingleFileTestCase):
+class StaticMemberTests(CSingleFileTestCase):
     source = """
         class StaticMember {
             public:
@@ -76,7 +76,7 @@ class StaticMemberTests(SingleFileTestCase):
         self.found_line_eq('+var:StaticMember::static_member', 'int StaticMember::<b>static_member</b> = 0;')
 
 
-class MemberTests(SingleFileTestCase):
+class MemberTests(CSingleFileTestCase):
     # We could probably strip this down a fair bit:
     source = """
         #include <stdint.h>

--- a/dxr/plugins/clang/tests/test_namespaces.py
+++ b/dxr/plugins/clang/tests/test_namespaces.py
@@ -1,9 +1,9 @@
 """Tests for searches about namespaces"""
 
-from dxr.testing import SingleFileTestCase, MINIMAL_MAIN
+from dxr.plugins.clang.tests import CSingleFileTestCase, MINIMAL_MAIN
 
 
-class NamespaceDefTests(SingleFileTestCase):
+class NamespaceDefTests(CSingleFileTestCase):
     """Tests for finding definitions of namespaces"""
 
     source = r"""
@@ -22,7 +22,7 @@ class NamespaceDefTests(SingleFileTestCase):
         self.found_line_eq('+namespace:Outer::Inner', 'namespace <b>Inner</b> {')
 
 
-class NamespaceExprRefTests(SingleFileTestCase):
+class NamespaceExprRefTests(CSingleFileTestCase):
     """Tests for finding references to namespaces in expressions"""
 
     source = r"""
@@ -50,7 +50,7 @@ class NamespaceExprRefTests(SingleFileTestCase):
         self.found_line_eq('+namespace-ref:Outer::Inner', 'Outer::<b>Inner</b>::bar();')
 
 
-class NamespaceDeclRefTests(SingleFileTestCase):
+class NamespaceDeclRefTests(CSingleFileTestCase):
     """Tests for finding references to namespaces in declarations"""
 
     source = r"""
@@ -75,7 +75,7 @@ class NamespaceDeclRefTests(SingleFileTestCase):
         self.found_line_eq('+namespace-ref:Outer::Inner', 'Outer::<b>Inner</b>::MyClass *y;')
 
 
-class NamespaceUsingDirectiveTests(SingleFileTestCase):
+class NamespaceUsingDirectiveTests(CSingleFileTestCase):
     """Tests for the 'using' directive"""
 
     source = r"""
@@ -94,7 +94,7 @@ class NamespaceUsingDirectiveTests(SingleFileTestCase):
         self.found_line_eq('+namespace-ref:Outer::Inner', 'using namespace Outer::<b>Inner</b>;')
 
 
-class NamespaceUsingDeclarationTests(SingleFileTestCase):
+class NamespaceUsingDeclarationTests(CSingleFileTestCase):
     """Tests for the 'using' declaration"""
 
     source = r"""
@@ -121,7 +121,7 @@ class NamespaceUsingDeclarationTests(SingleFileTestCase):
         self.found_line_eq('+namespace-ref:Outer::Inner', 'using Outer::<b>Inner</b>::bar;')
 
 
-class NamespaceAliasTests(SingleFileTestCase):
+class NamespaceAliasTests(CSingleFileTestCase):
     """Tests for namespace aliases"""
 
     source = r"""

--- a/dxr/plugins/clang/tests/test_operator_call.py
+++ b/dxr/plugins/clang/tests/test_operator_call.py
@@ -1,7 +1,7 @@
-from dxr.testing import SingleFileTestCase
+from dxr.plugins.clang.tests import CSingleFileTestCase
 
 
-class OperatorCallTests(SingleFileTestCase):
+class OperatorCallTests(CSingleFileTestCase):
     source = """
         struct Foo
         {
@@ -41,7 +41,7 @@ class OperatorCallTests(SingleFileTestCase):
             'foo[<b>beta</b>];')
 
 
-class ExplicitOperatorCallTests(SingleFileTestCase):
+class ExplicitOperatorCallTests(CSingleFileTestCase):
     source = """
         struct Foo
         {

--- a/dxr/plugins/clang/tests/test_overrides.py
+++ b/dxr/plugins/clang/tests/test_overrides.py
@@ -1,10 +1,10 @@
 """Tests for searches about overrides of virtual methods"""
 
-from dxr.testing import SingleFileTestCase, MINIMAL_MAIN
+from dxr.plugins.clang.tests import CSingleFileTestCase, MINIMAL_MAIN
 import nose.tools
 
 
-class SingleOverrideTests(SingleFileTestCase):
+class SingleOverrideTests(CSingleFileTestCase):
     source = r"""
         class Base {
             virtual void foo();
@@ -29,7 +29,7 @@ class SingleOverrideTests(SingleFileTestCase):
             '+overrides:Base::foo()', 'void Derived::<b>foo</b>() {')
 
 
-class ParallelOverrideTests(SingleFileTestCase):
+class ParallelOverrideTests(CSingleFileTestCase):
     """Test overrides for two classes that both directly inherit from one base
     class."""
 
@@ -63,7 +63,7 @@ class ParallelOverrideTests(SingleFileTestCase):
                              ('void DerivedB::<b>foo</b>() {', 15)])
 
 
-class HierarchyOverrideTests(SingleFileTestCase):
+class HierarchyOverrideTests(CSingleFileTestCase):
     """Test overrides in a three class hierarchy."""
 
     source = r"""
@@ -100,7 +100,7 @@ class HierarchyOverrideTests(SingleFileTestCase):
                            'void Derived2::<b>foo</b>() {')
 
 
-class HierarchyImplicitOverrideTests(SingleFileTestCase):
+class HierarchyImplicitOverrideTests(CSingleFileTestCase):
     """Test overrides in a three class hierarchy where the middle class does
     not explictly define the method."""
 
@@ -128,7 +128,7 @@ class HierarchyImplicitOverrideTests(SingleFileTestCase):
                            'void Derived2::<b>foo</b>() {')
 
 
-class MultipleOverrides(SingleFileTestCase):
+class MultipleOverrides(CSingleFileTestCase):
     """Test overrides when one method simultanously overrides more than one
     other method."""
 

--- a/dxr/plugins/clang/tests/test_type_templates.py
+++ b/dxr/plugins/clang/tests/test_type_templates.py
@@ -1,7 +1,7 @@
-from dxr.testing import SingleFileTestCase, MINIMAL_MAIN
+from dxr.plugins.clang.tests import CSingleFileTestCase, MINIMAL_MAIN
 
 
-class TypeTests(SingleFileTestCase):
+class TypeTests(CSingleFileTestCase):
     source = r"""
         template <typename T>
         class Foo
@@ -19,7 +19,7 @@ class TypeTests(SingleFileTestCase):
         self.found_line_eq('type-ref:Foo',
                            '<b>Foo</b>&lt;int&gt;();')
 
-class BaseClassTests(SingleFileTestCase):
+class BaseClassTests(CSingleFileTestCase):
     source = r"""
         template <typename T>
         class Foo
@@ -35,7 +35,7 @@ class BaseClassTests(SingleFileTestCase):
         self.found_line_eq('type-ref:Foo',
                            'class Bar : public <b>Foo</b>&lt;T&gt;')
 
-class TemplateParameterTests(SingleFileTestCase):
+class TemplateParameterTests(CSingleFileTestCase):
     source = r"""
         template <typename T>
         class Foo

--- a/dxr/plugins/clang/tests/test_typedefs.py
+++ b/dxr/plugins/clang/tests/test_typedefs.py
@@ -1,7 +1,7 @@
-from dxr.testing import SingleFileTestCase, MINIMAL_MAIN
+from dxr.plugins.clang.tests import CSingleFileTestCase, MINIMAL_MAIN
 
 
-class TypedefTests(SingleFileTestCase):
+class TypedefTests(CSingleFileTestCase):
     source = r"""
         typedef int MyTypedef;
 

--- a/dxr/plugins/clang/tests/test_types.py
+++ b/dxr/plugins/clang/tests/test_types.py
@@ -1,7 +1,7 @@
-from dxr.testing import SingleFileTestCase, MINIMAL_MAIN
+from dxr.plugins.clang.tests import CSingleFileTestCase, MINIMAL_MAIN
 
 
-class TypeTests(SingleFileTestCase):
+class TypeTests(CSingleFileTestCase):
     source = r"""
         class Foo {};
         class Bar {};
@@ -18,7 +18,7 @@ class TypeTests(SingleFileTestCase):
         self.found_nothing('type:*Foo* type:*Quux*')
 
 
-class InjectedTypeTests(SingleFileTestCase):
+class InjectedTypeTests(CSingleFileTestCase):
     source = r"""
         template <typename T>
         class Foo {

--- a/dxr/plugins/clang/tests/test_vars.py
+++ b/dxr/plugins/clang/tests/test_vars.py
@@ -1,7 +1,7 @@
-from dxr.testing import SingleFileTestCase, MINIMAL_MAIN
+from dxr.plugins.clang.tests import CSingleFileTestCase, MINIMAL_MAIN
 
 
-class VarTests(SingleFileTestCase):
+class VarTests(CSingleFileTestCase):
     source = r"""
         int global;
         int decoy;

--- a/dxr/plugins/clang/tests/test_warnings.py
+++ b/dxr/plugins/clang/tests/test_warnings.py
@@ -2,10 +2,10 @@
 
 import commands
 import re
-from dxr.testing import SingleFileTestCase, MINIMAL_MAIN
+from dxr.plugins.clang.tests import CSingleFileTestCase, MINIMAL_MAIN
 
 
-class TautWarningTests(SingleFileTestCase):
+class TautWarningTests(CSingleFileTestCase):
     """Tests for searches of a tautological comparison warning"""
 
     source = r"""
@@ -26,7 +26,7 @@ class TautWarningTests(SingleFileTestCase):
             'warning-opt:-Wtautological-compare', 'if (<b>x</b> &lt; 0)')
 
 
-class MultipleOnSameLineWarningTests(SingleFileTestCase):
+class MultipleOnSameLineWarningTests(CSingleFileTestCase):
     """Tests for searches when there are multiple warnings on one line"""
 
     source = r"""

--- a/dxr/plugins/clang/tests/test_wildcards.py
+++ b/dxr/plugins/clang/tests/test_wildcards.py
@@ -5,10 +5,10 @@
 from nose import SkipTest
 raise SkipTest
 
-from dxr.testing import SingleFileTestCase
+from dxr.plugins.clang.tests import CSingleFileTestCase
 
 
-class WildcardTests(SingleFileTestCase):
+class WildcardTests(CSingleFileTestCase):
     source = r"""
         int get_foo() {
             return 0;

--- a/dxr/plugins/rust/tests/__init__.py
+++ b/dxr/plugins/rust/tests/__init__.py
@@ -1,5 +1,6 @@
 from dxr.testing import SingleFileTestCase
 
+
 class RustSingleFileTestCase(SingleFileTestCase):
     """Test case suited to testing the Rust plugin."""
     source_filename = 'mod.rs'

--- a/dxr/plugins/urllink/tests/test_links.py
+++ b/dxr/plugins/urllink/tests/test_links.py
@@ -1,12 +1,12 @@
 """Tests for whether urllink finds and links URLs"""
 
-from dxr.testing import SingleFileTestCase, menu_on, MINIMAL_MAIN
+from dxr.testing import SingleFileTestCase, menu_on
 
 
 class LinkTests(SingleFileTestCase):
     source = r"""
         // Here's a link: http://www.example.com/
-        """ + MINIMAL_MAIN
+        """
 
     @classmethod
     def config_input(cls, config_dir_path):
@@ -16,7 +16,7 @@ class LinkTests(SingleFileTestCase):
 
     def test_one_link(self):
         """Make sure the simple case works."""
-        markup = self.source_page('main.cpp')
+        markup = self.source_page('main')
 
         menu_on(markup,
                 'http://www.example.com/',

--- a/dxr/testing.py
+++ b/dxr/testing.py
@@ -293,14 +293,14 @@ class SingleFileTestCase(TestCase):
     of files in the FS. I'll slam it down into a temporary DXR instance and
     then kick off the usual build process, deleting the instance afterward.
 
+    :cvar source_filename: The filename used for the source file
+
     """
     # Set this to True in a subclass to keep the generated instance around and
     # host it on port 8000 so you can examine it:
     stop_for_interaction = False
 
-    # Override this in a subclass to change the filename used for the
-    # source file.
-    source_filename = 'main.cpp'
+    source_filename = 'main'
 
     @classmethod
     def setup_class(cls):
@@ -313,13 +313,6 @@ class SingleFileTestCase(TestCase):
         for tree in cls.config().trees.itervalues():
             index_and_deploy_tree(tree)
         cls._es().refresh()
-
-    @classmethod
-    def config_input(cls, config_dir_path):
-        input = super(SingleFileTestCase, cls).config_input(config_dir_path)
-        input['DXR']['enabled_plugins'] = 'pygmentize clang'
-        input['code']['build_command'] = '$CXX -o main main.cpp'
-        return input
 
     @classmethod
     def teardown_class(cls):
@@ -385,23 +378,17 @@ class SingleFileTestCase(TestCase):
                 query, expected_pairs, is_case_sensitive=is_case_sensitive)
 
     def direct_result_eq(self, query, line_number, is_case_sensitive=True):
-        """Assume the filename "main.cpp"."""
-        return super(SingleFileTestCase, self).direct_result_eq(query, 'main.cpp', line_number, is_case_sensitive=is_case_sensitive)
+        return super(SingleFileTestCase, self).direct_result_eq(
+            query,
+            self.source_filename,
+            line_number,
+            is_case_sensitive=is_case_sensitive)
 
 
 def _make_file(path, filename, contents):
     """Make file ``filename`` within ``path``, full of unicode ``contents``."""
     with open(join(path, filename), 'w') as file:
         file.write(contents.encode('utf-8'))
-
-
-# Tests that don't otherwise need a main() can append this one just to get
-# their code to compile:
-MINIMAL_MAIN = """
-    int main(int argc, char* argv[]) {
-        return 0;
-    }
-    """
 
 
 def _decoded_menu_on(haystack, text):

--- a/tests/test_build_failure.py
+++ b/tests/test_build_failure.py
@@ -8,6 +8,12 @@ class BuildFailureTests(SingleFileTestCase):
     source = r"""A bunch of garbage"""
 
     @classmethod
+    def config_input(cls, config_dir_path):
+        input = super(BuildFailureTests, cls).config_input(config_dir_path)
+        input['code']['build_command'] = '/bin/false'
+        return input
+
+    @classmethod
     def setup_class(cls):
         """Make sure a failed build returns a non-zero status code."""
         try:

--- a/tests/test_direct.py
+++ b/tests/test_direct.py
@@ -1,4 +1,4 @@
-from dxr.testing import SingleFileTestCase, MINIMAL_MAIN
+from dxr.testing import SingleFileTestCase
 
 
 class DirectSearchTests(SingleFileTestCase):
@@ -9,14 +9,14 @@ class DirectSearchTests(SingleFileTestCase):
         // How are you gentlemen
         // All your base
         // Are belong to us
-        """ + MINIMAL_MAIN
+        """
 
     def test_line_number(self):
         """A file name and line number should take you directly to that file
         and line number."""
-        self.direct_result_eq('main.cpp:6', 6)
+        self.direct_result_eq('main:6', 6)
 
     def test_file(self):
         """A file name should take you directly to that file, without
         highlighting a particular line."""
-        self.direct_result_eq('main.cpp', None)
+        self.direct_result_eq('main', None)

--- a/tests/test_filter_aggregates.py
+++ b/tests/test_filter_aggregates.py
@@ -1,7 +1,7 @@
-from dxr.testing import SingleFileTestCase
+from dxr.plugins.clang.tests import CSingleFileTestCase
 
 
-class FilterAggregateTests(SingleFileTestCase):
+class FilterAggregateTests(CSingleFileTestCase):
     """Tests the id- and ref- aggregate filters defined in query.py"""
     source = r"""#include <stdio.h>
 

--- a/tests/test_strings.py
+++ b/tests/test_strings.py
@@ -4,14 +4,18 @@ from nose import SkipTest
 from nose.tools import eq_, ok_
 
 from dxr.query import highlight
-from dxr.testing import SingleFileTestCase, MINIMAL_MAIN
+from dxr.testing import SingleFileTestCase
 
 
 class StringTests(SingleFileTestCase):
     source = """
         void main_idea() {
         }
-        """ + MINIMAL_MAIN
+
+        int main(int argc, char* argv[]) {
+            return 0;
+        }
+        """
 
     def test_negated_word(self):
         """Make sure a negated word with underscores supresses results."""
@@ -59,7 +63,7 @@ class RegexpTests(SingleFileTestCase):
     source = """// Which of us is the beaver?
         // The paddle-shaped tail is a dead giveaway.
         // We know it's you, Shahad.
-        """ + MINIMAL_MAIN
+        """
 
     def test_case_sensitive(self):
         self.found_line_eq('regexp:" ?The ?"',


### PR DESCRIPTION
SingleFileTestCase is now language-agnostic but still concrete.

Deleted a few MINIMAL_MAINs that were there only to make the compiler happy. Now we don't run the compiler in those cases. As a bonus, those tests will be a bit faster.