### PR TITLE
Simple docker dev environment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,20 @@
+FROM quay.io/fubar/ubuntu-indexer
+MAINTAINER Peter
+
+# Install Rust.
+RUN curl -s https://static.rust-lang.org/rustup.sh | sh -s -- --channel=nightly --date=2015-06-14 --yes
+# It's okay Mercurial, you can trust staff group.
+RUN echo [trusted] >> /home/jenkins/.hgrc && echo groups = staff >> /home/jenkins/.hgrc
+# Replace the distributed dxr with the one from here (working copy).
+ADD . /builds/dxr-build-env/dxr
+# Run make.
+RUN . venv/bin/activate && \
+    dxr/peep.py install -r dxr/requirements.txt && \
+    cd dxr && \
+    python setup.py install && \
+    make && \
+    cd - && \
+    deactivate
+RUN pip install nose-progressive
+
+WORKDIR /builds/dxr-build-env/dxr

--- a/docker/README
+++ b/docker/README
@@ -4,16 +4,11 @@ So if you run `dxr index`, that happens here.
 Usage of the docker environment:
 Put a dxr.config and source code directory here.
 
-Run an elasticsearch docker container, and expose port 8000.
-docker run --name es -p 80:8000 elasticsearch
-
-Remark: By default the elasticsearch container does not support javascript
-queries, which DXR uses -- regexp searches will fail unless you rebuild the
-elasticsearch container with an updated config file.
-
 In the parent (repository root):
-docker build -t dxr .
-docker run --net container:es dxr index
-docker run --net container:es dxr serve -a
+
+Run an elasticsearch docker container, and expose port 8000.
+make es
+make image
+make index clean serve
 
 Visit $DOCKER_IP in the browser.

--- a/docker/README
+++ b/docker/README
@@ -1,0 +1,19 @@
+This directory is copied up to the container, and is set as the WORKDIR.
+So if you run `dxr index`, that happens here.
+
+Usage of the docker environment:
+Put a dxr.config and source code directory here.
+
+Run an elasticsearch docker container, and expose port 8000.
+docker run --name es -p 80:8000 elasticsearch
+
+Remark: By default the elasticsearch container does not support javascript
+queries, which DXR uses -- regexp searches will fail unless you rebuild the
+elasticsearch container with an updated config file.
+
+In the parent (repository root):
+docker build -t dxr .
+docker run --net container:es dxr index
+docker run --net container:es dxr serve -a
+
+Visit $DOCKER_IP in the browser.

--- a/docker/code/main.c
+++ b/docker/code/main.c
@@ -1,0 +1,1 @@
+// Hello hello hello

--- a/docker/dxr.config
+++ b/docker/dxr.config
@@ -1,0 +1,6 @@
+[DXR]
+enabled_plugins     = pygmentize urllink
+
+[code]
+source_folder       = .
+build_command =

--- a/docker_es/Dockerfile
+++ b/docker_es/Dockerfile
@@ -1,0 +1,9 @@
+FROM elasticsearch:1.5
+
+RUN plugin install elasticsearch/elasticsearch-lang-javascript/2.7.0
+RUN plugin install mobz/elasticsearch-head
+# Modified configs.
+COPY elasticsearch.yml /usr/share/elasticsearch/config/elasticsearch.yml
+COPY elasticsearch.yml /etc/elasticsearch/elasticsearch.yml
+# Add some memory.
+RUN sed 's/#ES_HEAP_SIZE=.*/ES_HEAP_SIZE=3500m/' /etc/init.d/elasticsearch > /etc/init.d/elasticsearch

--- a/docker_es/elasticsearch.yml
+++ b/docker_es/elasticsearch.yml
@@ -1,0 +1,4 @@
+bootstrap.mlockall: true
+network.bind_host: 127.0.0.1
+discovery.zen.ping.multicast.enabled: false
+script.disable_dynamic: false


### PR DESCRIPTION
Add dockerfiles for dxr and elasticsearch development, and makefile targets.

Taking a different approach from #415, I build upon fubar's dxr-docker image to make a dev image by replacing the Github DXR pull with the local copy.

Usage:
Prereq: Have docker running.
1. Build elasticsearch image and run it. `make es`
2. Build DXR image. `make image`
3. Run tests/index some code. `make tests` or `make index clean serve`
Remark: can specify tests via `make tests TESTS=tests/test_<...>.py`

TODO:
update docs.
maybe use docker-compose to setup the two docker images at once.

Some questions:
Would it be better to bring dxr-docker in first?