### PR TITLE
Get clang plugin overrides and overriddens menu entries working again.

### DIFF
--- a/dxr/plugins/clang/indexers.py
+++ b/dxr/plugins/clang/indexers.py
@@ -62,7 +62,7 @@ class FileToIndex(FileToIndexBase):
         self.overriddens = overriddens
         self.parents = parents
         self.children = children
-        self.condensed = condense_file(temp_folder, path)
+        self.condensed = condense_file(temp_folder, path, overrides, overriddens)
 
     def needles_by_line(self):
         return all_needles(

--- a/dxr/plugins/clang/tests/test_clang.py
+++ b/dxr/plugins/clang/tests/test_clang.py
@@ -11,11 +11,13 @@ from StringIO import StringIO
 from nose.tools import eq_
 
 from dxr.indexers import Extent, Position, FuncSig
-from dxr.plugins.clang.condense import condense, DISPATCH_TABLE
+from dxr.plugins.clang.condense import condense, process_call, process_function
 from dxr.plugins.clang.needles import sig_needles
 
 
 DEFAULT_EXTENT = Extent(start=Position(0, 0), end=Position(0, 0))
+DISPATCH_TABLE = {'call': process_call,
+                  'function': process_function}
 
 
 def condense_csv(csv_str):

--- a/dxr/plugins/clang/tests/test_menus/code/extern.c
+++ b/dxr/plugins/clang/tests/test_menus/code/extern.c
@@ -26,3 +26,17 @@ namespace Space {
 namespace Bar = Space;
 
 #define MACRO "polo"
+
+class BaseClass {
+public:
+  virtual void virtualFunc() { }
+  virtual void pVirtualFunc() = 0;
+};
+
+class DerivedClass : public BaseClass {
+public:
+  void virtualFunc();
+  void pVirtualFunc() { }
+};
+
+void DerivedClass::virtualFunc() { }

--- a/dxr/plugins/clang/tests/test_menus/code/main.cpp
+++ b/dxr/plugins/clang/tests/test_menus/code/main.cpp
@@ -12,7 +12,13 @@ int main(int argc, char* argv[]) {
 
   MACRO;
 
-  return var;
+  var++;
+
+  BaseClass* der = new DerivedClass;
+  der->virtualFunc();
+  delete der;
+
+  return 1;
 }
 
 VERY_EXTERNAL

--- a/dxr/plugins/clang/tests/test_menus/test_menus.py
+++ b/dxr/plugins/clang/tests/test_menus/test_menus.py
@@ -6,6 +6,7 @@ unscathed.
 
 """
 from dxr.testing import DxrInstanceTestCase, menu_on, menu_item_not_on
+import nose.tools
 
 
 class MenuTests(DxrInstanceTestCase):
@@ -154,3 +155,55 @@ class MenuTests(DxrInstanceTestCase):
         menu_item_not_on(self.source_page('main.cpp'),
                          'VERY_EXTERNAL',
                          'Jump to definition')
+
+    def test_override_overrides(self):
+        """Make sure virtual functions that have an override are recognized."""
+        menu_on(self.source_page('extern.c'),
+                'virtualFunc',
+                {'html': 'Find overrides',
+                 'href': '/code/search?q=%2Boverrides%3ABaseClass%3A%3AvirtualFunc%28%29'})
+
+    def test_override_overridden(self):
+        """Make sure virtual functions that override something are
+        recognized."""
+        menu_on(self.source_page('extern.c'),
+                'virtualFunc',
+                {'html': 'Find overridden',
+                 'href': '/code/search?q=%2Boverridden%3ADerivedClass%3A%3AvirtualFunc%28%29'},
+                 text_instance=2)
+
+    def test_override_def(self):
+        """Make sure virtual function defs are recognized."""
+        menu_on(self.source_page('extern.c'),
+                'virtualFunc',
+                {'html': 'Find overridden',
+                 'href': '/code/search?q=%2Boverridden%3ADerivedClass%3A%3AvirtualFunc%28%29'},
+                 text_instance=3)
+
+    def test_override_ref(self):
+        """Make sure virtual function refs are recognized."""
+        menu_on(self.source_page('main.cpp'),
+                'virtualFunc',
+                {'html': 'Find overrides',
+                 'href': '/code/search?q=%2Boverrides%3ABaseClass%3A%3AvirtualFunc%28%29'})
+
+    # We don't yet recognize pure virtual functions as something that gets
+    # overridden - activate the next two tests when that gets fixed.
+
+    @nose.tools.raises(AssertionError) # remove this line when fixed
+    def test_override_pure_overrides(self):
+        """Make sure pure virtual functions that have an override are
+        recognized."""
+        menu_on(self.source_page('extern.c'),
+                'pVirtualFunc',
+                {'html': 'Find overrides',
+                 'href': '/code/search?q=%2Boverrides%3ABaseClass%3A%3ApVirtualFunc%28%29'})
+
+    @nose.tools.raises(AssertionError) # remove this line when fixed
+    def test_override_pure_overridden(self):
+        """Make sure overrides of a pure virtual function are recognized."""
+        menu_on(self.source_page('extern.c'),
+                'pVirtualFunc',
+                {'html': 'Find overridden',
+                 'href': '/code/search?q=%2Boverridden%3ADerivedClass%3A%3ApVirtualFunc%28%29'},
+                 text_instance=2)

--- a/dxr/plugins/clang/tests/test_menus/test_references.py
+++ b/dxr/plugins/clang/tests/test_menus/test_references.py
@@ -31,4 +31,4 @@ class ReferenceTests(DxrInstanceTestCase):
         Plain old var: queries are covered in test_c_vardecl.
 
         """
-        self.found_line_eq('var-ref:var', 'return <b>var</b>;', 15)
+        self.found_line_eq('var-ref:var', '<b>var</b>++;', 15)

--- a/dxr/testing.py
+++ b/dxr/testing.py
@@ -391,37 +391,50 @@ def _make_file(path, filename, contents):
         file.write(contents.encode('utf-8'))
 
 
-def _decoded_menu_on(haystack, text):
-    """Return the JSON-decoded menu found around the source code ``text`` in
-    the HTML ``haystack``.
+def _decoded_menu_on(haystack, text, text_instance=1):
+    """Return the JSON-decoded menu found around the ``text_instance``th source
+    code occurrence of ``text`` in the HTML ``haystack``.
 
     Raise an AssertionError if there is no menu there.
 
     """
     # We just use cheap-and-cheesy regexes for now, to avoid pulling in and
     # compiling the entirety of lxml to run pyquery.
-    match = re.search(
-            '<a data-menu="([^"]+)"[^>]*>' + re.escape(cgi.escape(text)) + '</a>',
-            haystack)
+    pattern = '<a data-menu="([^"]+)"[^>]*>' + re.escape(cgi.escape(text)) + '</a>'
+    if text_instance == 1:
+        match = re.search(pattern, haystack)
+    else:
+        matches = re.finditer(pattern, haystack)
+        for _ in range(text_instance):
+            try:
+                match = matches.next()
+            except StopIteration:
+                match = None
+
     if match:
         return json.loads(match.group(1).replace('&quot;', '"')
                                         .replace('&lt;', '<')
                                         .replace('&gt;', '>')
                                         .replace('&amp;', '&'))
     else:
-        ok_(False, "No menu around '%s' was found." % text)
+        ok_(False, "No menu around occurrence %d of '%s' was found." %
+                   (text_instance, text))
 
 
-def menu_on(haystack, text, *menu_items):
+def menu_on(haystack, text, *menu_items, **kwargs):
     """Assert that there is a context menu on certain text that contains
     certain menu items.
 
     :arg haystack: The HTML source of a page to search
-    :arg text: The text contained by the menu's anchor tag. The first
-        menu-having anchor tag containing the text is the one compared against.
+    :arg text: The text contained by the menu's anchor tag. The
+        ``text_instance``th menu-having anchor tag containing the text is the
+        one compared against.
     :arg menu_items: Dicts whose pairs must be contained in some item of the
         menu. If an item is found to match, it is discarded can cannot be
         reused to match another element of ``menu_items``.
+    :arg text_instance: An optional keyword-only arg that specifies which
+        occurrence of ``text`` to compare against.  Defaults to 1 (the first
+        occurrence).
 
     """
     def removed_match(expected, found_items):
@@ -450,11 +463,14 @@ def menu_on(haystack, text, *menu_items):
                 return True
         return False
 
-    found_items = _decoded_menu_on(haystack, text)
+    text_instance = kwargs.pop('text_instance', 1)
+    found_items = _decoded_menu_on(haystack, text, text_instance)
     for expected in menu_items:
         removed = removed_match(expected, found_items)
         if not removed:
-            ok_(False, "No menu item with the keys %r was found in the menu around '%s'." % (expected, text))
+            ok_(False, "No menu item with the keys %r " % (expected) +
+                "was found in the menu around occurrence " +
+                "%d of '%s'." % (text_instance, text))
 
 
 def menu_item_not_on(haystack, text, menu_item_html):


### PR DESCRIPTION
Partially fixes bug 1191562.  The remaining cases where the
overrides and overriddens menu options still don't appear are for a
pure virtual function and its override.