### PR TITLE
Deal with Python node location lookups that fail to exist in the lookup tables

### DIFF
--- a/dxr/plugins/python/tests/test_callers.py
+++ b/dxr/plugins/python/tests/test_callers.py
@@ -61,3 +61,26 @@ class CallersTests(PythonSingleFileTestCase):
 
         """
         self.found_line_eq('callers:outer_call_bar', '<b>outer_call_bar()</b>', 20)
+
+
+class CallersMethodTests(PythonSingleFileTestCase):
+    source = dedent("""
+    class Foo(object):
+        @classmethod
+        def class_method(cls):
+            pass
+
+        def method(self):
+            pass
+
+    Foo.class_method()
+
+    foo = Foo()
+    foo.method()
+    """)
+
+    def test_class_method_called(self):
+        self.found_nothing('callers:class_method')
+
+    def test_method_called(self):
+        self.found_nothing('callers:method')


### PR DESCRIPTION
Currently, this should only be method calls.  This happens because the
ast node for calls point to the first token in the chain, instead of
the method token.