### PR TITLE
Catch UnicodeDecodeError when doing the initial analysis on Python files

### DIFF
--- a/dxr/plugins/python/analysis.py
+++ b/dxr/plugins/python/analysis.py
@@ -52,7 +52,7 @@ class TreeAnalysis(object):
         """
         try:
             syntax_tree = ast_parse(file_contents(path, encoding))
-        except (IOError, SyntaxError, TypeError) as error:
+        except (IOError, SyntaxError, TypeError, UnicodeDecodeError) as error:
             rel_path = os.path.relpath(path, self.source_folder)
             warn('Failed to analyze {filename} due to error "{error}".'.format(
                  filename=rel_path, error=error))

--- a/dxr/plugins/python/indexers.py
+++ b/dxr/plugins/python/indexers.py
@@ -110,25 +110,25 @@ class IndexingNodeVisitor(ast.NodeVisitor, ClassFunctionVisitorMixin):
         if start is not None:
             self.yield_needle('py_type', node.name, start, end)
 
-        # Index the class hierarchy for classes for the derived: and
-        # bases: filters.
-        class_name = self.get_class_name(node)
+            # Index the class hierarchy for classes for the derived: and
+            # bases: filters.
+            class_name = self.get_class_name(node)
 
-        bases = self.tree_analysis.get_base_classes(class_name)
-        for qualname in bases:
-            self.yield_needle(needle_type='py_derived',
-                              name=local_name(qualname), qualname=qualname,
-                              start=start, end=end)
+            bases = self.tree_analysis.get_base_classes(class_name)
+            for qualname in bases:
+                self.yield_needle(needle_type='py_derived',
+                                  name=local_name(qualname), qualname=qualname,
+                                  start=start, end=end)
 
-        derived_classes = self.tree_analysis.get_derived_classes(class_name)
-        for qualname in derived_classes:
-            self.yield_needle(needle_type='py_bases',
-                              name=local_name(qualname), qualname=qualname,
-                              start=start, end=end)
+            derived_classes = self.tree_analysis.get_derived_classes(class_name)
+            for qualname in derived_classes:
+                self.yield_needle(needle_type='py_bases',
+                                  name=local_name(qualname), qualname=qualname,
+                                  start=start, end=end)
 
-        # Show a menu when hovering over this class.
-        self.yield_ref(start, end,
-                       ClassRef(self.file_to_index.tree, class_name))
+            # Show a menu when hovering over this class.
+            self.yield_ref(start, end,
+                           ClassRef(self.file_to_index.tree, class_name))
 
         super(IndexingNodeVisitor, self).visit_ClassDef(node)
 


### PR DESCRIPTION
If a file is encoded in some other encoding and has a sequence of
bytes that prevents it from being interpreted as UTF-8, it'll get
slurped up as a bytestring instead of a unicode string.  And in that
case, it'll probably hit the ast_parse utility function and throw this
error.