### PR TITLE
Unpin the version of rust.

### DIFF
--- a/tooling/docker/dev/set_up_common.sh
+++ b/tooling/docker/dev/set_up_common.sh
@@ -3,4 +3,4 @@
 # don't do anything specific to development or CI.
 
 # Install Rust.
-curl -s https://static.rust-lang.org/rustup.sh | sh -s -- --channel=nightly --date=2015-06-14 --yes
+curl -s https://static.rust-lang.org/rustup.sh | sh -s -- --channel=nightly --yes


### PR DESCRIPTION
Nightly seems to have been working in prod for some time, so let's track it for awhile.