### PR TITLE
Get the clang plugin to recognize multiple directly overridden functions

### DIFF
--- a/dxr/plugins/clang/condense.py
+++ b/dxr/plugins/clang/condense.py
@@ -22,9 +22,9 @@ class UselessLine(Exception):
     """A CSV line isn't suitable for getting anything useful out of."""
 
 
-POSSIBLE_KINDS = set(['call', 'macro', 'function', 'variable', 'ref',
-                       'type', 'impl', 'decldef', 'typedef', 'warning',
-                       'namespace', 'namespace_alias', 'include'])
+POSSIBLE_KINDS = set(['call', 'macro', 'function', 'func_override', 'variable',
+                      'ref', 'type', 'impl', 'decldef', 'typedef', 'warning',
+                      'namespace', 'namespace_alias', 'include'])
 
 
 def c_type_sig(inputs, output, method=None):
@@ -103,7 +103,7 @@ def process_override(overrides, overriddens, props):
     """
     # It may not be necessary to have a list here. In multiple inheritance,
     # does clang ever consider a method to override multiple other methods, or
-    # is it at most one each?
+    # is it at most one each?  Answer: clang recognizes multiple overriddens.
     overrides.setdefault(props['qualname'], set()).add(
             (props['overriddenqualname'], props['overriddenname']))
 
@@ -315,10 +315,9 @@ def condense_global(csv_folder):
     condense(
         lines_from_csvs(csv_folder, '*.csv'),
         {'impl': partial(process_impl, parents, children),
-         'function': partial(process_override, overrides, overriddens)},
-        predicate=lambda kind, fields: (kind == 'function' and
-                                        'overriddenname' in fields) or
-                                       kind == 'impl')
+         'func_override': partial(process_override, overrides, overriddens)},
+        predicate=lambda kind, fields: (kind == 'func_override' or
+                                        kind == 'impl'))
 
     # Turn some sets into lists. There's no need to keep them as sets, and
     # lists are tighter on RAM, which will make them faster to pass to workers.

--- a/dxr/plugins/clang/tests/test_overrides.py
+++ b/dxr/plugins/clang/tests/test_overrides.py
@@ -150,9 +150,6 @@ class MultipleOverrides(CSingleFileTestCase):
         }
         """ + MINIMAL_MAIN
 
-    # This test is not yet working because we don't track that Derived::foo
-    # overrides Base2::foo
-    @nose.tools.raises(AssertionError)  # remove this line when fixed
     def test_overridden(self):
         self.found_lines_eq('+overridden:Derived::foo()',
                             [('void Base1::<b>foo</b>() {', 5),
@@ -162,9 +159,6 @@ class MultipleOverrides(CSingleFileTestCase):
         self.found_line_eq('+overrides:Base1::foo()',
                            'void Derived::<b>foo</b>() {')
 
-    # This test is not yet working because we don't track that Derived::foo
-    # overrides Base2::foo
-    @nose.tools.raises(AssertionError)  # remove this line when fixed
     def test_overrides2(self):
         self.found_line_eq('+overrides:Base2::foo()',
                            'void Derived::<b>foo</b>() {')


### PR DESCRIPTION
If a virtual function overrides virtuals in multiple direct base classes, all of
the overriddens should be recognized.