### PR TITLE
dxr-index.cpp updates

### DIFF
--- a/dxr/plugins/clang/dxr-index.cpp
+++ b/dxr/plugins/clang/dxr-index.cpp
@@ -24,7 +24,8 @@
 #include "sha1.h"
 
 #define CLANG_AT_LEAST(major, minor) \
-  (CLANG_VERSION_MAJOR > (major) || (CLANG_VERSION_MAJOR == (major) && CLANG_VERSION_MINOR >= (minor)))
+  (CLANG_VERSION_MAJOR > (major) || \
+   (CLANG_VERSION_MAJOR == (major) && CLANG_VERSION_MINOR >= (minor)))
 
 using namespace clang;
 
@@ -48,7 +49,8 @@ inline bool str_starts_with(const std::string &s, const std::string &prefix) {
 }
 
 inline bool str_ends_with(const std::string &s, const std::string &suffix) {
-  return s.size() >= suffix.size() && s.compare(s.size() - suffix.size(), suffix.size(), suffix) == 0;
+  return s.size() >= suffix.size() &&
+    s.compare(s.size() - suffix.size(), suffix.size(), suffix) == 0;
 }
 
 // BEWARE: use only as a temporary
@@ -67,9 +69,9 @@ struct FileInfo {
       // Remove the trailing `/' as well.
       realname.erase(0, srcdir.length() + 1);
     } else if (rname.compare(0, output.length(), output) == 0) {
-      // We're in the output directory, so we are probably a generated header
+      // We're in the output directory, so we are probably a generated header.
       // We use the escape character to indicate the objdir nature.
-      // Note that output also has the `/' already placed
+      // Note that output also has the `/' already placed.
       interesting = true;
       realname.replace(0, output.length(), GENERATED);
     }
@@ -84,24 +86,32 @@ typedef std::shared_ptr<FileInfo> FileInfoPtr;
 
 class IndexConsumer;
 
+// PreprocThunk handles our consumption of the preprocessing stage of the
+// compilation.
+// Functionally, we just pass off the work to our IndexConsumer object.
 class PreprocThunk : public PPCallbacks {
   IndexConsumer *real;
 public:
   PreprocThunk(IndexConsumer *c) : real(c) {}
 #if CLANG_AT_LEAST(3, 3)
   void MacroDefined(const Token &tok, const MacroDirective *md) override;
-  void MacroExpands(const Token &tok, const MacroDirective *md, SourceRange range, const MacroArgs *ma) override;
+  void MacroExpands(const Token &tok, const MacroDirective *md, SourceRange range,
+                    const MacroArgs *ma) override;
   void MacroUndefined(const Token &tok, const MacroDirective *md) override;
 #if CLANG_AT_LEAST(3, 4)
-  void Defined(const Token &tok, const MacroDirective *md, SourceRange range) override;
+  void Defined(const Token &tok, const MacroDirective *md,
+               SourceRange range) override;
 #else
   void Defined(const Token &tok, const MacroDirective *md) override;
 #endif
-  void Ifdef(SourceLocation loc, const Token &tok, const MacroDirective *md) override;
-  void Ifndef(SourceLocation loc, const Token &tok, const MacroDirective *md) override;
+  void Ifdef(SourceLocation loc, const Token &tok,
+             const MacroDirective *md) override;
+  void Ifndef(SourceLocation loc, const Token &tok,
+              const MacroDirective *md) override;
 #else
   void MacroDefined(const Token &MacroNameTok, const MacroInfo *MI) override;
-  void MacroExpands(const Token &MacroNameTok, const MacroInfo *MI, SourceRange Range) override;
+  void MacroExpands(const Token &MacroNameTok, const MacroInfo *MI,
+                    SourceRange Range) override;
   void MacroUndefined(const Token &tok, const MacroInfo *MI) override;
   void Defined(const Token &tok) override;
   void Ifdef(SourceLocation loc, const Token &tok) override;
@@ -119,6 +129,7 @@ public:
       const Module *imported) override;
 };
 
+// IndexConsumer is our primary AST consumer.
 class IndexConsumer : public ASTConsumer,
                       public RecursiveASTVisitor<IndexConsumer>,
                       public DiagnosticConsumer {
@@ -157,8 +168,9 @@ private:
     return getFileInfo(filenamestr);
   }
 public:
-  IndexConsumer(CompilerInstance &ci) :
-    ci(ci), sm(ci.getSourceManager()), features(ci.getLangOpts()) {
+  IndexConsumer(CompilerInstance &ci)
+    : ci(ci), sm(ci.getSourceManager()), features(ci.getLangOpts()) {
+
     inner = ci.getDiagnostics().takeClient();
     ci.getDiagnostics().setClient(this, false);
     ci.getPreprocessor().addPPCallbacks(new PreprocThunk(this));
@@ -175,7 +187,8 @@ public:
 
   static void setTmpDir(const std::string& dir) { tmpdir = dir; }
 
-  // Helpers for processing declarations
+  //// Helpers for processing declarations
+
   // Should we ignore this location?
   bool interestingLocation(SourceLocation loc) {
     // If we don't have a valid location... it's probably not interesting.
@@ -207,7 +220,9 @@ public:
     if (!isInvalid) {
       unsigned line = sm.getExpansionLineNumber(loc, &isInvalid);
       if (!isInvalid) {
-        buffer = getFileInfo(sm.getFilename(loc).str())->realname;  // getFilename seems to want a SpellingLoc. I may be disappointing it. I'm not sure what it will do if it's disappointed.
+        // getFilename seems to want a SpellingLoc. I may be disappointing
+        // it. I'm not sure what it will do if it's disappointed.
+        buffer = getFileInfo(sm.getFilename(loc).str())->realname;
         buffer += ":";
         buffer += line;
         buffer += ":";
@@ -229,21 +244,18 @@ public:
   std::string getQualifiedName(const NamedDecl &d) {
     std::string ret;
     const DeclContext *ctx = d.getDeclContext();
-    if (ctx->isFunctionOrMethod() && isa<NamedDecl>(ctx))
-    {
+    if (ctx->isFunctionOrMethod() && isa<NamedDecl>(ctx)) {
       // This is a local variable.
       // d.getQualifiedNameAsString() will return the unqualifed name for this
       // but we want an actual qualified name so we can distinguish variables
       // with the same name but that are in different functions.
       ret = getQualifiedName(*cast<NamedDecl>(ctx)) + "::" + d.getNameAsString();
     }
-    else
-    {
+    else {
       ret = d.getQualifiedNameAsString();
     }
 
-    if (const FunctionDecl *fd = dyn_cast<FunctionDecl>(&d))
-    {
+    if (const FunctionDecl *fd = dyn_cast<FunctionDecl>(&d)) {
       // This is a function.  getQualifiedNameAsString will return a string
       // like "ANamespace::AFunction".  To this we append the list of parameters
       // so that we can distinguish correctly between
@@ -252,8 +264,7 @@ public:
       // void ANamespace::AFunction(float);
       ret += "(";
       const FunctionType *ft = fd->getType()->castAs<FunctionType>();
-      if (const FunctionProtoType *fpt = dyn_cast<FunctionProtoType>(ft))
-      {
+      if (const FunctionProtoType *fpt = dyn_cast<FunctionProtoType>(ft)) {
         unsigned num_params = fd->getNumParams();
         for (unsigned i = 0; i < num_params; ++i) {
           if (i)
@@ -272,22 +283,23 @@ public:
         ret += " const";
     }
 
-    // Make anonymous namespaces in separate files have separate names
+    // Make anonymous namespaces in separate files have separate names.
 #if CLANG_AT_LEAST(3, 5)
     const std::string anon_ns = "(anonymous namespace)";
 #else
     const std::string anon_ns = "<anonymous namespace>";
 #endif
-    if (StringRef(ret).startswith(anon_ns))
-    {
+    if (StringRef(ret).startswith(anon_ns)) {
       const std::string &filename = ci.getFrontendOpts().Inputs[0].getFile().str();
       const std::string &realname = getFileInfo(filename)->realname;
-      ret = "(" + ret.substr(1, anon_ns.size() - 2) + " in " + realname + ")" + ret.substr(anon_ns.size());
+      ret = "(" + ret.substr(1, anon_ns.size() - 2) + " in " + realname + ")" +
+        ret.substr(anon_ns.size());
     }
     return ret;
   }
 
-  // Switch the output pointer to a specific file's CSV, and write a line header to it.
+  // Switch the output pointer to a specific file's CSV, and write a line header
+  // to it.
   void beginRecord(const char *name, SourceLocation loc) {
     // Only a PresumedLoc has a getFilename() method, unfortunately. We'd
     // rather have the expansion location than the presumed one, as we're not
@@ -318,8 +330,7 @@ public:
   // first macro. This is useful for getting back to the actual place that
   // cites a variable that then gets passed to a macro.
   SourceLocation escapeMacros(SourceLocation loc) {
-    while (loc.isValid() && loc.isMacroID())
-    {
+    while (loc.isValid() && loc.isMacroID()) {
       if (!sm.isMacroArgExpansion(loc))
         return SourceLocation();
       loc = sm.getImmediateSpellingLoc(loc);
@@ -327,8 +338,7 @@ public:
     return loc;
   }
 
-  Decl *getNonClosureDecl(Decl *d)
-  {
+  Decl *getNonClosureDecl(Decl *d) {
     DeclContext *dc;
     for (dc = d->getDeclContext(); dc->isClosure(); dc = dc->getParent())
       ;
@@ -338,7 +348,7 @@ public:
   void printScope(Decl *d) {
     Decl *ctxt = getNonClosureDecl(d);
     // Ignore namespace scopes, since it doesn't really help for source code
-    // organization
+    // organization.
     while (NamespaceDecl::classof(ctxt))
       ctxt = getNonClosureDecl(ctxt);
     // If the scope is an anonymous struct/class/enum/union, replace it with the
@@ -358,11 +368,16 @@ public:
   }
 
   // vars, funcs, types, enums, classes, unions, etc.
-  void declDef(const char *kind, const NamedDecl *decl, const NamedDecl *def, SourceLocation begin, SourceLocation end) {
-    if (!def || def == decl)  // Why aren't we interested in declarations of things that aren't [later] defined?
+  void declDef(const char *kind, const NamedDecl *decl, const NamedDecl *def,
+               SourceLocation begin, SourceLocation end) {
+    if (!def || def == decl) {
+      // Why aren't we interested in declarations of things that aren't [later]
+      // defined?
       return;
+    }
 
-    beginRecord("decldef", decl->getLocation());  // Assuming this is an expansion location.
+    beginRecord("decldef", decl->getLocation());  // Assuming this is an
+                                                  // expansion location.
     recordValue("name", decl->getNameAsString());
     recordValue("qualname", getQualifiedName(*def));
     recordValue("loc", locationToString(decl->getLocation()));
@@ -372,6 +387,8 @@ public:
       recordValue("kind", kind);
     *out << std::endl;
   }
+
+  //// AST processing overrides
 
   // All we need is to follow the final declaration.
   void HandleTranslationUnit(ASTContext &ctx) override {
@@ -410,8 +427,7 @@ public:
     if (!interestingLocation(d->getLocation()))
       return true;
 
-    if (d->isThisDeclarationADefinition())
-    {
+    if (d->isThisDeclarationADefinition()) {
       SourceLocation begin;
       // Information we need for types: kind, fqname, simple name, location
       beginRecord("type", d->getLocation());
@@ -428,7 +444,8 @@ public:
       *out << std::endl;
     }
 
-    declDef("type", d, d->getDefinition(), d->getLocation(), afterToken(d->getLocation()));
+    declDef("type", d, d->getDefinition(),
+            d->getLocation(), afterToken(d->getLocation()));
     return true;
   }
 
@@ -438,11 +455,10 @@ public:
 
     // TagDecl already did decldef and type outputting; we just need impl
     for (CXXRecordDecl::base_class_iterator iter = d->bases_begin();
-        iter != d->bases_end(); ++iter) {
+         iter != d->bases_end(); ++iter) {
       const Type *t = (*iter).getType().getTypePtr();
       NamedDecl *base = t->getAsCXXRecordDecl();
-      // I don't know what's going on... just bail!
-      if (!base)
+      if (!base)  // I don't know what's going on... just bail!
         return true;
       beginRecord("impl", d->getLocation());
       recordValue("name", d->getNameAsString());
@@ -467,9 +483,7 @@ public:
     if (!interestingLocation(d->getLocation()))
       return true;
 
-    if (d->isThisDeclarationADefinition() ||
-        d->isPure())  // until we have better support for pure-virtual functions
-    {
+    if (d->isThisDeclarationADefinition() || d->isPure()) {
       SourceLocation functionLocation = d->getLocation();
       beginRecord("function", functionLocation);
       std::string functionName = d->getNameAsString();
@@ -526,7 +540,8 @@ public:
 
     const FunctionDecl *def;
     if (d->isDefined(def))
-      declDef("function", d, def, d->getNameInfo().getBeginLoc(), d->getNameInfo().getEndLoc());
+      declDef("function", d, def,
+              d->getNameInfo().getBeginLoc(), d->getNameInfo().getEndLoc());
 
     return true;
   }
@@ -535,22 +550,26 @@ public:
     if (!interestingLocation(d->getLocation()))
       return true;
 
-    for (CXXConstructorDecl::init_const_iterator it = d->init_begin(), e = d->init_end(); it != e; ++it)
-    {
+    for (CXXConstructorDecl::init_const_iterator it = d->init_begin(),
+           e = d->init_end();
+         it != e; ++it) {
       const CXXCtorInitializer *ci = *it;
       if (!ci->getMember() || !ci->isWritten())
         continue;
-      printReference("variable", ci->getMember(), ci->getMemberLocation(), ci->getMemberLocation());
+      printReference("variable", ci->getMember(),
+                     ci->getMemberLocation(), ci->getMemberLocation());
     }
 
     return true;
   }
 
-  bool treatThisValueDeclAsADefinition(const ValueDecl *d)
-  {
+  bool treatThisValueDeclAsADefinition(const ValueDecl *d) {
     const VarDecl *vd = dyn_cast<VarDecl>(d);
-    if (!vd)
-      return true;  // Things that are not VarDecls (FieldDecl, EnumConstantDecl) are always treated as definitions
+    if (!vd) {
+      // Things that are not VarDecls (FieldDecl, EnumConstantDecl) are always
+      // treated as definitions.
+      return true;
+    }
     if (!vd->isThisDeclarationADefinition())
       return false;
     if (!isa<ParmVarDecl>(d))
@@ -561,8 +580,7 @@ public:
     return fd && fd->isThisDeclarationADefinition();
   }
 
-  std::string getValueForValueDecl(ValueDecl *d)
-  {
+  std::string getValueForValueDecl(ValueDecl *d) {
     if (const VarDecl *vd = dyn_cast<VarDecl>(d)) {
       const Expr *init = vd->getAnyInitializer(vd);
       if (!isa<ParmVarDecl>(vd) &&
@@ -570,9 +588,8 @@ public:
           vd->getType().isConstQualified()) {
         if (const APValue *apv = vd->evaluateValue()) {
           std::string ret = apv->getAsString(vd->getASTContext(), vd->getType());
-          // workaround for constant strings being shown as &"foo" or &"foo"[0]
-          if (str_starts_with(ret, "&\""))
-          {
+          // Workaround for constant strings being shown as &"foo" or &"foo"[0]
+          if (str_starts_with(ret, "&\"")) {
             if (str_ends_with(ret, "\""))
               return ret.substr(1);
             if (str_ends_with(ret, "\"[0]"))
@@ -587,9 +604,6 @@ public:
     return std::string();
   }
 
-  // This isn't even getting called except for argc and argv. [Actually, I only confirmed that by calling beginRecord(). Maybe it's malfunctioning in this case; we did change it.]
-  // I've confirmed that the tip of es does the right thing.
-  // Let's see if just pasting in the dxr-index.cpp code from es does the right thing. It does. So the problem is in here somewhere. So let's see REALLY if this is being called. IT IS!
   void visitVariableDecl(ValueDecl *d) {
     SourceLocation location = escapeMacros(d->getLocation());
     if (!interestingLocation(location)) {
@@ -618,7 +632,8 @@ public:
         VarDecl *first = vd->getFirstDeclaration();
 #endif
         VarDecl *lastTentative = nullptr;
-        for (VarDecl::redecl_iterator i = first->redecls_begin(), e = first->redecls_end();
+        for (VarDecl::redecl_iterator i = first->redecls_begin(),
+               e = first->redecls_end();
              i != e; ++i) {
           VarDecl::DefinitionKind kind = i->isThisDeclarationADefinition();
           if (kind == VarDecl::TentativeDefinition) {
@@ -627,7 +642,8 @@ public:
         }
         def = lastTentative;
       }
-      declDef("variable", vd, def, vd->getLocation(), afterToken(vd->getLocation()));  // TODO: See if there's a vd->getNameInfo(), as in other calls we make to declDef.
+      declDef("variable", vd, def,
+              vd->getLocation(), afterToken(vd->getLocation()));
     }
   }
 
@@ -643,7 +659,8 @@ public:
     // XXX: this seems broken?
 #if 0
     const Type *real = d->getUnderlyingType().getTypePtr();
-    if (TagType::classof(real)) {DiagnosticsEngine &D = CI.getDiagnostics();
+    if (TagType::classof(real)) {
+      DiagnosticsEngine &D = CI.getDiagnostics();
       unsigned DiagID = D.getCustomDiagID(DiagnosticsEngine::Error,
         "Output directory '" + output + "' does not exist");
       D.Report(DiagID);
@@ -658,7 +675,6 @@ public:
     recordValue("qualname", getQualifiedName(*d));
     recordValue("loc", locationToString(d->getLocation()));
     recordValue("locend", locationToString(afterToken(d->getLocation())));
-//    recordValue("underlying", d->getUnderlyingType().getAsString());
     printScope(d);
     *out << std::endl;
     return true;
@@ -674,15 +690,14 @@ public:
     recordValue("name", d->getNameAsString());
     recordValue("qualname", getQualifiedName(*d));
     recordValue("loc", locationToString(d->getLocation()));
-    recordValue("locend", locationToString(afterToken(d->getLocation())));  // TODO: d->getNameInfo()?
+    recordValue("locend", locationToString(afterToken(d->getLocation())));
     printScope(d);
     *out << std::endl;
     return true;
   }
 
-  // Like "namespace foo;"
-  bool VisitNamespaceDecl(NamespaceDecl *d)
-  {
+  // Like "namespace foo;".
+  bool VisitNamespaceDecl(NamespaceDecl *d) {
     if (!interestingLocation(d->getLocation()))
       return true;
     beginRecord("namespace", d->getLocation());
@@ -695,8 +710,7 @@ public:
   }
 
   // Like "namespace bar = foo;"
-  bool VisitNamespaceAliasDecl(NamespaceAliasDecl *d)
-  {
+  bool VisitNamespaceAliasDecl(NamespaceAliasDecl *d) {
     if (!interestingLocation(d->getLocation()))
       return true;
 
@@ -709,24 +723,24 @@ public:
 
     if (d->getQualifierLoc())
       visitNestedNameSpecifierLoc(d->getQualifierLoc());
-    printReference("namespace", d->getAliasedNamespace(), d->getTargetNameLoc(), d->getTargetNameLoc());
+    printReference("namespace", d->getAliasedNamespace(),
+                   d->getTargetNameLoc(), d->getTargetNameLoc());
     return true;
   }
 
   // Like "using namespace std;"
-  bool VisitUsingDirectiveDecl(UsingDirectiveDecl *d)
-  {
+  bool VisitUsingDirectiveDecl(UsingDirectiveDecl *d) {
     if (!interestingLocation(d->getLocation()))
       return true;
     if (d->getQualifierLoc())
       visitNestedNameSpecifierLoc(d->getQualifierLoc());
-    printReference("namespace", d->getNominatedNamespace(), d->getIdentLocation(), d->getIdentLocation());
+    printReference("namespace", d->getNominatedNamespace(),
+                   d->getIdentLocation(), d->getIdentLocation());
     return true;
   }
 
   // Like "using std::string;"
-  bool VisitUsingDecl(UsingDecl *d)
-  {
+  bool VisitUsingDecl(UsingDecl *d) {
     if (!interestingLocation(d->getLocation()))
       return true;
     if (d->getQualifierLoc())
@@ -752,7 +766,8 @@ public:
   }
 
   // Expressions!
-  void printReference(const char *kind, NamedDecl *d, SourceLocation refLoc, SourceLocation end) {
+  void printReference(const char *kind, NamedDecl *d,
+                      SourceLocation refLoc, SourceLocation end) {
     if (!interestingLocation(d->getLocation()) || !interestingLocation(refLoc))
       return;
     SourceLocation nonMacroRefLoc = escapeMacros(refLoc);
@@ -767,13 +782,12 @@ public:
     *out << std::endl;
   }
 
-  const char *kindForDecl(const Decl *d)
-  {
+  const char *kindForDecl(const Decl *d) {
     if (isa<FunctionDecl>(d))
       return "function";
     if (isa<EnumConstantDecl>(d) || isa<VarDecl>(d) || isa<FieldDecl>(d))
       return "variable";
-    return nullptr;   // unhandled for now
+    return nullptr;  // Unhandled for now
   }
 
   bool VisitMemberExpr(MemberExpr *e) {
@@ -797,7 +811,7 @@ public:
          not the entire range between '(' and ')' (or '[' and ']'). */
       if (fd->getOverloadedOperator() == OO_Call ||     // operator()
           fd->getOverloadedOperator() == OO_Subscript)  // operator[]
-       end = start;
+        end = start;
     }
     printReference(kindForDecl(e->getDecl()),
                    e->getDecl(),
@@ -923,32 +937,35 @@ public:
       return true;
 
     printReference("typedef", l.getDecl(), l.getBeginLoc(), l.getEndLoc());
-    // TODO: It seems like a lot of the (presumably working) old stuff used getBeginLoc and getEndLoc. Try switching to those where available if things don't work.
+    // TODO: It seems like a lot of the (presumably working) old stuff used
+    // getBeginLoc and getEndLoc. Try switching to those where available if
+    // things don't work.
     return true;
   }
 
-  SourceLocation removeTrailingColonColon(SourceLocation begin, SourceLocation end)
-  {
+  SourceLocation removeTrailingColonColon(SourceLocation begin,
+                                          SourceLocation end) {
     if (!end.isValid())
       return end;
 
     SmallVector<char, 32> buffer;
-    if (Lexer::getSpelling(end, buffer, sm, features) != "::")  // Doesn't descend any deeper into a "spelling" or "expansion" location than the location already is.
+    if (Lexer::getSpelling(end, buffer, sm, features) != "::") {
+      // Doesn't descend any deeper into a "spelling" or "expansion" location
+      // than the location already is.
       return end;
+    }
 
     SourceLocation prev;
     for (SourceLocation loc = begin;
          loc.isValid() && loc != end && loc != prev;
-         loc = afterToken(loc))
-    {
+         loc = afterToken(loc)) {
       prev = loc;
     }
 
     return prev.isValid() ? prev : end;
   }
 
-  void visitNestedNameSpecifierLoc(NestedNameSpecifierLoc l)
-  {
+  void visitNestedNameSpecifierLoc(NestedNameSpecifierLoc l) {
     if (!interestingLocation(l.getBeginLoc()))
       return;
 
@@ -957,7 +974,7 @@ public:
 
     SourceLocation begin = l.getLocalBeginLoc(),
                    end = l.getLocalEndLoc();
-    // we don't want the "::" to be part of the link.
+    // We don't want the "::" to be part of the link.
     end = removeTrailingColonColon(begin, end);
 
     NestedNameSpecifier *nss = l.getNestedNameSpecifier();
@@ -970,8 +987,11 @@ public:
   // Warnings!
   SourceLocation getWarningExtentLocation(SourceLocation loc) {
     while (loc.isMacroID()) {
-      if (sm.isMacroArgExpansion(loc))
-        loc = sm.getImmediateSpellingLoc(loc);  // TODO: Why do we want to attach the warning to the macro definition site rather than its use?
+      if (sm.isMacroArgExpansion(loc)) {
+        // TODO: Why do we want to attach the warning to the macro definition
+        // site rather than its use?
+        loc = sm.getImmediateSpellingLoc(loc);
+      }
       else
         loc = sm.getImmediateExpansionRange(loc).first;
     }
@@ -1003,15 +1023,17 @@ public:
     } else {
       SourceLocation loc = getWarningExtentLocation(info.getLocation());
       recordValue("loc", locationToString(loc));
-      recordValue("locend", locationToString(afterToken(loc)));  // Not great, but it's basically what it did before, via printExtent
+      // This isn't great, but it's basically what it did before, via
+      // printExtent.
+      recordValue("locend", locationToString(afterToken(loc)));
     }
     *out << std::endl;
   }
 
   // Macros!
   void MacroDefined(const Token &MacroNameTok, const MacroInfo *MI) {
-    if (MI->isBuiltinMacro()) return;
-    if (!interestingLocation(MI->getDefinitionLoc())) return;
+    if (MI->isBuiltinMacro() || !interestingLocation(MI->getDefinitionLoc()))
+      return;
 
     // Yep, we're tokenizing this ourselves. Fun!
     SourceLocation nameStart = MI->getDefinitionLoc();
@@ -1026,11 +1048,12 @@ public:
     // Grab the macro arguments if it has some
     if (nameLen < length && contents[nameLen] == '(') {
       argsStart = nameLen;
-      for (argsEnd = nameLen + 1; argsEnd < length; argsEnd++)
+      for (argsEnd = nameLen + 1; argsEnd < length; argsEnd++) {
         if (contents[argsEnd] == ')') {
           argsEnd++;
           break;
         }
+      }
       defnStart = argsEnd;
     } else {
       defnStart = nameLen;
@@ -1047,16 +1070,19 @@ public:
     recordValue("loc", locationToString(nameStart));
     recordValue("locend", locationToString(afterToken(nameStart)));
     recordValue("name", std::string(contents, nameLen));
-    if (argsStart > 0)
+    if (argsStart > 0) {
       recordValue("args", std::string(contents + argsStart,
-        argsEnd - argsStart), true);
+                                      argsEnd - argsStart), true);
+    }
     if (defnStart < length) {
       std::string text =  std::string(contents + defnStart,
         length - defnStart);
       // FIXME: handle non-ASCII characters better
-      for (size_t i = 0; i < text.size(); ++i)
-        if ((text[i] < ' ' || text[i] >= 0x7F) && text[i] != '\t' && text[i] != '\n')
+      for (size_t i = 0; i < text.size(); ++i) {
+        if ((text[i] < ' ' || text[i] >= 0x7F) &&
+            text[i] != '\t' && text[i] != '\n')
           text[i] = '?';
+      }
       recordValue("text", text, true);
     }
     *out << std::endl;
@@ -1148,47 +1174,52 @@ public:
 };
 
 #if CLANG_AT_LEAST(3, 3)
-  void PreprocThunk::MacroDefined(const Token &tok, const MacroDirective *md) {
-    real->MacroDefined(tok, md->getMacroInfo());
-  }
-  void PreprocThunk::MacroExpands(const Token &tok, const MacroDirective *md, SourceRange range, const MacroArgs *ma) {
-    real->MacroExpands(tok, md->getMacroInfo(), range);
-  }
-  void PreprocThunk::MacroUndefined(const Token &tok, const MacroDirective *md) {
-    real->MacroUndefined(tok, md->getMacroInfo());
-  }
+void PreprocThunk::MacroDefined(const Token &tok, const MacroDirective *md) {
+  real->MacroDefined(tok, md->getMacroInfo());
+}
+void PreprocThunk::MacroExpands(const Token &tok, const MacroDirective *md,
+                                SourceRange range, const MacroArgs *ma) {
+  real->MacroExpands(tok, md->getMacroInfo(), range);
+}
+void PreprocThunk::MacroUndefined(const Token &tok, const MacroDirective *md) {
+  real->MacroUndefined(tok, md->getMacroInfo());
+}
 #if CLANG_AT_LEAST(3, 4)
-  void PreprocThunk::Defined(const Token &tok, const MacroDirective *md, SourceRange) {
+void PreprocThunk::Defined(const Token &tok, const MacroDirective *md,
+                           SourceRange) {
 #else
-  void PreprocThunk::Defined(const Token &tok, const MacroDirective *md) {
+void PreprocThunk::Defined(const Token &tok, const MacroDirective *md) {
 #endif
-    real->Defined(tok, md->getMacroInfo());
-  }
-  void PreprocThunk::Ifdef(SourceLocation loc, const Token &tok, const MacroDirective *md) {
-    real->Ifdef(loc, tok, md->getMacroInfo());
-  }
-  void PreprocThunk::Ifndef(SourceLocation loc, const Token &tok, const MacroDirective *md) {
-    real->Ifndef(loc, tok, md->getMacroInfo());
-  }
+  real->Defined(tok, md->getMacroInfo());
+}
+void PreprocThunk::Ifdef(SourceLocation loc, const Token &tok,
+                         const MacroDirective *md) {
+  real->Ifdef(loc, tok, md->getMacroInfo());
+}
+void PreprocThunk::Ifndef(SourceLocation loc, const Token &tok,
+                          const MacroDirective *md) {
+  real->Ifndef(loc, tok, md->getMacroInfo());
+}
 #else
-  void PreprocThunk::MacroDefined(const Token &tok, const MacroInfo *MI) {
-    real->MacroDefined(tok, MI);
-  }
-  void PreprocThunk::MacroExpands(const Token &tok, const MacroInfo *MI, SourceRange Range) {
-    real->MacroExpands(tok, MI, Range);
-  }
-  void PreprocThunk::MacroUndefined(const Token &tok, const MacroInfo *MI) {
-    real->MacroUndefined(tok, MI);
-  }
-  void PreprocThunk::Defined(const Token &tok) {
-    real->Defined(tok, nullptr);
-  }
-  void PreprocThunk::Ifdef(SourceLocation loc, const Token &tok) {
-    real->Ifdef(loc, tok, nullptr);
-  }
-  void PreprocThunk::Ifndef(SourceLocation loc, const Token &tok) {
-    real->Ifndef(loc, tok, nullptr);
-  }
+void PreprocThunk::MacroDefined(const Token &tok, const MacroInfo *MI) {
+  real->MacroDefined(tok, MI);
+}
+void PreprocThunk::MacroExpands(const Token &tok, const MacroInfo *MI,
+                                SourceRange Range) {
+  real->MacroExpands(tok, MI, Range);
+}
+void PreprocThunk::MacroUndefined(const Token &tok, const MacroInfo *MI) {
+  real->MacroUndefined(tok, MI);
+}
+void PreprocThunk::Defined(const Token &tok) {
+  real->Defined(tok, nullptr);
+}
+void PreprocThunk::Ifdef(SourceLocation loc, const Token &tok) {
+  real->Ifdef(loc, tok, nullptr);
+}
+void PreprocThunk::Ifndef(SourceLocation loc, const Token &tok) {
+  real->Ifndef(loc, tok, nullptr);
+}
 #endif
 void PreprocThunk::InclusionDirective(  // same in 3.2 and 3.3
     SourceLocation hashLoc,
@@ -1200,12 +1231,15 @@ void PreprocThunk::InclusionDirective(  // same in 3.2 and 3.3
     StringRef searchPath,
     StringRef relativePath,
     const Module *imported) {
-  real->InclusionDirective(hashLoc, includeTok, fileName, isAngled, filenameRange, file, searchPath, relativePath, imported);
+  real->InclusionDirective(hashLoc, includeTok, fileName, isAngled, filenameRange,
+                           file, searchPath, relativePath, imported);
 }
 
+// Our plugin entry point.
 class DXRIndexAction : public PluginASTAction {
 protected:
-  ASTConsumer *CreateASTConsumer(CompilerInstance &CI, llvm::StringRef f) override {
+  ASTConsumer *CreateASTConsumer(CompilerInstance &CI,
+                                 llvm::StringRef f) override {
     return new IndexConsumer(CI);
   }
 
@@ -1218,7 +1252,9 @@ protected:
       D.Report(DiagID);
       return false;
     }
-    // Load our directories
+    // Load our directories.
+
+    // The source directory.
     char *abs_src = realpath(args[0].c_str(), nullptr);
     if (!abs_src) {
       DiagnosticsEngine &D = CI.getDiagnostics();
@@ -1228,6 +1264,8 @@ protected:
       return false;
     }
     FileInfo::srcdir = abs_src;
+
+    // The build output directory.
     const char *env = getenv("DXR_CXX_CLANG_OBJECT_FOLDER");
     std::string output;
     if (env)
@@ -1246,15 +1284,15 @@ protected:
     output += "/";
     FileInfo::output = output;
 
-    const char* tmp = getenv("DXR_CXX_CLANG_TEMP_FOLDER");
+    // The temp directory for this plugin's output.
+    const char *tmp = getenv("DXR_CXX_CLANG_TEMP_FOLDER");
     std::string tmpdir;
-    if(tmp){
+    if (tmp)
       tmpdir = tmp;
-    }else
+    else
       tmpdir = output;
-
-    char* abs_tmpdir = realpath(tmpdir.c_str(), nullptr);
-    if(!abs_tmpdir){
+    char *abs_tmpdir = realpath(tmpdir.c_str(), nullptr);
+    if (!abs_tmpdir) {
       DiagnosticsEngine &D = CI.getDiagnostics();
       unsigned DiagID = D.getCustomDiagID(DiagnosticsEngine::Error,
         "Temporary directory '%0' does not exist");


### PR DESCRIPTION
I indexed (a couple weeks old version of) firefox several times with and without the patch, and all runs were within a minute of each other, sometimes slower, sometimes faster with the patch.  (That's a little surprising to me, but I also ran a debug indexing version where I was writing to files from the plugin, and the writes were definitely happening, so I'm pretty sure those indexing runs actually used the patches...)

I tried not to be too draconian on the style "cleanup", so in the end maybe no one will be happy!  :P  Feel free to suggest more changes, or changes you prefer should be taken back.
