### PR TITLE
Fix scroll blanking issues

### DIFF
--- a/dxr/static_unhashed/js/dxr.js
+++ b/dxr/static_unhashed/js/dxr.js
@@ -282,9 +282,11 @@ $(function() {
 
         // If no data is returned, inform the user.
         if (!data.results.length) {
-            contentContainer
-                .empty()
-                .append(nunjucks.render('results_container.html', data));
+            if (!append) {
+                contentContainer
+                    .empty()
+                    .append(nunjucks.render('results_container.html', data));
+            }
         } else {
             var results = data.results;
             resultsLineCount = countLines(results);


### PR DESCRIPTION
This is sort of a wallpaper, but even so. We shouldn't clear the result page if we're appending.

I'll look at setting up docker. The other issue here is that we're assuming that if the resultLineCount is equal or bigger than the previous limit, we want more stuff. That isn't the case if the total number of results we expect is equal to that number. That is, on my MBP, the limit that gets determined based on my screen height is 40 + 25 = 65. So if I load a query with exactly 65 results, and scroll down, it triggers a request for more data, because the number of results I got (65) matches the limit we used (65), and because it also matches the total number of results, the next set of results comes in empty, causing the bug.