### PR TITLE
Pin the version of rust we're using.

### DIFF
--- a/makefile
+++ b/makefile
@@ -7,7 +7,7 @@ all: static plugins requirements .dxr_installed
 
 test: all
 	$$VIRTUAL_ENV/bin/pip install nose
-	$$VIRTUAL_ENV/bin/nosetests -v
+	$$VIRTUAL_ENV/bin/nosetests -v --nologcapture
 
 clean: static_clean
 	rm -rf tooling/node/node_modules/.bin/nunjucks-precompile \

--- a/tooling/docker/dev/set_up_common.sh
+++ b/tooling/docker/dev/set_up_common.sh
@@ -3,4 +3,4 @@
 # don't do anything specific to development or CI.
 
 # Install Rust.
-curl -s https://static.rust-lang.org/rustup.sh | sh -s -- --channel=nightly --yes
+curl -s https://static.rust-lang.org/rustup.sh | sh -s -- --channel=nightly --date=2016-01-25 --yes


### PR DESCRIPTION
Pin the version of rust we're using.

They changed something after this date that broke our tests. We should still fix them, but it's annoying when our tests aren't deterministic.

Also stop blowing ES logs onto the test console. More often than not, they obscure what we really want to read.
