### PR TITLE
Browser history processing

### DIFF
--- a/dxr/static_unhashed/js/code-highlighter.js
+++ b/dxr/static_unhashed/js/code-highlighter.js
@@ -269,13 +269,7 @@ $(function () {
             }
 
         } else {
-            //set lastModifierKey ranges and single lines to null, then clear all highlights
-            lastModifierKey = null;
-            //Remove existing highlights.
-            $('.line-number, .code code').removeClass('last-selected highlighted multihighlight clicked');
-            //empty out single lines and ranges arrays
-            rangesArray = [];
-            singleLinesArray = [];
+            removeAllHighlighting();
             //toggle highlighting on for any line that was not previously clicked
             if (lastSelectedNum !== clickedNum) {
                 //With this we're one better than github, which doesn't allow toggling single lines
@@ -287,8 +281,15 @@ $(function () {
         setWindowHash();
     });
 
-    //highlight line(s) if someone visits a url directly with an #anchor
-    $(document).ready(function () {
+    function removeAllHighlighting() {
+        lastModifierKey = null;
+        rangesArray = [];
+        singleLinesArray = [];
+        $('.line-number, .code code').removeClass('last-selected highlighted multihighlight clicked');
+    }
+
+    //highlight line(s) if someone visits a url with an #anchor
+    function processHash() {
         if (window.location.hash.substring(1)) {
             var toHighlight = getSortedHashLines(),
                 jumpPosition = $('#' + toHighlight.lineStart).offset(),
@@ -323,6 +324,12 @@ $(function () {
             //tidy up an incoming url that might be typed in manually
             setWindowHash();
         }
-    });
+    }
 
+    // Highlight any lines specified by hash in either a direct page load or a history pop.
+    $(document).ready(processHash);
+    $(window).on('popstate', function() {
+        removeAllHighlighting();
+        processHash();
+    });
 });

--- a/dxr/static_unhashed/js/context_menu.js
+++ b/dxr/static_unhashed/js/context_menu.js
@@ -164,11 +164,17 @@ $(function() {
         }
     });
 
-    // Remove the menu when a user clicks outside it.
-    window.addEventListener('mousedown', function() {
+    function removeContextMenu() {
         toggleSymbolHighlights();
         $('#context-menu').remove();
-    }, false);
+    }
+
+    // Remove the menu when a user clicks outside it, or when the page is loaded
+    // via backward and forward history moves to this page, or via reload.
+    $(window).on('mousedown pageshow', removeContextMenu);
+
+    // Remove the menu when a user clicks on one of its links.
+    fileContainer.on('click', '#context-menu a', removeContextMenu);
 
     onEsc(function() {
         $('#context-menu').remove();

--- a/dxr/static_unhashed/js/dxr.js
+++ b/dxr/static_unhashed/js/dxr.js
@@ -381,7 +381,8 @@ $(function() {
             }
         }
 
-        clearTimeout(historyWaiter);
+        if (!appendResults)
+            clearTimeout(historyWaiter);
 
         if (query.length === 0) {
             hideBubble();  // Don't complain when I delete what I typed. You didn't complain when it was empty before I typed anything.
@@ -580,16 +581,14 @@ $(function() {
     // If on load of the search endpoint we have a query string then we need to
     // load the results of the query and activate infinite scroll.
     window.addEventListener('load', function() {
-        if (locationIsSearch()) {
+        lastURLWasSearch = locationIsSearch();
+        if (lastURLWasSearch) {
             // Set case-sensitive checkbox according to the URL, and make sure
             // the localstorage mirrors it.
             var urlIsCaseSensitive = caseFromUrl() === true;
             caseSensitiveBox.prop('checked', urlIsCaseSensitive);
             localStorage.setItem('caseSensitive', urlIsCaseSensitive);
             doQuery(false, window.location.href);
-            lastURLWasSearch = true;
-        } else {
-            lastURLWasSearch = false;
         }
     });
 });

--- a/dxr/static_unhashed/js/dxr.js
+++ b/dxr/static_unhashed/js/dxr.js
@@ -404,6 +404,7 @@ $(function() {
                 // Check whether to redirect to a direct hit.
                 if (data.redirect) {
                     window.location.href = data.redirect;
+                    lastURLWasSearch = false;
                     return;
                 }
                 data.query = query;
@@ -533,6 +534,10 @@ $(function() {
         $(this).text(formatDate($(this).data('datetime')));
     });
 
+    function locationIsSearch() {
+        return /search$/.test(window.location.pathname) && window.location.search;
+    }
+
     // Expose the DXR Object to the global object.
     window.dxr = dxr;
 
@@ -549,11 +554,11 @@ $(function() {
     // Reload the page when we go back or forward.
     function popStateHandler(event) {
         if (event.state ||  // If it's a search (we only push state on a search), or...
-            (!window.location.search && lastURLWasSearch)) {  // if we switched from search to file view:
+            (!locationIsSearch() && lastURLWasSearch)) {  // if we switched from search to file view:
             window.onpopstate = null;
             window.location.reload();
         }
-        lastURLWasSearch = window.location.search ? true : false;
+        lastURLWasSearch = locationIsSearch();
     }
 
     /**
@@ -575,7 +580,7 @@ $(function() {
     // If on load of the search endpoint we have a query string then we need to
     // load the results of the query and activate infinite scroll.
     window.addEventListener('load', function() {
-        if (/search$/.test(window.location.pathname) && window.location.search) {
+        if (locationIsSearch()) {
             // Set case-sensitive checkbox according to the URL, and make sure
             // the localstorage mirrors it.
             var urlIsCaseSensitive = caseFromUrl() === true;

--- a/dxr/static_unhashed/js/dxr.js
+++ b/dxr/static_unhashed/js/dxr.js
@@ -411,7 +411,13 @@ $(function() {
                     if (addToHistory) {
                         var pushHistory = function () {
                             // Strip off offset= and limit= when updating.
-                            var displayURL = queryString.replace(/[&?]offset=\d+/, '').replace(/[&?]limit=\d+/, '');
+                            function dropAmp(fullMatch, ampOrQuestion) {
+                                // Drop a leading ampersand, keep a leading question mark.
+                                return (ampOrQuestion === '?') ? '?' : '';
+                            }
+                            var displayURL = queryString.replace(/([&?])offset=\d+/, dropAmp).
+                                                         replace(/([&?])limit=\d+/, dropAmp).
+                                                         replace('?&', '?');
                             history.pushState({}, '', displayURL);
                         };
                         if (redirect)


### PR DESCRIPTION
Handle browser history moves better:

* Don't push history every time we run a doQuery since that leads to duplicate history entries (one on the page load, then another a couple seconds later when the doQuery pushHistory timer pops).
* Run a reload on popstate when we go from a query url to a non-query url.
* Now that non-query views can be reloaded in history, make sure we're handling highlighting correctly on re-views.
* Correctly handle (with regard to history) the case where a context menu entry points to an anchor on the current page.
* Dismiss the context menu when we change history and when we click a link on the context menu.