### PR TITLE
Cut off python name inheritance cycles.  Fixes bug 1264627.

### DIFF
--- a/dxr/plugins/python/analysis.py
+++ b/dxr/plugins/python/analysis.py
@@ -21,14 +21,13 @@ class TreeAnalysis(object):
         """Analyze the given paths.
 
         :arg python_path: Absolute path to the root folder where Python
-        modules for the tree are stored.
-
+            modules for the tree are stored.
         :arg source_folder: Absolute path to the root folder storing all the
-        files in the tree. Used to generate relative paths when emitting
-        warnings.
-
+            files in the tree. Used to generate relative paths when emitting
+            warnings.
         :arg paths: Iterable containing tuples of the form (path, encoding)
-        for each file that should be analyzed.
+            for each file that should be analyzed.
+
         """
         self.python_path = python_path
         self.source_folder = source_folder
@@ -105,11 +104,11 @@ class TreeAnalysis(object):
         inherits from in their canonical form.
 
         :arg seen: The set of normalized base class names already known.  Python
-        doesn't permit actual inheritance cycles, but we don't currently
-        distinguish between a locally defined name and a name from the built-in
-        namespace, so something like
-        'class DeprecationWarning(DeprecationWarning)' (with no import needed
-        for the built-in DeprecationWarning) would lead to a cycle.
+            doesn't permit actual inheritance cycles, but we don't currently
+            distinguish between a locally defined name and a name from the
+            built-in namespace, so something like
+            'class DeprecationWarning(DeprecationWarning)' (with no import
+            needed for the built-in DeprecationWarning) would lead to a cycle.
 
         """
         for base in self.base_classes[absolute_class_name]:
@@ -126,11 +125,11 @@ class TreeAnalysis(object):
         class in their canonical form.
 
         :arg seen: The set of normalized base class names already known.  Python
-        doesn't permit actual inheritance cycles, but we don't currently
-        distinguish between a locally defined name and a name from the built-in
-        namespace, so something like
-        'class DeprecationWarning(DeprecationWarning)' (with no import needed
-        for the built-in DeprecationWarning) would lead to a cycle.
+            doesn't permit actual inheritance cycles, but we don't currently
+            distinguish between a locally defined name and a name from the
+            built-in namespace, so something like
+            'class DeprecationWarning(DeprecationWarning)' (with no import
+            needed for the built-in DeprecationWarning) would lead to a cycle.
 
         """
         for derived in self.derived_classes[absolute_class_name]:

--- a/dxr/plugins/python/indexers.py
+++ b/dxr/plugins/python/indexers.py
@@ -176,7 +176,7 @@ class FileToIndex(FileToIndexBase):
     def __init__(self, path, contents, plugin_name, tree, tree_analysis):
         """
         :arg tree_analysis: TreeAnalysisResult object with the results
-        from the post-build analysis.
+            from the post-build analysis.
 
         """
         super(FileToIndex, self).__init__(path, contents, plugin_name, tree)

--- a/dxr/plugins/python/indexers.py
+++ b/dxr/plugins/python/indexers.py
@@ -114,13 +114,15 @@ class IndexingNodeVisitor(ast.NodeVisitor, ClassFunctionVisitorMixin):
             # bases: filters.
             class_name = self.get_class_name(node)
 
-            bases = self.tree_analysis.get_base_classes(class_name)
+            bases = self.tree_analysis.get_base_classes(class_name,
+                                                        set([class_name]))
             for qualname in bases:
                 self.yield_needle(needle_type='py_derived',
                                   name=local_name(qualname), qualname=qualname,
                                   start=start, end=end)
 
-            derived_classes = self.tree_analysis.get_derived_classes(class_name)
+            derived_classes = self.tree_analysis.get_derived_classes(class_name,
+                                                                     set([class_name]))
             for qualname in derived_classes:
                 self.yield_needle(needle_type='py_bases',
                                   name=local_name(qualname), qualname=qualname,

--- a/dxr/plugins/python/tests/test_derived.py
+++ b/dxr/plugins/python/tests/test_derived.py
@@ -1,4 +1,5 @@
 from textwrap import dedent
+import nose.tools
 
 from dxr.plugins.python.tests import PythonSingleFileTestCase
 
@@ -47,3 +48,47 @@ class DerivedTests(PythonSingleFileTestCase):
             'class <b>Parent2</b>(Grandparent):',
             'class <b>Child</b>(Parent, Parent2):',
         ])
+
+
+class NameCycleTests(PythonSingleFileTestCase):
+    """In class inheritance processing, we currently don't distinguish between
+    a local name and a built-in name, so even though python doesn't permit
+    inheritance cycles, it can appear to us that we do have cycles - make sure
+    we cut them off.
+
+    """
+    # DeprecationWarning and UserWarning belong to the exceptions module, but
+    # python exposes them in the built-in namespace, so they don't need to be
+    # explicitly imported.
+    source = dedent("""
+    class DeprecationWarning(DeprecationWarning):
+        pass
+
+    class Oops(UserWarning):
+        pass
+    class UserWarning(Oops):
+        pass
+    """)
+
+    def test_inheritance_name_cycles(self):
+        """Make sure we don't crash on indexing, and test that we return
+        reasonable results for the part of the inheritance graph we don't cut
+        off.
+
+        """
+        self.found_nothing('bases:main.DeprecationWarning')
+        self.found_lines_eq('derived:main.Oops', [
+            'class <b>UserWarning</b>(Oops):'
+            ])
+        self.found_lines_eq('bases:main.UserWarning', [
+            'class <b>Oops</b>(UserWarning):'
+            ])
+
+    @nose.tools.raises(AssertionError)  # remove this line when fixed
+    def test_inheritance_name_cycle_lookup_looping(self):
+        """Make sure we don't find the wrong name (local vs. built-in) on
+        base: and derived: searches when we have an inheritance name cycle.
+
+        """
+        self.found_nothing('bases:main.Oops')
+        self.found_nothing('derived:main.UserWarning')

--- a/dxr/plugins/python/tests/test_derived.py
+++ b/dxr/plugins/python/tests/test_derived.py
@@ -1,5 +1,5 @@
 from textwrap import dedent
-import nose.tools
+from nose.tools import raises
 
 from dxr.plugins.python.tests import PythonSingleFileTestCase
 
@@ -84,7 +84,7 @@ class NameCycleTests(PythonSingleFileTestCase):
             'class <b>Oops</b>(UserWarning):'
             ])
 
-    @nose.tools.raises(AssertionError)  # remove this line when fixed
+    @raises(AssertionError)  # remove this line when fixed
     def test_inheritance_name_cycle_lookup_looping(self):
         """Make sure we don't find the wrong name (local vs. built-in) on
         base: and derived: searches when we have an inheritance name cycle.


### PR DESCRIPTION
The bug is caused by a class definition in
mozilla-central/testing/web-platform/tests/tools/py/py/_log/warning.py of
'class DeprecationWarning(DeprecationWarning):', where the base
DeprecationWarning is a built-in which is never explicitly imported.  We don't
distinguish between the new DeprecationWarning name and the built-in name, so
it looks to us like we have an inheritance cycle.  Similar bugs can occur
with longer cycles.

The fix here cuts those off so that we don't crash on indexing when we exceed
the allowed recursion depth.