### PR TITLE
Canonicalize clang function decls before pulling parameter names.

### DIFF
--- a/dxr/plugins/clang/dxr-index.cpp
+++ b/dxr/plugins/clang/dxr-index.cpp
@@ -256,6 +256,9 @@ public:
     }
 
     if (const FunctionDecl *fd = dyn_cast<FunctionDecl>(&d)) {
+      // If you don't use the canonical decl you can get different param strings
+      // depending on which ref you're querying (which is bad).
+      fd = fd->getCanonicalDecl();
       // This is a function.  getQualifiedNameAsString will return a string
       // like "ANamespace::AFunction".  To this we append the list of parameters
       // so that we can distinguish correctly between

--- a/dxr/plugins/clang/tests/test_qualnames/code/foo.cpp
+++ b/dxr/plugins/clang/tests/test_qualnames/code/foo.cpp
@@ -1,0 +1,10 @@
+#include "main.h"
+
+using namespace bear;
+using namespace sonic;
+
+// "Find callers" on these functions used to return 0 results.
+void f_class(t_class ) {}
+void f_enum_class(const t_enum_class * const ) {}
+void f_template(t_template<fur> ) {}
+void sonic::f_typedef(streamOfInts ) {} // (This one has always worked.)

--- a/dxr/plugins/clang/tests/test_qualnames/code/foo.cpp
+++ b/dxr/plugins/clang/tests/test_qualnames/code/foo.cpp
@@ -8,3 +8,4 @@ void f_class(t_class ) {}
 void f_enum_class(const t_enum_class * const ) {}
 void f_template(t_template<fur> ) {}
 void sonic::f_typedef(streamOfInts ) {} // (This one has always worked.)
+void f_bool(bool ) {}

--- a/dxr/plugins/clang/tests/test_qualnames/code/main.cpp
+++ b/dxr/plugins/clang/tests/test_qualnames/code/main.cpp
@@ -9,4 +9,5 @@ int main() {
   f_enum_class(&oversized_feature);
   f_template(t_template<fur>());
   f_typedef(streamOfInts());
+  f_bool(true);
 }

--- a/dxr/plugins/clang/tests/test_qualnames/code/main.cpp
+++ b/dxr/plugins/clang/tests/test_qualnames/code/main.cpp
@@ -1,0 +1,12 @@
+#include "main.h"
+
+using namespace bear;
+using namespace sonic;
+
+int main() {
+  f_class(t_class());
+  t_enum_class oversized_feature = t_enum_class::paw;
+  f_enum_class(&oversized_feature);
+  f_template(t_template<fur>());
+  f_typedef(streamOfInts());
+}

--- a/dxr/plugins/clang/tests/test_qualnames/code/main.h
+++ b/dxr/plugins/clang/tests/test_qualnames/code/main.h
@@ -20,3 +20,4 @@ void f_typedef(streamOfInts ); // (This one has always worked.)
 class fur {};
 } // namespace sonic
 void f_template(t_template<sonic::fur> );
+void f_bool(bool );

--- a/dxr/plugins/clang/tests/test_qualnames/code/main.h
+++ b/dxr/plugins/clang/tests/test_qualnames/code/main.h
@@ -1,0 +1,22 @@
+// The namespace and translation unit setups of this tree provide some of the
+// conditions under which clang used to give different parameter type names
+// depending on where in the source tree the parameter was requested.
+
+namespace bear {
+
+class t_class {};
+enum class t_enum_class { paw };
+
+} // namespace bear
+
+template<class T> class t_template { };
+typedef t_template<int> streamOfInts;
+
+// "Find callers" on these function decls used to return 0 results.
+void f_class(bear::t_class );
+void f_enum_class(const bear::t_enum_class * const );
+namespace sonic {
+void f_typedef(streamOfInts ); // (This one has always worked.)
+class fur {};
+} // namespace sonic
+void f_template(t_template<sonic::fur> );

--- a/dxr/plugins/clang/tests/test_qualnames/code/makefile
+++ b/dxr/plugins/clang/tests/test_qualnames/code/makefile
@@ -1,0 +1,12 @@
+CXXFLAGS := -std=c++11 # for class enums
+
+all: code
+
+code: main.o foo.o
+	$(CXX) -o $@ $^
+
+%.o: %.cpp
+	$(CXX) $(CXXFLAGS) -c -o $@ $^
+
+clean:
+	rm -f code *.o

--- a/dxr/plugins/clang/tests/test_qualnames/dxr.config
+++ b/dxr/plugins/clang/tests/test_qualnames/dxr.config
@@ -1,0 +1,9 @@
+[DXR]
+enabled_plugins     = pygmentize clang
+es_index            = dxr_test_{format}_{tree}_{unique}
+es_alias            = dxr_test_{format}_{tree}
+es_catalog_index    = dxr_test_catalog
+
+[code]
+source_folder       = code
+build_command       = make clean; make -j $jobs

--- a/dxr/plugins/clang/tests/test_qualnames/test_qualnames.py
+++ b/dxr/plugins/clang/tests/test_qualnames/test_qualnames.py
@@ -70,3 +70,11 @@ class ConsistencyTests(DxrInstanceTestCase):
                              'sonic::f_typedef(streamOfInts)',
                              '<b>f_typedef(streamOfInts())</b>;',
                              11)
+
+    def test_bool_qualname_consistency(self):
+        """Test that we're using 'bool' instead of '_Bool' for all of our
+        bool parameter names."""
+        self._qualname_check('f_bool',
+                             'f_bool(bool)',
+                             '<b>f_bool(true)</b>;',
+                             12)

--- a/dxr/plugins/clang/tests/test_qualnames/test_qualnames.py
+++ b/dxr/plugins/clang/tests/test_qualnames/test_qualnames.py
@@ -1,0 +1,72 @@
+"""Test that the plugin returns consistent qualnames for function parameters
+referenced in varying namespace environments.
+
+"""
+from urllib import quote_plus
+
+from dxr.testing import DxrInstanceTestCase, menu_on
+
+class ConsistencyTests(DxrInstanceTestCase):
+    def _qualname_check(self, name, qualname, call_line, line):
+        """Test function qualname consistency across function refs at header,
+        implementation, and call sites.
+
+        :arg name: The function's name (without namespace)
+        :arg qualname: The qualname of the function as fed to 'callers:'
+        :arg call_line: The expected line from the result of the 'callers:'
+            search
+        :arg line: The expected line number of the single result from the
+            'callers:' search
+
+        """
+        callers_query = (
+            '/code/search?q=%2Bcallers%3A%22{0}%22'.format(quote_plus(qualname)) if
+            ' ' in qualname else
+            '/code/search?q=%2Bcallers%3A{0}'.format(quote_plus(qualname)))
+        # Check that the header ref uses the right qualname:
+        menu_on(self.source_page('main.h'),
+                name,
+                {'html': 'Find callers',
+                 'href': callers_query})
+        # Check that the implementation ref uses the right qualname:
+        menu_on(self.source_page('foo.cpp'),
+                name,
+                {'html': 'Find callers',
+                 'href': callers_query})
+        # Check that a call site uses the right qualname:
+        menu_on(self.source_page('main.cpp'),
+                name,
+                {'html': 'Find callers',
+                 'href': callers_query})
+        # Check that we actually find the caller:
+        self.found_line_eq('+callers:"{0}"'.format(qualname),
+                            call_line,
+                            line)
+
+    def test_class_qualname_consistency(self):
+        """Test consistency for a function with a class parameter."""
+        self._qualname_check('f_class',
+                             'f_class(bear::t_class)',
+                             '<b>f_class(t_class())</b>;',
+                             7)
+
+    def test_enum_class_qualname_consistency(self):
+        """Test consistency for a function with an enum class parameter."""
+        self._qualname_check('f_enum_class',
+                             'f_enum_class(const bear::t_enum_class *const)',
+                             '<b>f_enum_class(&amp;oversized_feature)</b>;',
+                             9)
+
+    def test_template_qualname_consistency(self):
+        """Test consistency for a function with a namespaced templated parameter."""
+        self._qualname_check('f_template',
+                             'f_template(t_template<sonic::fur>)',
+                             '<b>f_template(t_template&lt;fur&gt;())</b>;',
+                             10)
+
+    def test_typedef_namespace_consisteny(self):
+        """Test consistency for a namespaced function with a typedefed parameter."""
+        self._qualname_check('f_typedef',
+                             'sonic::f_typedef(streamOfInts)',
+                             '<b>f_typedef(streamOfInts())</b>;',
+                             11)


### PR DESCRIPTION
The current practice of using non-canonical decls leads to parameter names
depending on which ref to the function they're pulled from, which means
function qualnames for a given function vary across refs, and then search is
broken.