### PR TITLE
Correctly set 'limit' in JS doQuery when a queryString exists.

### DIFF
--- a/dxr/static_unhashed/js/dxr.js
+++ b/dxr/static_unhashed/js/dxr.js
@@ -282,6 +282,7 @@ $(function() {
 
         // If no data is returned, inform the user.
         if (!data.results.length) {
+            resultsLineCount = 0;
             if (!append) {
                 contentContainer
                     .empty()
@@ -418,8 +419,12 @@ $(function() {
                         previousDataLimit = limit;
                         dataOffset = 0;
                     }
-                    // Start the scroll pos poller.
-                    pollScrollPosition();
+                    // If there were no results this time then we shouldn't turn
+                    // infinite scroll (back) on (otherwise if the number of
+                    // results exactly equals the limit we can end up sending a
+                    // query returning 0 results everytime we scroll).
+                    if (resultsLineCount)
+                        pollScrollPosition();
                 }
 
                 oneFewerRequest();


### PR DESCRIPTION
* On an initial (i.e. non-append) search-results load we were setting
  previousDataLimit to the computed 'limit' var, but the actual limit (explicit
  or implicit) in the case of a pre-existing queryString passed into doQuery can
  be larger than 'limit', in which case we wind up rerequesting results starting
  from the smaller 'limit' when we infinite scroll.  This was only an issue when
  loading a url with an existing query in it and enough search results to
  require infinite scroll.

* Also don't update global search result variables like 'previousDataLimit' and
  'dataOffset' when we receive old outdated results that we ignore.

* Stop infinite scroll when a query returns no results:
If previousDataLimit == resultsLineCount (e.g. there are 100 total results and
we use the default limit of 100) then we used to get into endless infinite
scroll queries returning 0 results everytime we scrolled.  Now we stop
infinite scroll when a query returns 0 results.