### PR TITLE
Add context expansion to LINE search results. [ready to merge when things calm down]

### DIFF
--- a/dxr/static_unhashed/css/dxr.css
+++ b/dxr/static_unhashed/css/dxr.css
@@ -171,7 +171,6 @@ td pre code {
     float: left;
     margin: 0;
     padding: 0;
-    position: relative;
 }
 code a {
     cursor: pointer;
@@ -193,11 +192,11 @@ code a {
 
 /* results */
 
-.results tr:hover,
+.results .result_line:hover,
 .file tr:hover {
     background: none;
 }
-.results tr,
+.results .result_line, .results.result-head
 .file tr {
     border: 0;
     line-height: 1.3;
@@ -205,40 +204,62 @@ code a {
 .left-column,
 .file td:first-child {
     text-align: right;
-    color: #aaa;
+    color: #555;
     width: 6ex;
-}
-.results td {
-    padding: .1rem .5rem;
 }
 .results a {
     cursor: pointer;
     display: inline-block;
 }
-.file a:target {
-    background-color: gray;
-    color: white;
-    padding: 0 .5rem;
-}
 .results code {
     white-space: pre;
 }
-.result-head td
+.result_line, .result-head {
+    position: relative;
+    padding-left: 60px;
+}
+.result_line {
+    padding-top: 5px;
+}
+.result-head
 {
     padding-top: .3rem; /* Additional padding to visually seperate results.*/
-    padding-bottom: 0;
 }
-.result-head td.left-column
+.left-column, .leftmost-column {
+    position: absolute;
+}
+.result-head .left-column
 {
-    padding-right: .2rem; /* Moves the icon closer to the path by reducing the padding.*/
+    left: 8px;
+}
+.result_line .leftmost-column {
+    left: 0px;
+}
+.result_line .left-column {
+    left: 1.5ex;
+}
+.leftmost-column > span:hover
+{
+    cursor: pointer;
+    background: rgba(0, 140, 0, 0.14)
 }
 .result-head a
 {
     display: inline;
 }
+.results .ctx_row {
+    opacity: 0.5;
+}
+.ctx_row .left_column {
+    color: #bbb;
+}
 
 /* end results */
-
+.file a:target {
+    background-color: gray;
+    color: white;
+    padding: 0 .5rem;
+}
 .file td {
     padding: 0;
 }

--- a/dxr/templates/layout.html
+++ b/dxr/templates/layout.html
@@ -91,7 +91,7 @@
     {% set eof = True if state_eof else False %}
 
     <!-- avoid inline JS and use data attributes instead. Hackey but hey... -->
-    <span id="data" data-root="{{ www_root }}" data-search="{{ url_for('.search', tree=tree) }}" data-tree="{{ tree }}"></span>
+    <span id="data" data-root="{{ www_root }}" data-lines="{{ url_for('.lines', tree=tree) }}" data-search="{{ url_for('.search', tree=tree) }}" data-tree="{{ tree }}"></span>
     <span id="state" data-offset="{{state_offset or 0}}" data-limit="{{state_limit or 100}}" data-results-line-count="{{ results_line_count }}" data-eof="{{ eof }}"></span>
 
     {% block site_js %}

--- a/dxr/templates/nunjucks/context_lines.html
+++ b/dxr/templates/nunjucks/context_lines.html
@@ -1,8 +1,14 @@
-{% macro result_lines(result, www_root, tree) -%}
+{% macro context_lines(result, www_root, tree) -%}
   {% for entry in result.lines %}
-    <div class="result_line" data-line={{ entry.line_number }}>
+    <div class="result_line ctx_row" data-line={{ entry.line_number }}>
       <div class="leftmost-column">
-          <span class="ctx_full">♢</span>
+          {% if loop.length > 1 %}
+            {% if loop.index == 1 %}
+                <span class="ctx_up">△</span>
+            {% elif loop.revindex == 1 %}
+                <span class="ctx_down">▽</span>
+            {% endif %}
+          {% endif %}
       </div>
       <div class="left-column">
         <a href="{{ www_root }}/{{ tree }}/source/{{ result.path }}#{{ entry.line_number }}">
@@ -11,7 +17,7 @@
       </div>
       <div>
         <a href="{{ www_root }}/{{ tree }}/source/{{ result.path }}#{{ entry.line_number }}">
-          <code aria-labelledby="{{ entry.line_number }}">{{ entry.line|safe }}</code>
+          <code aria-labelledby="{{ entry.line_number }}">{{ entry.line }}</code>
         </a>
       </div>
     </div>
@@ -19,4 +25,4 @@
 {%- endmacro %}
 
 {# When not being included as a macro, render the code above. #}
-{{ result_lines(result, www_root, tree) }}
+{{ context_lines(result, www_root, tree) }}

--- a/dxr/templates/nunjucks/results.html
+++ b/dxr/templates/nunjucks/results.html
@@ -2,17 +2,17 @@
 
 {% macro results_list(results, www_root, tree) -%}
   {% for result in results %}
-    <tbody class="result" data-path="{{ result.path }}">
-      <tr class="result-head">
-        <td class="left-column">
+    <div class="result" data-path="{{ result.path }}">
+      <div class="result-head">
+        <div class="left-column">
           <div class="{{result.iconClass}} icon-container"></div>
-        </td>
-        <td>
+        </div>
+        <div>
           {{ result.pathLine|safe }}
-        </td>
-      </tr>
+        </div>
+      </div>
       {{ result_lines(result, www_root, tree) }}
-    </tbody>
+    </div>
   {% endfor %}
 {%- endmacro %}
 

--- a/dxr/templates/nunjucks/results_container.html
+++ b/dxr/templates/nunjucks/results_container.html
@@ -4,12 +4,7 @@
 {{ results_header(result_count, result_count_formatted, top_of_tree, tree_tuples, tree) }}
 
 {% if results|length > 0 %}
-  <table class="results">
-    <caption class="visually-hidden">Query matches</caption>
-    <thead class="visually-hidden">
-      <th scope="col">Line</th>
-      <th scope="col">Code Snippet</th>
-    </thead>
+  <div class="results">
     {{ results_list(results, www_root, tree) }}
-  </table>
+  </div>
 {% endif %}

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -1,0 +1,47 @@
+import json
+
+from nose.tools import eq_
+
+from dxr.testing import SingleFileTestCase
+
+
+class ContextTests(SingleFileTestCase):
+    """Tests the id- and ref- aggregate filters defined in query.py"""
+    source = r"""#include <stdio.h>
+// Hello World Example
+int main(int argc, char* argv[]){
+    printf("Hello World %d\n", 2);
+    return 0;
+}
+            """
+
+    def get_ctx(self, fr, to):
+        """Helper method to get lines from fr to to.
+        """
+        return json.loads(self.client().get(
+            self.url_for('.lines', tree='code', path='main', start=fr, end=to))
+            .data)['lines']
+
+    def test_normal(self):
+        """Test that normal context getting works."""
+        eq_(self.get_ctx(1, 2),
+            [{'line_number': 1, 'line': '#include <stdio.h>\n'},
+             {'line_number': 2, 'line': '// Hello World Example\n'}])
+        eq_(self.get_ctx(2, 5),
+            [{u'line_number': 2, u'line': u'// Hello World Example\n'},
+             {u'line_number': 3, u'line': u'int main(int argc, char* argv[]){\n'},
+             {u'line_number': 4, u'line': u'    printf("Hello World %d\\n", 2);\n'},
+             {u'line_number': 5, u'line': u'    return 0;\n'}])
+
+    def test_edges(self):
+        """Test that the edge cases of context getting don't crash."""
+        eq_(self.get_ctx(0, 3),
+            [{u'line_number': 1, u'line': u'#include <stdio.h>\n'},
+             {u'line_number': 2, u'line': u'// Hello World Example\n'},
+             {u'line_number': 3, u'line': u'int main(int argc, char* argv[]){\n'}])
+        eq_(self.get_ctx(3, 9),
+            [{u'line_number': 3, u'line': u'int main(int argc, char* argv[]){\n'},
+             {u'line_number': 4, u'line': u'    printf("Hello World %d\\n", 2);\n'},
+             {u'line_number': 5, u'line': u'    return 0;\n'},
+             {u'line_number': 6, u'line': u'}\n'},
+             {u'line_number': 7, u'line': u'            '}])


### PR DESCRIPTION
Remove tables from the results layout, and add a button on the left to
expand context by querying the new 'lines' app endpoint.

The new layout has space for 5 digits in the line number column.

Maybe fixes [bug 771000](https://bugzilla.mozilla.org/show_bug.cgi?id=771000).

[Example video](https://raw.githubusercontent.com/pelmers/log/master/ctx%20demo.mp4)