### PR TITLE
Reload on popState event every time the page being loaded is a search.

### DIFF
--- a/dxr/static_unhashed/js/dxr.js
+++ b/dxr/static_unhashed/js/dxr.js
@@ -496,7 +496,7 @@ $(function() {
     });
 
     function locationIsSearch() {
-        return /search$/.test(window.location.pathname) && window.location.search;
+        return /search$/.test(window.location.pathname) && window.location.search !== '';
     }
 
     // Expose the DXR Object to the global object.
@@ -514,8 +514,8 @@ $(function() {
 
     // Reload the page when we go back or forward.
     function popStateHandler(event) {
-        if (event.state ||  // If it's a search (we only push state on a search), or...
-            (!locationIsSearch() && lastURLWasSearch)) {  // if we switched from search to file view:
+        if (locationIsSearch() ||  // If new location is a search, or...
+            lastURLWasSearch) {  // if we switched from search to file view:
             window.onpopstate = null;
             window.location.reload();
         }


### PR DESCRIPTION
This fixes the case where we start a new page with a search url (which doesn't
trigger a history push), and then search some more, and then go back.