### PR TITLE
Update deployment doc node version requirement.

### DIFF
--- a/docs/source/deployment.rst
+++ b/docs/source/deployment.rst
@@ -37,7 +37,7 @@ their equivalents on other distributions:
   theoretically support back to 3.2.
 * llvm-dev (LLVM dev headers, version 3.5 recommended)
 * pkg-config
-* npm (Node.js and its package manager)
+* npm; node 6.0.0 or higher
 * openjdk-7-jdk
 * elasticsearch 1.1 or higher. The elasticsearch corporation maintains its own
   packages; they aren't often found in distros. Newer is better, though I tend


### PR DESCRIPTION
In terms of non-docker deployment, I get a not-very-helpful error when I try to `make` the new js plugin (congrats on getting that working by the way!!) with an older node :

```
make -C dxr/plugins/js
make[1]: Entering directory '/tmp/dxr/dxr/plugins/js'
cd analyze_js; npm install
npm WARN package.json js_esprima@1.0.0 No repository field.
npm WARN package.json js_esprima@1.0.0 No README data

> js_esprima@1.0.0 preinstall /tmp/dxr/dxr/plugins/js/analyze_js
> lockdown

sh: lockdown: command not found
npm ERR! weird error 127
npm ERR! not ok code 0
makefile:2: recipe for target 'build' failed
make[1]: *** [build] Error 1
make[1]: Leaving directory '/tmp/dxr/dxr/plugins/js'
makefile:100: recipe for target 'plugins' failed
make: *** [plugins] Error 2
```
When I upgrade to node 6.2.0, no problem.  Should we give a heads up in the deployment docs?