### PR TITLE
Reduce memory usage in js plugin

### DIFF
--- a/dxr/indexers.py
+++ b/dxr/indexers.py
@@ -487,8 +487,6 @@ def span_to_lines((kv, span)):
         warn('Bad Extent: end.row < start.row: %s < %s' %
              (span.end.row, span.start.row))
     else:
-        num_rows = span.end.row - span.start.row
-
         # TODO: There are a lot of Nones used as slice bounds below. Do we
         # ever translate them back into char offsets? If not, does the
         # highlighter or anything else choke on them?
@@ -499,7 +497,6 @@ def span_to_lines((kv, span)):
             yield (kv, 0, None), row
 
         yield (kv, 0, span.end.col), span.end.row
-
 
 
 def split_into_lines(triples):
@@ -519,8 +516,6 @@ def split_into_lines(triples):
             warn('Bad extent: end.row < start.row: %s < %s' %
                  (extent.end.row, extent.start.row))
         else:
-            num_rows = extent.end.row - extent.start.row
-
             # TODO: There are a lot of Nones used as slice bounds below. Do we
             # ever translate them back into char offsets? If not, does the
             # highlighter or anything else choke on them?

--- a/dxr/plugins/js/analyze_js/analyze_file.js
+++ b/dxr/plugins/js/analyze_js/analyze_file.js
@@ -329,7 +329,7 @@ const Analyzer = {
       break;
 
     default:
-      console.log(`In ${fileIndex}, Unexpected statement: ${stmt.type} ${JSON.stringify(stmt)}`);
+      console.warn(`In ${fileIndex}, Unexpected statement: ${stmt.type} ${JSON.stringify(stmt)}`);
       break;
     }
   },
@@ -388,7 +388,7 @@ const Analyzer = {
 
   // Handle an expression by dispatching based on its type.
   expression(expr) {
-    if (!expr) console.log(Error().stack);
+    if (!expr) console.warn(Error().stack);
 
     switch (expr.type) {
     case "Identifier":
@@ -613,8 +613,8 @@ const Analyzer = {
       break;
 
     default:
-      console.log(Error().stack);
-      console.log(`In ${fileIndex}, Unexpected expression ${expr.type}: ${JSON.stringify(expr)}`);
+      console.warn(Error().stack);
+      console.warn(`In ${fileIndex}, Unexpected expression ${expr.type}: ${JSON.stringify(expr)}`);
       break;
     }
   },
@@ -635,7 +635,7 @@ const Analyzer = {
   // Handle a pattern-matching assignment by dispatching on type.
   pattern(pat) {
     if (!pat) {
-      console.log(Error().stack);
+      console.warn(Error().stack);
     }
 
     switch (pat.type) {
@@ -671,7 +671,7 @@ const Analyzer = {
       break;
 
     default:
-      console.log(`In ${fileIndex}, Unexpected pattern: ${pat.type} ${JSON.stringify(pat)}`);
+      console.warn(`In ${fileIndex}, Unexpected pattern: ${pat.type} ${JSON.stringify(pat)}`);
       break;
     }
   }
@@ -749,7 +749,7 @@ function analyzeJS(filepath, relpath, tempFilepath)
       Analyzer.program(ast);
     }
   } catch (e) {
-    console.log(fileIndex, e.name, e.message);
+    console.error(fileIndex, e.name, e.message);
   }
   fs.writeFileSync(tempFilepath, outLines.join('\n'));
 }

--- a/dxr/plugins/js/analyze_js/analyze_tree.js
+++ b/dxr/plugins/js/analyze_js/analyze_tree.js
@@ -61,8 +61,8 @@ function main() {
       const tempPath = path.join(tempRoot, pathSegment);
       ensurePath(tempPath);
       analyzeFile(fullPath,
-                        path.join(pathSegment, stat.name),
-                        path.join(tempPath, stat.name + '.data'));
+                  path.join(pathSegment, stat.name),
+                  path.join(tempPath, stat.name + '.data'));
     }
     next();
   });


### PR DESCRIPTION
Mozilla-central has not been able to index since JS landed because of out of memory.
A js-only run's memory profile looks as follows.
![jsonly](https://cloud.githubusercontent.com/assets/2406051/15722572/40bb169a-27f3-11e6-9fa3-8b179fee3e4c.png)
The largest spike corresponds to mandreel.js, a 277k-line file which was the most likely cause of out of memory.
I add a limit of 100k lines to the JS analyzer because even with the improvements this file will still require about 1.4G of memory, which might still be too much given 4 workers at a time.
