### PR TITLE
Reduce peak memory

### DIFF
--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -84,8 +84,9 @@ containing the config file.
     working directory).
 
 ``skip_stages``
-    Build/indexing stages to skip, for debugging: ``build``, ``index``, or
-    both, whitespace-separated. Default: none
+    Build/indexing/clean stages to skip, for debugging: ``build``, ``index``,
+    ``clean``, or any combination, whitespace-separated Either of ``build`` or
+    ``index`` implies ``clean``. Default: none
 
 ``temp_folder``
     A ``format()``-style template for deciding where to store temporary files

--- a/dxr/build.py
+++ b/dxr/build.py
@@ -354,7 +354,7 @@ def _unignored_folders(folders, source_path, ignore_filenames, ignore_paths):
                 yield folder
 
 
-def file_contents(path, encoding_guess):  # TODO: Make accessible to TreeToIndex.post_build.
+def unicode_contents(path, encoding_guess):  # TODO: Make accessible to TreeToIndex.post_build.
     """Return the unicode contents of a file if we can figure out a decoding,
     or else None.
 
@@ -433,7 +433,7 @@ def index_file(tree, tree_indexers, path, es, index):
 
     """
     try:
-        contents = file_contents(path, tree.source_encoding)
+        contents = unicode_contents(path, tree.source_encoding)
     except IOError as exc:
         if exc.errno == ENOENT and islink(path):
             # It's just a bad symlink (or a symlink that was swiped out

--- a/dxr/indexers.py
+++ b/dxr/indexers.py
@@ -131,8 +131,7 @@ class TreeToIndex(PluginConfig):
         :arg path: A path to the file to index, relative to the tree's source
             folder
         :arg contents: What's in the file: unicode if we managed to guess an
-            encoding and decode it, str otherwise (only the first 4 kb unless
-            it's an image to avoid loading the contents of large binary blobs)
+            encoding and decode it, None otherwise
 
         Return None if there is no indexing to do on the file.
 
@@ -176,11 +175,11 @@ class FileToSkim(PluginConfig):
             source folder. Such a file might not exist on disk. This is useful
             mostly as a hint for syntax coloring.
         :arg contents: What's in the file: unicode if we knew or successfully
-            guessed an encoding, str otherwise. Don't return any by-line data
-            for strs; the framework won't have succeeded in breaking up the
+            guessed an encoding, None otherwise. Don't return any by-line data
+            for None; the framework won't have succeeded in breaking up the
             file by line for display, so there will be no useful UI for those
             data to support. In fact, most skimmers won't be be able to do
-            anything useful with strs at all. For unicode, split the file into
+            anything useful with None at all. For unicode, split the file into
             lines using universal newlines (``unicode.splitlines()`` with no
             params); that's what the rest of the framework expects.
         :arg tree: The :class:`~dxr.config.TreeConfig` of the tree to which
@@ -345,8 +344,8 @@ class FileToIndex(FileToSkim):
         :arg path: A path to the file to index, relative to the tree's source
             folder
         :arg contents: What's in the file: unicode if we managed to guess at an
-            encoding and decode it, str otherwise. Don't return any by-line
-            data for strs; the framework won't have succeeded in breaking up
+            encoding and decode it, None otherwise. Don't return any by-line
+            data for None; the framework won't have succeeded in breaking up
             the file by line for display, so there will be no useful UI for
             those data to support. Think more along the lines of returning
             EXIF data to search by for a JPEG. For unicode, split the file into

--- a/dxr/indexers.py
+++ b/dxr/indexers.py
@@ -131,7 +131,8 @@ class TreeToIndex(PluginConfig):
         :arg path: A path to the file to index, relative to the tree's source
             folder
         :arg contents: What's in the file: unicode if we managed to guess an
-            encoding and decode it, str otherwise
+            encoding and decode it, str otherwise (only the first 4 kb unless
+            it's an image to avoid loading the contents of large binary blobs)
 
         Return None if there is no indexing to do on the file.
 

--- a/dxr/indexers.py
+++ b/dxr/indexers.py
@@ -563,3 +563,20 @@ def iterable_per_line(triples):
             for line_num in xrange(1, last_line)]
 
     # If this has to be generic so we can use it on annotations_by_line as well, pass in a key function that extracts the line number and maybe another that constructs the return value.
+
+def iterable_per_line_sorted(triples):
+    """Yield iterables of (key, value mapping), one for each line, where triples are sorted already."""
+    last_row = 1
+    last_row_kvs = []
+    for k, v, extent in triples:
+        if extent.start.row == last_row:
+            last_row_kvs.append((k, v))
+        else:
+            yield last_row_kvs
+            # Yield empty lists for any skipped lines.
+            for _ in xrange(last_row + 1, extent.start.row):
+                yield []
+            last_row_kvs = [(k, v)]
+            last_row = extent.start.row
+    # Emit anything on the last line.
+    yield last_row_kvs

--- a/dxr/lines.py
+++ b/dxr/lines.py
@@ -464,15 +464,12 @@ def finished_tags(lines, refs, regions):
     """
     # Plugins return unicode offsets, not byte ones.
 
-    # Get start and endpoints of intervals:
-    tags = list(tag_boundaries(chain(refs, regions)))
-
-    tags.extend(line_boundaries(lines))
-
-    # Sorting is actually not a significant use of time in an actual indexing
-    # run.
-    tags.sort(key=nesting_order)  # balanced_tags undoes this, but we tolerate
-                                  # that in html_lines().
+    # balanced_tags undoes the sorting, but we tolerate that in html_lines().
+    # Remark: this sort is the memory peak, but it is not a significant use of
+    # time in an indexing run.
+    tags = sorted(chain(tag_boundaries(chain(refs, regions)),
+                        line_boundaries(lines)),
+                  key=nesting_order)
     remove_overlapping_refs(tags)
     return balanced_tags(tags)
 

--- a/dxr/mime.py
+++ b/dxr/mime.py
@@ -14,11 +14,25 @@ def icon(path, is_binary=False):
     return class_name
 
 
-def decode_data(data, encoding_guess):
-    """Given str data, return an (is_text, data) tuple, where data is returned
-    as unicode if we think it's text and were able to determine an encoding for
-    it."""
-    if not is_binary_string(data[:1024]):
+def decode_file(file_handle, encoding_guess):
+    """Given a file handle, return an (is_text, data) tuple, where data is
+    returned as unicode if we think the block is text and were able to
+    determine an encoding for it, otherwise a string."""
+    initial_portion = file_handle.read(4096)
+    if not is_binary_string(initial_portion):
+        # Move the cursor back to the start of the file.
+        file_handle.seek(0)
+        return decode_data(file_handle.read(), encoding_guess, False)
+    return False, initial_portion
+
+
+def decode_data(data, encoding_guess, can_be_binary=True):
+    """Given string data, return an (is_text, data) tuple, where data is
+    returned as unicode if we think it's text and were able to determine an
+    encoding for it.
+    If can_be_binary is False, then skip the initial is_binary check.
+    """
+    if not (can_be_binary and is_binary_string(data[:1024])):
         try:
             # Try our default encoding.
             data = data.decode(encoding_guess)

--- a/dxr/mime.py
+++ b/dxr/mime.py
@@ -14,18 +14,6 @@ def icon(path, is_binary=False):
     return class_name
 
 
-def decode_file(file_handle, encoding_guess):
-    """Given a file handle, return an (is_text, data) tuple, where data is
-    returned as unicode if we think the block is text and were able to
-    determine an encoding for it, otherwise a string."""
-    initial_portion = file_handle.read(4096)
-    if not is_binary_string(initial_portion):
-        # Move the cursor back to the start of the file.
-        file_handle.seek(0)
-        return decode_data(file_handle.read(), encoding_guess, False)
-    return False, initial_portion
-
-
 def decode_data(data, encoding_guess, can_be_binary=True):
     """Given string data, return an (is_text, data) tuple, where data is
     returned as unicode if we think it's text and were able to determine an

--- a/dxr/plugins/core.py
+++ b/dxr/plugins/core.py
@@ -464,6 +464,10 @@ class FileToIndex(dxr.indexers.FileToIndex):
         # We store both the contents of textual images twice so that they can
         # both show up in searches and be previewed in the browser.
         if is_binary_image(self.path) or is_textual_image(self.path):
+            # If the file was binary, then contents are None, so read it here.
+            if self.contents is None:
+                with open(self.absolute_path(), "rb") as imagefile:
+                    self.contents = imagefile.read()
             bytestring = (self.contents.encode('utf-8') if self.contains_text()
                           else self.contents)
             yield 'raw_data', b64encode(bytestring)

--- a/dxr/plugins/core.py
+++ b/dxr/plugins/core.py
@@ -466,8 +466,8 @@ class FileToIndex(dxr.indexers.FileToIndex):
         if is_binary_image(self.path) or is_textual_image(self.path):
             # If the file was binary, then contents are None, so read it here.
             if self.contents is None:
-                with open(self.absolute_path(), "rb") as imagefile:
-                    self.contents = imagefile.read()
+                with open(self.absolute_path(), 'rb') as image_file:
+                    self.contents = image_file.read()
             bytestring = (self.contents.encode('utf-8') if self.contains_text()
                           else self.contents)
             yield 'raw_data', b64encode(bytestring)

--- a/dxr/plugins/js/indexers.py
+++ b/dxr/plugins/js/indexers.py
@@ -6,8 +6,8 @@ from os.path import basename, dirname, relpath, join, exists
 
 from dxr.plugins.js.refs import PLUGIN_NAME, QualifiedRef
 import dxr.indexers
-from dxr.indexers import (Extent, Position, iterable_per_line,
-                          with_start_and_end, split_into_lines)
+from dxr.indexers import (Extent, Position, iterable_per_line_sorted,
+                          with_start_and_end)
 from dxr.utils import cumulative_sum
 
 
@@ -45,7 +45,6 @@ class TreeToIndex(dxr.indexers.TreeToIndex):
 
     def file_to_index(self, path, contents):
         return FileToIndex(path, contents, self.plugin_name, self.tree)
-
 
 class FileToIndex(dxr.indexers.FileToIndex):
     def __init__(self, path, contents, plugin_name, tree):
@@ -95,7 +94,7 @@ class FileToIndex(dxr.indexers.FileToIndex):
                     typ += '_ref'
                 yield self.build_needle(typ, row, start, end, line.name, line.sym)
 
-        return iterable_per_line(with_start_and_end(all_needles()))
+        return iterable_per_line_sorted(with_start_and_end(all_needles()))
 
     def refs(self):
         for line in self.lines:

--- a/dxr/plugins/python/analysis.py
+++ b/dxr/plugins/python/analysis.py
@@ -8,7 +8,7 @@ import os
 from collections import defaultdict
 from warnings import warn
 
-from dxr.build import file_contents
+from dxr.build import unicode_contents
 from dxr.plugins.python.utils import (ClassFunctionVisitorMixin,
                                       convert_node_to_name, package_for_module,
                                       path_to_module, ast_parse)
@@ -50,7 +50,7 @@ class TreeAnalysis(object):
 
         """
         try:
-            syntax_tree = ast_parse(file_contents(path, encoding))
+            syntax_tree = ast_parse(unicode_contents(path, encoding))
         except (IOError, SyntaxError, TypeError, UnicodeDecodeError) as error:
             rel_path = os.path.relpath(path, self.source_folder)
             warn('Failed to analyze {filename} due to error "{error}".'.format(


### PR DESCRIPTION
Clear dicts after use, add 'clean' to skip_stages option.
Because a list held references to all the dicts, memory usage increased
as the indexer adds fields to the dict, even though it never used the
dict after yielding it, especially applicable to files with many lines.
Reduce peak memory usage by 10-20%.

I add "clean" to skip_stages since I had it for testing and it seems intuitive to have, but I can back that part out.

Also the sorted iterable_per_line only reduces memory usage marginally, because the peak still occurs when all the needles are concretized and then sorted in finished_tags, so I could bring that out too for simplification without much impact (tens of megabytes).

The second change is that files are initially only read up to the first 4kb, and the full contents are not read until either 1) we know it might not be binary, or 2) it's an image whose contents we store.