### PR TITLE
Avoid reflow on click by unwrapping and removing padding

### DIFF
--- a/dxr/lines.py
+++ b/dxr/lines.py
@@ -160,7 +160,7 @@ class Ref(object):
         else:
             title = ''
         if self.qualname_hash is not None:
-            cls = ' class="tok%i"' % self.qualname_hash
+            cls = ' data-id="tok%i"' % self.qualname_hash
         else:
             cls = ''
 

--- a/dxr/static_unhashed/css/dxr.css
+++ b/dxr/static_unhashed/css/dxr.css
@@ -183,9 +183,8 @@ code a {
 .code code a {
     cursor: context-menu;
 }
-mark {
-    position: relative;
-    padding: .5rem;
+.clicking {
+    background-color: yellow;
 }
 .logo a:focus {
     background-color: transparent;
@@ -251,9 +250,6 @@ mark {
 }
 .access-key {
     text-decoration: underline;
-}
-mark {
-    padding: .3rem 0;
 }
 
 /* Context Menu */

--- a/dxr/static_unhashed/js/context_menu.js
+++ b/dxr/static_unhashed/js/context_menu.js
@@ -25,12 +25,13 @@ $(function() {
      */
     function toggleSymbolHighlights(currentNode) {
         // First remove all highlighting
-        fileContainer.find('mark a').unwrap();
+        fileContainer.find('.clicking').removeClass('clicking');
 
         // Only add highlights if the currentNode is not undefined or null and
         // is an anchor link, as symbols will always be links.
         if (currentNode && currentNode[0].tagName === 'A') {
-            fileContainer.find('.' + currentNode.attr('class')).wrap('<mark />');
+            let id = currentNode.data('id');
+            fileContainer.find('a[data-id=' + id + ']').addClass('clicking');
         }
     }
 


### PR DESCRIPTION
Fixes bug 1279001 by avoiding DOM mutation and box model recalculating (not changing padding).

Unfortunately it looks a little less pretty because we don't have the padding around the background.
<img width="368" alt="screen shot 2016-06-08 at 1 28 38 pm" src="https://cloud.githubusercontent.com/assets/2406051/15909824/f63bc01c-2d7c-11e6-8b27-f7689cab49df.png">
