### PR TITLE
Avoid a second re-layout by attaching the menu to the body.

### DIFF
--- a/dxr/static_unhashed/css/dxr.css
+++ b/dxr/static_unhashed/css/dxr.css
@@ -185,6 +185,7 @@ code a {
 }
 .clicking {
     background-color: yellow;
+    box-shadow: 0px 0.15rem yellow, 0px -0.15rem yellow;
 }
 .logo a:focus {
     background-color: transparent;

--- a/dxr/static_unhashed/js/context_menu.js
+++ b/dxr/static_unhashed/js/context_menu.js
@@ -170,7 +170,12 @@ $(function() {
             }
 
             contextMenu.menuItems = menuItems;
-            setContextMenu(fileContainer, contextMenu, event);
+            // Rather than putting the context menu in the file container,
+            // attaching it to the body makes the re-layout much quicker
+            // because the lines of the file do not need to be re-flowed.
+            // In the end they're the same, since the menu will be absolute'd
+            // to where it should go.
+            setContextMenu($('body'), contextMenu, event);
         }
     });
 


### PR DESCRIPTION
Also use a box-shadow to recreate the original padded appearance.