### PR TITLE
Add a descriptor plugin that emulates MXR's descriptor column.

### DIFF
--- a/docs/source/development.rst
+++ b/docs/source/development.rst
@@ -203,6 +203,7 @@ collection of subcomponents which do the actual work:
 
 .. digraph:: plugin
 
+   "Plugin" -> "FolderToIndex";
    "Plugin" -> "TreeToIndex" -> "FileToIndex";
    "Plugin" -> "FileToSkim";
    "Plugin" -> "filters";
@@ -248,8 +249,14 @@ manually:
     .. autoclass:: dxr.plugins.Plugin
        :members:
 
-Actual plugin functionality is implemented within tree indexers, file
-indexers, filters, and skimmers.
+Actual plugin functionality is implemented within file indexers, tree indexers,
+file indexers, filters, and skimmers.
+
+Folder Indexers
+=============
+
+.. autoclass:: dxr.indexers.TreeToIndex
+   :members:
 
 Tree Indexers
 =============

--- a/docs/source/development.rst
+++ b/docs/source/development.rst
@@ -253,9 +253,9 @@ Actual plugin functionality is implemented within file indexers, tree indexers,
 folder indexers, filters, and skimmers.
 
 Folder Indexers
-=============
+===============
 
-.. autoclass:: dxr.indexers.TreeToIndex
+.. autoclass:: dxr.indexers.FolderToIndex
    :members:
 
 Tree Indexers

--- a/docs/source/development.rst
+++ b/docs/source/development.rst
@@ -250,7 +250,7 @@ manually:
        :members:
 
 Actual plugin functionality is implemented within file indexers, tree indexers,
-file indexers, filters, and skimmers.
+folder indexers, filters, and skimmers.
 
 Folder Indexers
 =============

--- a/dxr/app.py
+++ b/dxr/app.py
@@ -361,6 +361,7 @@ def browse(tree, path=''):
 def concat_plugin_headers(plugin_list):
     """Return a list of the concatenation of all browse_headers in the
     FolderToIndexes of given plugin list.
+
     """
     return list(chain.from_iterable(p.folder_to_index.browse_headers
                                     for p in plugin_list if p.folder_to_index))

--- a/dxr/build.py
+++ b/dxr/build.py
@@ -602,7 +602,7 @@ def index_folders(tree, index, es):
                 continue
             needles = {'is_folder': True}
             for name, folder_to_index in folder_indexers:
-                needles.update(dict((folder_to_index(name, tree, folder)).needles()))
+                needles.update(dict(folder_to_index(name, tree, folder)).needles())
             es.index(index, FILE, needles)
 >>>>>>> 639bf4c... Add a descriptor plugin that emulates MXR's descriptor column.
 

--- a/dxr/build.py
+++ b/dxr/build.py
@@ -604,7 +604,6 @@ def index_folders(tree, index, es):
             for name, folder_to_index in folder_indexers:
                 needles.update(dict(folder_to_index(name, tree, folder)).needles())
             es.index(index, FILE, needles)
->>>>>>> 639bf4c... Add a descriptor plugin that emulates MXR's descriptor column.
 
 
 def index_files(tree, tree_indexers, index, pool, es):

--- a/dxr/build.py
+++ b/dxr/build.py
@@ -378,7 +378,7 @@ def unicode_contents(path, encoding_guess):  # TODO: Make accessible to TreeToIn
 
 
 def unignored(folder, ignore_paths, ignore_filenames, want_folders=False):
-    """Return an iterable of UTF-8 encoded absolute paths to unignored source
+    """Return an iterable of Unicode absolute paths to unignored source
     tree files or the folders that contain them. Skip any non-utf8-decodeable
     paths.
 

--- a/dxr/build.py
+++ b/dxr/build.py
@@ -602,7 +602,7 @@ def index_folders(tree, index, es):
                 continue
             needles = {'is_folder': True}
             for name, folder_to_index in folder_indexers:
-                needles.update(dict(folder_to_index(name, tree, folder)).needles())
+                needles.update(dict(folder_to_index(name, tree, folder).needles()))
             es.index(index, FILE, needles)
 
 

--- a/dxr/build.py
+++ b/dxr/build.py
@@ -414,7 +414,7 @@ def unignored(folder, ignore_paths, ignore_filenames, want_folders=False):
                 try:
                     yield join(root, f).decode('utf-8')
                 except UnicodeDecodeError:
-                    continue
+                    pass
 
         # Exclude folders that match an ignore pattern.
         # os.walk listens to any changes we make in `folders`.
@@ -425,7 +425,7 @@ def unignored(folder, ignore_paths, ignore_filenames, want_folders=False):
                 try:
                     yield join(root, f).decode('utf-8')
                 except UnicodeDecodeError:
-                    continue
+                    pass
 
 def index_file(tree, tree_indexers, path, es, index):
     """Index a single file into ES, and build a static HTML representation of it.

--- a/dxr/build.py
+++ b/dxr/build.py
@@ -378,8 +378,9 @@ def unicode_contents(path, encoding_guess):  # TODO: Make accessible to TreeToIn
 
 
 def unignored(folder, ignore_paths, ignore_filenames, want_folders=False):
-    """Return an iterable of absolute paths to unignored source tree files or
-    the folders that contain them.
+    """Return an iterable of UTF-8 encoded absolute paths to unignored source
+    tree files or the folders that contain them. Skip any non-utf8-decodeable
+    paths.
 
     Returned files include both binary and text ones.
 
@@ -410,7 +411,10 @@ def unignored(folder, ignore_paths, ignore_filenames, want_folders=False):
                 if any(fnmatchcase("/" + path.replace(os.sep, "/"), e) for e in ignore_paths):
                     continue  # Ignore the file.
 
-                yield join(root, f)
+                try:
+                    yield join(root, f).decode('utf-8')
+                except UnicodeDecodeError:
+                    continue
 
         # Exclude folders that match an ignore pattern.
         # os.walk listens to any changes we make in `folders`.
@@ -418,7 +422,10 @@ def unignored(folder, ignore_paths, ignore_filenames, want_folders=False):
             folders, rel_path, ignore_filenames, ignore_paths)
         if want_folders:
             for f in folders:
-                yield join(root, f)
+                try:
+                    yield join(root, f).decode('utf-8')
+                except UnicodeDecodeError:
+                    continue
 
 def index_file(tree, tree_indexers, path, es, index):
     """Index a single file into ES, and build a static HTML representation of it.
@@ -446,10 +453,6 @@ def index_file(tree, tree_indexers, path, es, index):
     # Just like index_folders, if the path is not in UTF-8, then elasticsearch
     # will not accept the path, so just move on.
     rel_path = relpath(path, tree.source_folder)
-    try:
-        rel_path = rel_path.decode('utf-8')
-    except UnicodeDecodeError:
-        return
     is_text = isinstance(contents, unicode)
     is_link = islink(path)
     # Index by line if the contents are text and the path is not a symlink.
@@ -572,7 +575,7 @@ def index_chunk(tree,
                        open_log(tree.log_folder,
                                 'index-chunk-%s.log' % worker_number))
                 for path in paths:
-                    log and log.write('Starting %s.\n' % path)
+                    log and log.write('Starting %s.\n' % path.encode('utf-8'))
                     index_file(tree, tree_indexers, path, es, index)
                 log and log.write('Finished chunk.\n')
             finally:
@@ -596,10 +599,6 @@ def index_folders(tree, index, es):
                      show_eta=False,  # never even close
                      label='Indexing folders') as folders:
         for folder in folders:
-            try:
-                folder = folder.decode('utf-8')
-            except UnicodeDecodeError:
-                continue
             needles = {'is_folder': True}
             for name, folder_to_index in folder_indexers:
                 needles.update(dict(folder_to_index(name, tree, folder).needles()))
@@ -637,7 +636,7 @@ def index_files(tree, tree_indexers, index, pool, es):
             result = future.result()
             if result:
                 formatted_tb, type, value, path = result
-                print 'A worker failed while indexing %s:' % path
+                print 'A worker failed while indexing %s:' % path.encode('utf-8')
                 print formatted_tb
                 # Abort everything if anything fails:
                 raise type, value  # exits with non-zero

--- a/dxr/indexers.py
+++ b/dxr/indexers.py
@@ -65,6 +65,21 @@ class PluginConfig(object):
         return getattr(self.tree, self.plugin_name)
 
 
+class FolderToIndex(PluginConfig):
+    """The FolderToIndex generates needles for folders, and provides an
+    optional list of headers to display in browse view as `browse_headers`.
+    """
+    browse_headers = []
+
+    def __init__(self, plugin_name, tree, path):
+        self.plugin_name = plugin_name
+        self.tree = tree
+        self.path = path
+
+    def needles(self):
+        return []
+
+
 class TreeToIndex(PluginConfig):
     """A TreeToIndex performs build environment setup and teardown and serves
     as a repository for scratch data that should persist across an entire

--- a/dxr/indexers.py
+++ b/dxr/indexers.py
@@ -66,7 +66,7 @@ class PluginConfig(object):
 
 
 class FolderToIndex(PluginConfig):
-    """The FolderToIndex generates needles for folders, and provides an
+    """The FolderToIndex generates needles for folders and provides an
     optional list of headers to display in browse view as `browse_headers`.
     """
     browse_headers = []

--- a/dxr/plugins/__init__.py
+++ b/dxr/plugins/__init__.py
@@ -41,6 +41,7 @@ class Plugin(object):
     """
     def __init__(self,
                  filters=None,
+                 folder_to_index=None,
                  tree_to_index=None,
                  file_to_skim=None,
                  mappings=None,
@@ -50,6 +51,7 @@ class Plugin(object):
                  config_schema=None):
         """
         :arg filters: A list of filter classes
+        :arg folder_to_index: A :class:`FolderToIndex` subclass
         :arg tree_to_index: A :class:`TreeToIndex` subclass
         :arg file_to_skim: A :class:`FileToSkim` subclass
         :arg mappings: Additional Elasticsearch mapping definitions for all the
@@ -98,6 +100,7 @@ class Plugin(object):
         # we can parallelize even better. OTOH, there are probably a LOT of
         # files in any time-consuming tree, so we already have a perfectly
         # effective and easier way to parallelize.
+        self.folder_to_index = folder_to_index
         self.tree_to_index = tree_to_index
         self.file_to_skim = file_to_skim
         self.mappings = mappings or {}
@@ -138,6 +141,7 @@ class Plugin(object):
                     file_to_index_class=namespace.get('FileToIndex'))
 
         return cls(filters=filters_from_namespace(namespace),
+                   folder_to_index=namespace.get('FolderToIndex'),
                    tree_to_index=tree_to_index,
                    file_to_skim=namespace.get('FileToSkim'),
                    mappings=namespace.get('mappings'),

--- a/dxr/plugins/core.py
+++ b/dxr/plugins/core.py
@@ -4,7 +4,7 @@ from base64 import b64encode
 from datetime import datetime
 from itertools import chain
 from os import stat
-from os.path import relpath, splitext, realpath, basename
+from os.path import relpath, splitext, realpath, basename, split
 import re
 
 from flask import url_for
@@ -86,6 +86,7 @@ mappings = {
                 'type': 'boolean',
                 'index': 'no'
             },
+            'description': UNINDEXED_STRING,
 
             # Sidebar nav links:
             'links': {
@@ -435,6 +436,17 @@ class RefFilter(FilterAggregator):
 
     def __init__(self, term, enabled_plugins):
         super(RefFilter, self).__init__(term, enabled_plugins, lambda f: f.is_reference)
+
+
+class FolderToIndex(dxr.indexers.FolderToIndex):
+    def needles(self):
+        rel_path = relpath(self.path, self.tree.source_folder)
+        superfolder_path, folder_name = split(rel_path)
+        return [
+            ('path', [rel_path]),  # array for consistency with non-folder file docs
+            ('folder', superfolder_path),
+            ('name', folder_name)
+        ]
 
 
 class TreeToIndex(dxr.indexers.TreeToIndex):

--- a/dxr/plugins/descriptor/__init__.py
+++ b/dxr/plugins/descriptor/__init__.py
@@ -58,8 +58,8 @@ class FileToIndex(dxr.indexers.FileToIndex):
     """Do lots of work to yield a description needle."""
 
     comment_re = re.compile(r'(?:.*?/\*+)(?:\s*\*?\s*)(?P<description>.*?)(?:(?:\*+/)|(?:$))', flags=re.S)
-    docstring_res = [re.compile(r'"""\s*(?P<description>[^"]*)', flags=re.M),
-                     re.compile(r"'''\s*(?P<description>[^']*)", flags=re.M)]
+    docstring_res = [re.compile(r'"""\s*(?P<description>[^"]*)"""', flags=re.M),
+                     re.compile(r"'''\s*(?P<description>[^']*)'''", flags=re.M)]
     title_re = re.compile(r'<title>([^<]*)</title>')
 
     def __init__(self, path, contents, plugin_name, tree):
@@ -146,5 +146,5 @@ class FileToIndex(dxr.indexers.FileToIndex):
             desc_lower = desc.lower()
             # Skip any comment that contains the license or a tab-width
             # emacs/vim setting.
-            if not any((pattern in desc_lower for pattern in {'tab-width', 'license', 'vim:'})):
+            if not any(pattern in desc_lower for pattern in ('tab-width', 'license', 'vim:')):
                 return desc

--- a/dxr/plugins/descriptor/__init__.py
+++ b/dxr/plugins/descriptor/__init__.py
@@ -1,0 +1,106 @@
+"""Descriptor - Provide useful descriptions for common file types.
+Refer to https://mxr.mozilla.org/webtools-central/source/mxr/Local.pm#27
+"""
+import re
+from os import listdir
+from os.path import splitext, basename, join, isfile
+
+import dxr.indexers
+
+
+class FolderToIndex(dxr.indexers.FolderToIndex):
+    browse_headers = ['Description']
+
+    def needles(self):
+        """If the folder contains a readme, then yield the first line of the
+        readme as the description.
+        Similar to https://mxr.mozilla.org/webtools-central/source/mxr/Local.pm#251
+        """
+        for entry in listdir(self.path):
+            path = join(self.path, entry)
+            # If we find a readme, then open it and return the first line if
+            # it's non-empty.
+            if "readme" in entry.lower() and isfile(path):
+                with open(path) as readme:
+                    first_line = readme.readline(100).strip()
+                    if first_line:
+                        # Pack into a list for consistency with the file needle.
+                        return [("Description", [first_line])]
+        # Didn't find anything to use as a description
+        return []
+
+
+class FileToIndex(dxr.indexers.FileToIndex):
+    """Do lots of work to yield a description needle."""
+
+    comment_re = re.compile(r'(?:.*?/\*+)(?:\s*\*?\s*)(?P<description>.*?)(?:(?:\*+/.*)|(?:$))', flags=re.M)
+    docstring_re = re.compile(r'(\'\'\'|""")(?:\s*)(?P<description>.*?)(?:(?:(\'\'\'|"""))|(?:$))', flags=re.M)
+    title_re = re.compile(r'<title>([^<]*)</title>')
+
+    def needles(self):
+        if self.contains_text():
+            extension = splitext(self.path)[1]
+            description = None
+            if extension:
+                try:
+                    # Find the describer method, skipping the dot on extension.
+                    describer = getattr(self, 'describe_' + extension[1:])
+                except AttributeError:
+                    # Don't have a descriptor function for this file type, we can try generic later.
+                    pass
+                else:
+                    description = describer()
+            if not description:
+                description = self.generic_describe()
+            if description:
+                yield 'Description', description[:100].strip()
+
+    def describe_html(self):
+        """Return the contents of the <title> tag."""
+
+        match = re.search(self.title_re, self.contents)
+        if match:
+            return match.group(1)
+
+    def describe_py(self):
+        """Return the contents of the first line of the first docstring if
+        there is one in the first 60 lines."""
+
+        sixty_lines = self.contents.splitlines(True)[:60]
+        match = re.search(self.docstring_re, ''.join(sixty_lines))
+        if match:
+            return match.group('description')
+
+    def generic_describe(self):
+        """Look at the first 60 lines for a match for {{self.path|description}}
+        [delimiter] text, and return the first text we find. Unless it's a
+        readme, then return the first line."""
+
+        sixty_lines = self.contents.splitlines(True)[:60]
+        filename = basename(self.path)
+        # Is it a readme? Just return the first non-empty line.
+        if "readme" in filename.lower():
+            for line in sixty_lines:
+                if line:
+                    return line
+        # Not a readme file, try to match the filename: description pattern.
+        root, ext = splitext(filename)
+        delimiters = ':,-'
+        description_re = re.compile(r'({}|{}|description)\
+                                     ({})?\s*([{}]\n?)\s*\
+                                     (?P<description>[\w\s-]+)'.format(self.path,
+                                                                       root,
+                                                                       ext,
+                                                                       delimiters),
+                                    re.IGNORECASE)
+        for line in sixty_lines:
+            match = re.search(description_re, line)
+            if match:
+                return match.group('description')
+
+        # Haven't returned so we can fall back to the first non-empty line of
+        # the first doc-comment.
+        # TODO: skip the license
+        match = re.search(self.comment_re, ''.join(sixty_lines))
+        if match:
+            return match.group('description')

--- a/dxr/plugins/descriptor/__init__.py
+++ b/dxr/plugins/descriptor/__init__.py
@@ -57,7 +57,7 @@ class FolderToIndex(dxr.indexers.FolderToIndex):
 class FileToIndex(dxr.indexers.FileToIndex):
     """Do lots of work to yield a description needle."""
 
-    comment_re = re.compile(r'(?:.*?/\*+)(?:\s*\*?\s*)(?P<description>.*?)(?:(?:\*+/.*)|(?:$))', flags=re.M)
+    comment_re = re.compile(r'(?:.*?/\*+)(?:\s*\*?\s*)(?P<description>.*?)(?:(?:\*+/)|(?:$))', flags=re.S)
     docstring_res = [re.compile(r'"""\s*(?P<description>[^"]*)', flags=re.M),
                      re.compile(r"'''\s*(?P<description>[^']*)", flags=re.M)]
     title_re = re.compile(r'<title>([^<]*)</title>')
@@ -141,7 +141,10 @@ class FileToIndex(dxr.indexers.FileToIndex):
 
         # Haven't returned so we can fall back to the first non-empty line of
         # the first doc-comment.
-        # TODO: skip the license
-        match = self.comment_re.search(''.join(self.sixty_lines))
-        if match:
-            return match.group('description')
+        for match in self.comment_re.finditer(''.join(self.sixty_lines)):
+            desc = match.group('description')
+            desc_lower = desc.lower()
+            # Skip any comment that contains the license or a tab-width
+            # emacs/vim setting.
+            if not any((pattern in desc_lower for pattern in {'tab-width', 'license', 'vim:'})):
+                return desc

--- a/dxr/plugins/descriptor/__init__.py
+++ b/dxr/plugins/descriptor/__init__.py
@@ -119,9 +119,9 @@ class FileToIndex(dxr.indexers.FileToIndex):
         try:
             description_re = re.compile(r'(?:{}|{}|description)\
                                           (?:{})?\s*(?:[{}]\n?)\s*\
-                                          (?P<description>[\w\s-]+)'.format(re.escape(self.path),
-                                                                            re.escape(root),
-                                                                            re.escape(ext),
+                                          (?P<description>[\w\s-]+)'.format(re.escape(self.path.encode('utf-8')),
+                                                                            re.escape(root.encode('utf-8')),
+                                                                            re.escape(ext.encode('utf-8')),
                                                                             delimiters),
                                         re.IGNORECASE)
             for line in self.sixty_lines:

--- a/dxr/plugins/descriptor/__init__.py
+++ b/dxr/plugins/descriptor/__init__.py
@@ -125,13 +125,13 @@ class FileToIndex(dxr.indexers.FileToIndex):
         root, ext = splitext(filename)
         delimiters = ':,-'
         try:
-            description_re = re.compile(r'(?:{}|{}|description)\
-                                          (?:{})?\s*(?:[{}]\n?)\s*\
-                                          (?P<description>[\w\s-]+)'.format(re.escape(self.path.encode('utf-8')),
-                                                                            re.escape(root.encode('utf-8')),
-                                                                            re.escape(ext.encode('utf-8')),
-                                                                            delimiters),
-                                        re.IGNORECASE)
+            description_re = re.compile(ur'(?:{}|{}|description)'
+                                          '(?:{})?\s*(?:[{}]\n?)\s*'
+                                          '(?P<description>[\w\s-]+)'.format(re.escape(self.path),
+                                                                             re.escape(root),
+                                                                             re.escape(ext),
+                                                                             delimiters),
+                                        re.IGNORECASE | re.UNICODE)
             for line in self.sixty_lines:
                 match = description_re.search(line)
                 if match:

--- a/dxr/plugins/descriptor/__init__.py
+++ b/dxr/plugins/descriptor/__init__.py
@@ -15,10 +15,7 @@ def describe_readme(lines):
     presumed readme file or None if it can extract no suitable description.
     """
     # For now the heuristic is just the first non-empty line.
-    try:
-        return next(ifilter(None, (line.strip() for line in lines)))
-    except StopIteration:
-        return None
+    return next(ifilter(None, (line.strip() for line in lines)), None)
 
 
 class FolderToIndex(dxr.indexers.FolderToIndex):

--- a/dxr/plugins/descriptor/tests/test_descriptions/code/README
+++ b/dxr/plugins/descriptor/tests/test_descriptions/code/README
@@ -1,0 +1,1 @@
+  A line of the readme, with prepended spaces.

--- a/dxr/plugins/descriptor/tests/test_descriptions/code/foo.c
+++ b/dxr/plugins/descriptor/tests/test_descriptions/code/foo.c
@@ -1,0 +1,11 @@
+/**
+ * Here's some text which should not be in the description because there's a
+ * better match later.
+ *
+ *
+ *
+ *
+ *
+ * foo.c: great code.
+ */
+extern int foo;

--- a/dxr/plugins/descriptor/tests/test_descriptions/code/foo.js
+++ b/dxr/plugins/descriptor/tests/test_descriptions/code/foo.js
@@ -1,6 +1,6 @@
 /**
- * Define foo, a dynamic higher order weakly typed late binded function.
+ * Define foon, a dynamic higher order weakly typed late binded function.
  */
-function foo(x) {
+function foon(x) {
     return x() + 2;
 }

--- a/dxr/plugins/descriptor/tests/test_descriptions/code/foo.js
+++ b/dxr/plugins/descriptor/tests/test_descriptions/code/foo.js
@@ -1,0 +1,6 @@
+/**
+ * Define foo, a dynamic higher order weakly typed late binded function.
+ */
+function foo(x) {
+    return x() + 2;
+}

--- a/dxr/plugins/descriptor/tests/test_descriptions/code/foo.py
+++ b/dxr/plugins/descriptor/tests/test_descriptions/code/foo.py
@@ -1,0 +1,15 @@
+"""
+
+
+
+
+
+
+
+
+
+
+
+
+foo.py: some very Pythonic codes.
+"""

--- a/dxr/plugins/descriptor/tests/test_descriptions/code/foo.rs
+++ b/dxr/plugins/descriptor/tests/test_descriptions/code/foo.rs
@@ -1,0 +1,7 @@
+/**
+ * Some comment, this shouldn't be the description.
+ *
+ * Description: more foo.
+ */
+
+fn main() {}

--- a/dxr/plugins/descriptor/tests/test_descriptions/code/licensed.c
+++ b/dxr/plugins/descriptor/tests/test_descriptions/code/licensed.c
@@ -1,0 +1,9 @@
+/* -*- Mode: C++; tab-width: 2; indent-tabs-mode: nil; c-basic-offset: 2 -*- */
+/* vim: set ts=2 et sw=2 tw=80: */
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+/* The description appears after a MPL and after some mode settings. */
+int main() { return 0; }
+

--- a/dxr/plugins/descriptor/tests/test_descriptions/code/sub/README.txt
+++ b/dxr/plugins/descriptor/tests/test_descriptions/code/sub/README.txt
@@ -1,0 +1,3 @@
+Highly important subfolder. with a description over 100 bbytesbytesbytesbytesbytesbytesbytesbytesbytesbytesbytesbytesbytesbytesytes
+=====
+this line not in the description

--- a/dxr/plugins/descriptor/tests/test_descriptions/code/sub/foo.cpp
+++ b/dxr/plugins/descriptor/tests/test_descriptions/code/sub/foo.cpp
@@ -1,0 +1,3 @@
+/*
+ * Foo is great. */
+int foo = 3;

--- a/dxr/plugins/descriptor/tests/test_descriptions/code/sub/foo.html
+++ b/dxr/plugins/descriptor/tests/test_descriptions/code/sub/foo.html
@@ -1,0 +1,8 @@
+<html>
+    <head>
+        <title>foo html!</title>
+    </head>
+    <body>
+        Some foo.
+    </body>
+</html>

--- a/dxr/plugins/descriptor/tests/test_descriptions/dxr.config
+++ b/dxr/plugins/descriptor/tests/test_descriptions/dxr.config
@@ -1,0 +1,10 @@
+[DXR]
+enabled_plugins     = descriptor
+es_index            = dxr_test_{format}_{tree}_{unique}
+es_alias            = dxr_test_{format}_{tree}
+es_catalog_index    = dxr_test_catalog
+
+[code]
+source_folder       = code
+build_command       =
+clean_command       =

--- a/dxr/plugins/descriptor/tests/test_descriptions/test_descriptions.py
+++ b/dxr/plugins/descriptor/tests/test_descriptions/test_descriptions.py
@@ -10,8 +10,8 @@ from dxr.testing import DxrInstanceTestCase
 class DescriptionTests(DxrInstanceTestCase):
     def test_browse_page(self):
         """Test that the expected descriptions appear on the root page.
-        """
 
+        """
         response = self.client().get('/code/source/').data
         ok_("Highly important subfolder. with a description over 100 bbytesbytesbytesbytesbytesbytesbytesbytesbyt" in response)
         # Make sure we didn't exceed the limit.
@@ -26,8 +26,8 @@ class DescriptionTests(DxrInstanceTestCase):
 
     def test_sub_browse_page(self):
         """Test that the expected descriptions appear on the subfolder's page.
-        """
 
+        """
         response = self.client().get('/code/source/sub/').data
         # cpp description with /* */ comment
         ok_("Foo is great." in response)

--- a/dxr/plugins/descriptor/tests/test_descriptions/test_descriptions.py
+++ b/dxr/plugins/descriptor/tests/test_descriptions/test_descriptions.py
@@ -27,6 +27,8 @@ class DescriptionTests(DxrInstanceTestCase):
         ok_("more foo" in response)
         # Second case of generic description_re.
         ok_("great code" in response)
+        # Make sure license, vim, emacs mode lines skip.
+        ok_("The description appears after a MPL and after some mode settings." in response)
 
     def test_sub_browse_page(self):
         """Test that the expected descriptions appear on the subfolder's page.

--- a/dxr/plugins/descriptor/tests/test_descriptions/test_descriptions.py
+++ b/dxr/plugins/descriptor/tests/test_descriptions/test_descriptions.py
@@ -20,9 +20,13 @@ class DescriptionTests(DxrInstanceTestCase):
         # Check that I stripped prepended spaces.
         ok_("  A line of the readme, with prepended spaces." not in response)
         # Javascript description with /** */ comment
-        ok_("Define foo, a dynamic higher order weakly typed late binded function." in response)
+        ok_("Define foon, a dynamic higher order weakly typed late binded function." in response)
         # Python docstring
         ok_("foo.py: some very Pythonic codes." in response)
+        # First case of generic description_re.
+        ok_("more foo" in response)
+        # Second case of generic description_re.
+        ok_("great code" in response)
 
     def test_sub_browse_page(self):
         """Test that the expected descriptions appear on the subfolder's page.

--- a/dxr/plugins/descriptor/tests/test_descriptions/test_descriptions.py
+++ b/dxr/plugins/descriptor/tests/test_descriptions/test_descriptions.py
@@ -1,0 +1,37 @@
+"""Test that the plugin finds the expected descriptions, and they appear on the
+browse pages.
+
+"""
+from nose.tools import ok_
+
+from dxr.testing import DxrInstanceTestCase
+
+
+class DescriptionTests(DxrInstanceTestCase):
+    def test_browse_page(self):
+        """Test that the expected descriptions appear on the root page.
+        """
+
+        response = self.client().get('/code/source/').data
+        ok_("Highly important subfolder. with a description over 100 bbytesbytesbytesbytesbytesbytesbytesbytesbyt" in response)
+        # Make sure we didn't exceed the limit.
+        ok_("Highly important subfolder. with a description over 100 bbytesbytesbytesbytesbytesbytesbytesbytesbyte" not in response)
+        ok_("A line of the readme, with prepended spaces." in response)
+        # Check that I stripped prepended spaces.
+        ok_("  A line of the readme, with prepended spaces." not in response)
+        # Javascript description with /** */ comment
+        ok_("Define foo, a dynamic higher order weakly typed late binded function." in response)
+        # Python docstring
+        ok_("foo.py: some very Pythonic codes." in response)
+
+    def test_sub_browse_page(self):
+        """Test that the expected descriptions appear on the subfolder's page.
+        """
+
+        response = self.client().get('/code/source/sub/').data
+        # cpp description with /* */ comment
+        ok_("Foo is great." in response)
+        # html title
+        ok_("foo html!" in response)
+        # readme line
+        ok_("Highly important subfolder. with a description over 100 bbytesbytesbytesbytesbytesbytesbytesbytesbyt" in response)

--- a/dxr/templates/folder.html
+++ b/dxr/templates/folder.html
@@ -27,14 +27,20 @@
     <thead>
       <tr>
         <th scope="col">Name</th>
+        {% for header in plugin_headers %}
+          <th scope="col">{{ header }}</th>
+        {% endfor %}
         <th scope="col">Modified (UTC)</th>
         <th scope="col">Size</th>
       </tr>
     </thead>
     <tbody>
-      {% for icon, name, modified, size, relative_url in files_and_folders %}
+      {% for icon, name, modified, size, plugin_columns, relative_url in files_and_folders %}
         <tr>
           <td><a href="{{ relative_url }}" class="icon {{ icon }}">{{ name }}</a></td>
+          {% for col in plugin_columns %}
+            <td scope="col">{{ col }}</th>
+          {% endfor %}
           <td><a href="{{ relative_url }}">
             {% if modified is not none %}
               <time>{{ modified.strftime("%Y %b %d %H:%m") }}</time>

--- a/dxr/templates/folder.html
+++ b/dxr/templates/folder.html
@@ -39,7 +39,7 @@
         <tr>
           <td><a href="{{ relative_url }}" class="icon {{ icon }}">{{ name }}</a></td>
           {% for col in plugin_columns %}
-            <td scope="col">{{ col }}</th>
+            <td>{{ col }}</th>
           {% endfor %}
           <td><a href="{{ relative_url }}">
             {% if modified is not none %}

--- a/setup.py
+++ b/setup.py
@@ -22,6 +22,7 @@ setup(
                                   'clang = dxr.plugins.clang:plugin',
                                   'python = dxr.plugins.python:plugin',
                                   'omniglot = dxr.plugins.omniglot',
+                                  'descriptor = dxr.plugins.descriptor',
                                   'rust = dxr.plugins.rust:plugin',
                                   'xpidl = dxr.plugins.xpidl:plugin',
                                   'js = dxr.plugins.js:plugin',

--- a/tests/test_non_ascii_paths/makefile
+++ b/tests/test_non_ascii_paths/makefile
@@ -1,7 +1,0 @@
-all:
-	mkdir code
-	cd code && python -c "import os; os.mkdir('\x8d\xae\xa2\xa0\xef')"
-	cd code && python -c "open('\x8d\xae\xa2\xa0\xef/\xaf\xa0\xaf\xaa\xa0', 'w').write('Hello!\n')"
-clean:
-	rm -rf code
-	rm -f c


### PR DESCRIPTION
Also add some framework for plugins to supply needles on folders and
adding headers to the browsing view.

Fixes bug 1157968.
Example
<img width="871" alt="screen shot 2016-06-09 at 8 55 06 am" src="https://cloud.githubusercontent.com/assets/2406051/15936441/e474628c-2e1f-11e6-9d92-578802f77a7a.png">
