### PR TITLE
Display the last-committed time as modified column when possible.

### DIFF
--- a/dxr/app.py
+++ b/dxr/app.py
@@ -334,7 +334,10 @@ def _browse_folder(tree, path, config):
 
     """
     def item_or_list(item):
-        """If item is a list, return its first element. Otherwise, just return it.
+        """If item is a list, return its first element.
+
+        Otherwise, just return it.
+
         """
         # TODO @pelmers: remove this function when format bumps to 20
         if isinstance(item, list):

--- a/dxr/app.py
+++ b/dxr/app.py
@@ -333,6 +333,14 @@ def _browse_folder(tree, path, config):
     listing. Otherwise, raise NotFound.
 
     """
+    def item_or_list(item):
+        """If item is a list, return its first element. Otherwise, just return it.
+        """
+        # TODO @pelmers: remove this function when format bumps to 20
+        if isinstance(item, list):
+            return item[0]
+        return item
+
     frozen = frozen_config(tree)
 
     files_and_folders = filtered_query(
@@ -371,7 +379,7 @@ def _browse_folder(tree, path, config):
         files_and_folders=[
             (_icon_class_name(f),
              f['name'],
-             decode_es_datetime(f['modified'][0]) if 'modified' in f else None,
+             decode_es_datetime(item_or_list(f['modified'])) if 'modified' in f else None,
              f.get('size'),
              url_for('.browse', tree=tree, path=f.get('link', f['path'])[0]))
             for f in files_and_folders])

--- a/dxr/app.py
+++ b/dxr/app.py
@@ -371,7 +371,7 @@ def _browse_folder(tree, path, config):
         files_and_folders=[
             (_icon_class_name(f),
              f['name'],
-             decode_es_datetime(f['modified']) if 'modified' in f else None,
+             decode_es_datetime(f['modified'][0]) if 'modified' in f else None,
              f.get('size'),
              url_for('.browse', tree=tree, path=f.get('link', f['path'])[0]))
             for f in files_and_folders])

--- a/dxr/build.py
+++ b/dxr/build.py
@@ -499,7 +499,6 @@ def index_file(tree, tree_indexers, path, es, index):
                     folder=folder_name,
                     name=file_name,
                     size=file_info.st_size,
-                    modified=datetime.fromtimestamp(file_info.st_mtime),
                     is_folder=False,
 
                     # And these, which all get mashed into arrays:

--- a/dxr/hgext/previous_revisions.py
+++ b/dxr/hgext/previous_revisions.py
@@ -17,16 +17,18 @@ Mercurial extension that prints the last node in which each tracked file changed
 # with this program; if not, write to the Free Software Foundation, Inc.,
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
+
 def previous_revisions(ui, repo, **opts):
-    """Print the last node in which each file changed."""
+    """Print the last node@date@file in which each file changed."""
     last_change = {}
     for rev in range(0, repo['tip'].rev() + 1):
         ctx = repo[rev]
         # Go through all filenames changed in this commit
         for filename in ctx.files():
-            last_change[filename] = ctx.hex()
-    for filename, node in last_change.iteritems():
-        ui.write('%s:%s\n' % (node, filename))
+            # Date is returned as a (timestamp, timezone) tuple.
+            last_change[filename] = (ctx.hex(), ctx.date()[0])
+    for filename, (node, date) in last_change.iteritems():
+        ui.write('%s@%s@%s\n' % (node, date, filename))
 
 cmdtable = {
     'previous-revisions': (previous_revisions, [], '')

--- a/dxr/plugins/core.py
+++ b/dxr/plugins/core.py
@@ -478,14 +478,17 @@ class FileToIndex(dxr.indexers.FileToIndex):
             yield 'is_binary', True
         # Find the last modified time from version control if possible,
         # otherwise fall back to the timestamp from stat'ing the file.
-        modified = NotImplemented
+        modified = None
         if self.vcs:
             vcs_relative_path = relpath(self.absolute_path(),
                                         self.vcs.get_root_dir())
-            modified = self.vcs.last_modified_date(vcs_relative_path)
-        if not modified or modified is NotImplemented:
+            try:
+                modified = self.vcs.last_modified_date(vcs_relative_path)
+            except NotImplementedError:
+                pass
+        if modified is None:
             file_info = stat(self.absolute_path())
-            modified = datetime.fromtimestamp(file_info.st_mtime)
+            modified = datetime.utcfromtimestamp(file_info.st_mtime)
         yield 'modified', modified
 
     def needles_by_line(self):

--- a/dxr/plugins/core.py
+++ b/dxr/plugins/core.py
@@ -1,7 +1,9 @@
 """Core, non-language-specific features of DXR, implemented as a Plugin"""
 
 from base64 import b64encode
+from datetime import datetime
 from itertools import chain
+from os import stat
 from os.path import relpath, splitext, realpath, basename
 import re
 
@@ -474,6 +476,17 @@ class FileToIndex(dxr.indexers.FileToIndex):
         # binary, but not an image
         elif not self.contains_text():
             yield 'is_binary', True
+        # Find the last modified time from version control if possible,
+        # otherwise fall back to the timestamp from stat'ing the file.
+        modified = NotImplemented
+        if self.vcs:
+            vcs_relative_path = relpath(self.absolute_path(),
+                                        self.vcs.get_root_dir())
+            modified = self.vcs.last_modified_date(vcs_relative_path)
+        if not modified or modified is NotImplemented:
+            file_info = stat(self.absolute_path())
+            modified = datetime.fromtimestamp(file_info.st_mtime)
+        yield 'modified', modified
 
     def needles_by_line(self):
         """Fill out line number and content for every line."""

--- a/dxr/templates/folder.html
+++ b/dxr/templates/folder.html
@@ -35,7 +35,11 @@
       {% for icon, name, modified, size, relative_url in files_and_folders %}
         <tr>
           <td><a href="{{ relative_url }}" class="icon {{ icon }}">{{ name }}</a></td>
-          <td><a href="{{ relative_url }}"><time>{{ '' if modified is none else modified.strftime("%Y %b %d %H:%m") }}</time></a></td>
+          <td><a href="{{ relative_url }}">
+            {% if modified is not none %}
+              <time>{{ '' if modified is none else modified.strftime("%Y %b %d %H:%m") }}</time>
+            {% endif %}
+          </a></td>
           <td><a href="{{ relative_url }}">{{ '' if size is none else size|filesizeformat }}</a></td>
         </tr>
       {% endfor %}

--- a/dxr/templates/folder.html
+++ b/dxr/templates/folder.html
@@ -35,7 +35,7 @@
       {% for icon, name, modified, size, relative_url in files_and_folders %}
         <tr>
           <td><a href="{{ relative_url }}" class="icon {{ icon }}">{{ name }}</a></td>
-          <td><a href="{{ relative_url }}">{{ '' if modified is none else modified.strftime("%Y %b %d %H:%m") }}</a></td>
+          <td><a href="{{ relative_url }}"><time>{{ '' if modified is none else modified.strftime("%Y %b %d %H:%m") }}</time></a></td>
           <td><a href="{{ relative_url }}">{{ '' if size is none else size|filesizeformat }}</a></td>
         </tr>
       {% endfor %}

--- a/dxr/templates/folder.html
+++ b/dxr/templates/folder.html
@@ -27,7 +27,7 @@
     <thead>
       <tr>
         <th scope="col">Name</th>
-        <th scope="col">Modified</th>
+        <th scope="col">Modified (UTC)</th>
         <th scope="col">Size</th>
       </tr>
     </thead>

--- a/dxr/templates/folder.html
+++ b/dxr/templates/folder.html
@@ -37,7 +37,7 @@
           <td><a href="{{ relative_url }}" class="icon {{ icon }}">{{ name }}</a></td>
           <td><a href="{{ relative_url }}">
             {% if modified is not none %}
-              <time>{{ '' if modified is none else modified.strftime("%Y %b %d %H:%m") }}</time>
+              <time>{{ modified.strftime("%Y %b %d %H:%m") }}</time>
             {% endif %}
           </a></td>
           <td><a href="{{ relative_url }}">{{ '' if size is none else size|filesizeformat }}</a></td>

--- a/dxr/vcs.py
+++ b/dxr/vcs.py
@@ -84,7 +84,7 @@ class Vcs(object):
         raise NotImplementedError
 
     def last_modified_date(self, path):
-        """Return a datetime object that represents the last time a commit was
+        """Return a datetime object that represents the last UTC a commit was
         made to the given path.
         """
         raise NotImplementedError

--- a/dxr/vcs.py
+++ b/dxr/vcs.py
@@ -58,7 +58,7 @@ class Vcs(object):
 
     def is_tracked(self, path):
         """Does the repository track this file?"""
-        return NotImplemented
+        raise NotImplementedError
 
     def has_upstream(self):
         """Return true if this VCS has a usable upstream."""
@@ -69,35 +69,35 @@ class Vcs(object):
 
     def generate_log(self, path):
         """Construct URL to upstream view of log of file at path."""
-        return NotImplemented
+        raise NotImplementedError
 
     def generate_diff(self, path):
         """Construct URL to upstream view of diff of file at path."""
-        return NotImplemented
+        raise NotImplementedError
 
     def generate_blame(self, path):
         """Construct URL to upstream view of blame on file at path."""
-        return NotImplemented
+        raise NotImplementedError
 
     def generate_raw(self, path):
         """Construct URL to upstream view to raw file at path."""
-        return NotImplemented
+        raise NotImplementedError
 
     def last_modified_date(self, path):
         """Return a datetime object that represents the last time a commit was
         made to the given path.
         """
-        return NotImplemented
+        raise NotImplementedError
 
     @classmethod
     def get_contents(cls, path, revision, stderr=None):
         """Return contents of file at specified path at given revision, where path is an
         absolute path."""
-        return NotImplemented
+        raise NotImplementedError
 
     def display_rev(self, path):
         """Return a human-readable revision identifier for the repository."""
-        return NotImplemented
+        raise NotImplementedError
 
 
 class Mercurial(Vcs):
@@ -147,7 +147,7 @@ class Mercurial(Vcs):
         last_change = {}
         for line in client.rawcommand(['previous-revisions']).splitlines():
             commit, date, path = line.split('@', 2)
-            last_change[path] = (commit, datetime.fromtimestamp(float(date)))
+            last_change[path] = (commit, datetime.utcfromtimestamp(float(date)))
         return last_change
 
     @classmethod
@@ -216,7 +216,7 @@ class Git(Vcs):
                 consume_date = True
             else:
                 if consume_date:
-                    current_date = datetime.fromtimestamp(float(line))
+                    current_date = datetime.utcfromtimestamp(float(line))
                     consume_date = False
                 else:
                     # Then the line should have a file path, record it if we have

--- a/dxr/vcs.py
+++ b/dxr/vcs.py
@@ -17,6 +17,7 @@ TODO:
 - Check if the mercurial paths are specific to Mozilla's customization or not.
 
 """
+from datetime import datetime
 import marshal
 import os
 from os.path import relpath, join, split
@@ -82,6 +83,12 @@ class Vcs(object):
         """Construct URL to upstream view to raw file at path."""
         return NotImplemented
 
+    def last_modified_date(self, path):
+        """Return a datetime object that represents the last time a commit was
+        made to the given path.
+        """
+        return NotImplemented
+
     @classmethod
     def get_contents(cls, path, revision, stderr=None):
         """Return contents of file at specified path at given revision, where path is an
@@ -103,7 +110,7 @@ class Mercurial(Vcs):
                         configs=['extensions.previous_revisions=%s' % hgext]) as client:
             tip = client.tip()
             self.revision = tip.node
-            self.previous_revisions = self.find_previous_revisions(client)
+            self.previous_revisions = self._find_previous_revisions(client)
         self.upstream = self._construct_upstream_url()
 
     def has_upstream(self):
@@ -130,16 +137,17 @@ class Mercurial(Vcs):
         recomb[3] = recomb[4] = recomb[5] = ''  # Just those three
         return urlparse.urlunparse(recomb)
 
-    def find_previous_revisions(self, client):
-        """Find the last revision in which each file changed, for diff links.
+    def _find_previous_revisions(self, client):
+        """Find the last revision and date in which each file changed, for diff
+        links and timestamps..
 
-        Return a mapping {path: last commit nodes in which file at path changed}
+        Return a mapping {path: date, last commit nodes in which file at path changed}
 
         """
         last_change = {}
         for line in client.rawcommand(['previous-revisions']).splitlines():
-            node, path = line.split(':', 1)
-            last_change[path] = node
+            commit, date, path = line.split('@', 2)
+            last_change[path] = (commit, datetime.fromtimestamp(float(date)))
         return last_change
 
     @classmethod
@@ -160,12 +168,16 @@ class Mercurial(Vcs):
     def is_tracked(self, path):
         return path in self.previous_revisions
 
+    def last_modified_date(self, path):
+        if path in self.previous_revisions:
+            return self.previous_revisions[path][1]
+
     def generate_raw(self, path):
         return self.upstream + 'raw-file/' + self.revision + '/' + path
 
     def generate_diff(self, path):
         # We generate link to diff with the last revision in which the file changed.
-        return self.upstream + 'diff/' + self.previous_revisions[path] + '/' + path
+        return self.upstream + 'diff/' + self.previous_revisions[path][0] + '/' + path
 
     def generate_blame(self, path):
         return self.upstream + 'annotate/' + self.revision + '/' + path
@@ -188,6 +200,31 @@ class Git(Vcs):
                                  self.invoke_vcs(['ls-files'], self.root).splitlines())
         self.revision = self.invoke_vcs(['rev-parse', 'HEAD'], self.root).strip()
         self.upstream = self._construct_upstream_url()
+        self.last_changed = self._find_last_changed()
+
+    def _find_last_changed(self):
+        """Return map {path: date of last authored change}
+        """
+        consume_date = True
+        current_date = None
+        last_changed = {}
+        for line in self.invoke_vcs(
+                ['log', '--format=format:%at', '--name-only'], self.root).splitlines():
+            # Commits are separated by empty lines.
+            if not line:
+                # Then the next line is a date.
+                consume_date = True
+            else:
+                if consume_date:
+                    current_date = datetime.fromtimestamp(float(line))
+                    consume_date = False
+                else:
+                    # Then the line should have a file path, record it if we have
+                    # not seen it and it's tracked.
+                    if line in self.tracked_files and line not in last_changed:
+                        last_changed[line] = current_date
+        return last_changed
+
 
     def has_upstream(self):
         return self.upstream != ""
@@ -212,6 +249,9 @@ class Git(Vcs):
                      "navigation links to show.")
                 break
         return ""
+
+    def last_modified_date(self, path):
+        return self.last_changed.get(path)
 
     @classmethod
     def claim_vcs_source(cls, path, dirs, tree):

--- a/tests/test_vcs_git/test_vcs_git.py
+++ b/tests/test_vcs_git/test_vcs_git.py
@@ -77,9 +77,10 @@ class GitTests(DxrInstanceTestCaseMakeFirst):
         the last commit to the file.
         """
         response = self.client().get('/code/source/').data
-        # TODO: does this depend on time zone/locale?
-        ok_('2015 Oct 29' in response)
-        ok_('2015 May 26' in response)
+        # main.c
+        ok_('<time>2015 May 26 18:05</time>' in response)
+        # binary_file
+        ok_('<time>2016 Apr 07 21:04</time>' in response)
 
     def test_pygmentize(self):
         """Check that the pygmentize FileToSkim correctly colors a file from permalink."""

--- a/tests/test_vcs_git/test_vcs_git.py
+++ b/tests/test_vcs_git/test_vcs_git.py
@@ -72,6 +72,15 @@ class GitTests(DxrInstanceTestCaseMakeFirst):
         eq_(response.status_code, 200)
         ok_("This file tests" in response.data)
 
+    def test_mdates(self):
+        """Make sure that modified dates listed in browse view are dates of
+        the last commit to the file.
+        """
+        response = self.client().get('/code/source/').data
+        # TODO: does this depend on time zone/locale?
+        ok_('2015 Oct 29' in response)
+        ok_('2015 May 26' in response)
+
     def test_pygmentize(self):
         """Check that the pygmentize FileToSkim correctly colors a file from permalink."""
         client = self.client()

--- a/tests/test_vcs_hg/test_vcs_hg.py
+++ b/tests/test_vcs_hg/test_vcs_hg.py
@@ -43,3 +43,11 @@ class MercurialTests(DxrInstanceTestCaseMakeFirst):
         ok_('/rev/84798105c9ab5897f8c7d630d133d9003b44a62f/Colon:%20name" title="Permalink" class="permalink icon">Permalink</a>' in response.data)
         response = self.client().get('/code/rev/84798105c9ab5897f8c7d630d133d9003b44a62f/Colon: name')
         eq_(response.status_code, 200)
+
+    def test_mdates(self):
+        """Make sure that modified dates listed in browse view are dates of
+        the last commit to the file.
+        """
+        response = self.client().get('/code/source/').data
+        ok_('2015 Oct 29' in response)
+        ok_('2015 Jun 15' in response)

--- a/tests/test_vcs_hg/test_vcs_hg.py
+++ b/tests/test_vcs_hg/test_vcs_hg.py
@@ -49,5 +49,5 @@ class MercurialTests(DxrInstanceTestCaseMakeFirst):
         the last commit to the file.
         """
         response = self.client().get('/code/source/').data
-        ok_('2015 Oct 29' in response)
-        ok_('2015 Jun 15' in response)
+        ok_('<time>2014 Nov 06 19:11</time>' in response)
+        ok_('<time>2014 Oct 30 20:10</time>' in response)


### PR DESCRIPTION
Fixes bug 1189576

I'm not sure if the tests depend on the location where it's running, it may be better to generate the tests from timestamps instead in that case, i.e. I record the expected timestamp in the test, then the test case constructs the locale-specific format for it at run time.