### PR TITLE
Fix scrolling to selected line on page load in Chrome.

### DIFF
--- a/dxr/static_unhashed/js/code-highlighter.js
+++ b/dxr/static_unhashed/js/code-highlighter.js
@@ -319,6 +319,10 @@ $(function () {
             if (jumpPosition < 0) {
                 jumpPosition = 0;
             }
+
+            // Trying to scroll in the document ready handler doesn't work because some
+            // browsers (e.g. Chrome) will reset the scroll position later.
+            // Delaying the scroll with setTimeout works around this problem.
             window.setTimeout(function() {
                 window.scrollTo(0, jumpPosition);
             }, 0);

--- a/dxr/static_unhashed/js/code-highlighter.js
+++ b/dxr/static_unhashed/js/code-highlighter.js
@@ -316,11 +316,12 @@ $(function () {
             //for directly linked line(s), scroll to the offset minus 150px for fixed search bar height
             //but only scrollTo if the offset is more than 150px in distance from the top of the page
             jumpPosition = parseInt(jumpPosition.top, 10) - 150;
-            if (jumpPosition >= 0) {
-                window.scrollTo(0, jumpPosition);
-            } else {
-                window.scrollTo(0, 0);
+            if (jumpPosition < 0) {
+                jumpPosition = 0;
             }
+            window.setTimeout(function() {
+                window.scrollTo(0, jumpPosition);
+            }, 0);
             //tidy up an incoming url that might be typed in manually
             setWindowHash();
         }


### PR DESCRIPTION
Trying to scroll in the document ready handler in Chrome doesn't work
because Chrome will reset the scroll position later.  Delaying the scroll
with setTimeout works around this problem.