### PR TITLE
Add an XBL plugin for method identifier searches.

### DIFF
--- a/dxr/plugins/xbl/__init__.py
+++ b/dxr/plugins/xbl/__init__.py
@@ -34,8 +34,8 @@ class FileToIndex(dxr.indexers.FileToIndex):
         return self._analyzer
 
     def is_interesting(self):
-        return (self.path.endswith('.xml') and '<bindings' in self.contents
-                and super(FileToIndex, self).is_interesting())
+        return (super(FileToIndex, self).is_interesting and
+                self.path.endswith('.xml') and '<bindings' in self.contents)
 
     def refs(self):
         return self.analyzer.refs

--- a/dxr/plugins/xbl/__init__.py
+++ b/dxr/plugins/xbl/__init__.py
@@ -36,11 +36,11 @@ class FileToIndex(dxr.indexers.FileToIndex):
         return "<bindings" in self.contents and super(FileToIndex, self).is_interesting()
 
     def refs(self):
-        return self.analyzer.refs if self.analyzer else []
+        return self.analyzer.refs
 
     def needles_by_line(self):
         return iterable_per_line(
-            with_start_and_end(split_into_lines(self.analyzer.needles if self.analyzer else [])))
+            with_start_and_end(split_into_lines(self.analyzer.needles)))
 
 
 plugin = Plugin(

--- a/dxr/plugins/xbl/__init__.py
+++ b/dxr/plugins/xbl/__init__.py
@@ -1,0 +1,51 @@
+from functools import partial
+
+from dxr.filters import LINE
+import dxr.indexers
+from dxr.indexers import iterable_per_line, with_start_and_end, split_into_lines, QUALIFIED_LINE_NEEDLE
+from dxr.plugins import Plugin, filters_from_namespace, refs_from_namespace, AdHocTreeToIndex
+from dxr.plugins.xbl import refs, filters
+from dxr.plugins.xbl.analyzer import XBLAnalyzer
+from dxr.plugins.xbl.refs import PLUGIN_NAME
+
+
+mappings = {
+    LINE: {
+        'properties': {
+            # Method/prop/field definitions.
+            PLUGIN_NAME + '_prop': QUALIFIED_LINE_NEEDLE,
+            # Implementations of interfaces.
+            PLUGIN_NAME + '_type': QUALIFIED_LINE_NEEDLE,
+        }
+    }
+}
+
+
+class FileToIndex(dxr.indexers.FileToIndex):
+    def __init__(self, path, contents, plugin_name, tree):
+        super(FileToIndex, self).__init__(path, contents, plugin_name, tree)
+        self._analyzer = None
+
+    @property
+    def analyzer(self):
+        if not self._analyzer:
+            self._analyzer = XBLAnalyzer(self.tree, self.contents, self.tree.source_encoding)
+        return self._analyzer
+
+    def is_interesting(self):
+        return "<bindings" in self.contents and super(FileToIndex, self).is_interesting()
+
+    def refs(self):
+        return self.analyzer.refs if self.analyzer else []
+
+    def needles_by_line(self):
+        return iterable_per_line(
+            with_start_and_end(split_into_lines(self.analyzer.needles if self.analyzer else [])))
+
+
+plugin = Plugin(
+    tree_to_index=partial(AdHocTreeToIndex,
+                          file_to_index_class=FileToIndex),
+    refs=refs_from_namespace(refs.__dict__),
+    filters=filters_from_namespace(filters.__dict__),
+    mappings=mappings)

--- a/dxr/plugins/xbl/__init__.py
+++ b/dxr/plugins/xbl/__init__.py
@@ -29,11 +29,13 @@ class FileToIndex(dxr.indexers.FileToIndex):
     @property
     def analyzer(self):
         if not self._analyzer:
-            self._analyzer = XBLAnalyzer(self.tree, self.contents, self.tree.source_encoding)
+            self._analyzer = XBLAnalyzer(self.path, self.tree,
+                                         self.contents, self.tree.source_encoding)
         return self._analyzer
 
     def is_interesting(self):
-        return "<bindings" in self.contents and super(FileToIndex, self).is_interesting()
+        return (self.path.endswith('.xml') and '<bindings' in self.contents
+                and super(FileToIndex, self).is_interesting())
 
     def refs(self):
         return self.analyzer.refs

--- a/dxr/plugins/xbl/analyzer.py
+++ b/dxr/plugins/xbl/analyzer.py
@@ -1,0 +1,80 @@
+from warnings import warn
+import xml.parsers.expat as expat
+
+from dxr.indexers import Extent, Position
+from dxr.plugins.xbl.refs import PLUGIN_NAME, TypeRef
+
+
+class XBLAnalyzer(object):
+    def __init__(self, tree, contents, encoding):
+        self.tree = tree
+        self.contents = contents
+        self.lines = contents.splitlines(True)
+        self.parser = expat.ParserCreate(encoding)
+        # Stack of namespaces, issued by the 'id' attr of bindings.
+        self.namespace = []
+        self.needles = []
+        self.refs = []
+        # Late bind our custom handlers to the parser
+        self.parser.StartElementHandler = self.StartElementHandler
+        self.parser.EndElementHandler = self.EndElementHandler
+        try:
+            self.parser.Parse(self.contents)
+        except expat.ExpatError:
+            warn("Exception occurred on parsing XBL file {}".format(self.path))
+
+    def extent_for_name(self, name):
+        """Return Extent for the next occurrence of name.
+        """
+        # Because the parser does not provide location info on attr positions,
+        # we can only search for them from the current position.
+        found = False
+        for (number, line) in enumerate(self.lines[self.parser.CurrentLineNumber - 1:]):
+            if name in line:
+                row, col = self.parser.CurrentLineNumber + number, line.index(name)
+                found = True
+                break
+        if found:
+            return Extent(Position(row, col), Position(row, col + len(name)))
+        else:
+            warn("Could not find {} from line {}".format(name, self.parser.CurrentLineNumber))
+
+    def yield_ref(self, ref, name):
+        """Yield the ref for the next occurrence of given name.
+        """
+        start = self.contents.find(name, self.parser.CurrentByteIndex)
+        end = start + len(name)
+        self.refs.append((start, end, ref))
+
+    def yield_needle(self, name, ident, qualname=None):
+        """Construct a needle with given name and mapping for the provided
+        ident, optionally with a qualified component.
+        """
+        # If qualname is not provided, then use name.
+        mapping = {'name': ident, 'qualname': qualname or ident}
+        extent = self.extent_for_name(ident)
+        if extent:
+            self.needles.append((PLUGIN_NAME + '_' + name, mapping, extent))
+
+    # Begin definitions of parser event handlers.
+
+    def StartElementHandler(self, name, attrs):
+        if "implementation" in name:
+            for impl in attrs['implements'].split(','):
+                name = impl.strip()
+                self.yield_needle('type', name)
+                self.yield_ref(TypeRef(self.tree, name), name)
+
+        elif "binding" in name:
+            # Enter the scope of a binding.
+            self.namespace.append(attrs['id'])
+
+        elif "property" in name or "method" in name or "field" in name:
+            def_name = attrs['name']
+            # Build the qualified name from the most recent binding id.
+            self.yield_needle('prop', def_name, '{}#{}'.format(self.namespace[-1], def_name))
+
+    def EndElementHandler(self, name):
+        if "binding" in name:
+            # Left scope of a binding tag, pop the stack.
+            self.namespace.pop()

--- a/dxr/plugins/xbl/analyzer.py
+++ b/dxr/plugins/xbl/analyzer.py
@@ -1,4 +1,3 @@
-from itertools import islice
 from warnings import warn
 import xml.parsers.expat as expat
 
@@ -43,9 +42,7 @@ class XBLAnalyzer(object):
             found = False
         # Not on the current line, keep going until we find it.
         if not found:
-            for number, line in enumerate(islice(self.lines,
-                                                 self.parser.CurrentLineNumber,
-                                                 len(self.lines))):
+            for number, line in enumerate(self.lines[self.parser.CurrentLineNumber:]):
                 offset = line.find(name)
                 if offset != -1:
                     row, col = self.parser.CurrentLineNumber + number + 1, offset

--- a/dxr/plugins/xbl/analyzer.py
+++ b/dxr/plugins/xbl/analyzer.py
@@ -6,8 +6,9 @@ from dxr.plugins.xbl.refs import PLUGIN_NAME, TypeRef
 
 
 class XBLAnalyzer(object):
-    def __init__(self, tree, contents, encoding):
+    def __init__(self, path, tree, contents, encoding):
         self.tree = tree
+        self.path = path
         self.contents = contents
         self.lines = contents.splitlines(True)
         self.parser = expat.ParserCreate(encoding)
@@ -20,28 +21,28 @@ class XBLAnalyzer(object):
         self.parser.EndElementHandler = self.EndElementHandler
         try:
             self.parser.Parse(self.contents)
-        except expat.ExpatError:
-            warn("Exception occurred on parsing XBL file {}".format(self.path))
+        except expat.ExpatError as err:
+            warn('Exception occurred on parsing XBL file {}'.format(self.path))
+            warn(err.message)
 
     def extent_for_name(self, name):
-        """Return Extent for the next occurrence of name.
-        """
+        """Return Extent for the next occurrence of name."""
         # Because the parser does not provide location info on attr positions,
         # we can only search for them from the current position.
         found = False
-        for (number, line) in enumerate(self.lines[self.parser.CurrentLineNumber - 1:]):
-            if name in line:
-                row, col = self.parser.CurrentLineNumber + number, line.index(name)
+        for number, line in enumerate(self.lines[self.parser.CurrentLineNumber - 1:]):
+            offset = line.find(name)
+            if offset != -1:
+                row, col = self.parser.CurrentLineNumber + number, offset
                 found = True
                 break
         if found:
             return Extent(Position(row, col), Position(row, col + len(name)))
         else:
-            warn("Could not find {} from line {}".format(name, self.parser.CurrentLineNumber))
+            warn('Could not find {} from line {}'.format(name, self.parser.CurrentLineNumber))
 
     def yield_ref(self, ref, name):
-        """Yield the ref for the next occurrence of given name.
-        """
+        """Yield the ref for the next occurrence of given name."""
         start = self.contents.find(name, self.parser.CurrentByteIndex)
         end = start + len(name)
         self.refs.append((start, end, ref))
@@ -59,22 +60,22 @@ class XBLAnalyzer(object):
     # Begin definitions of parser event handlers.
 
     def StartElementHandler(self, name, attrs):
-        if "implementation" in name:
+        if 'implementation' == name:
             for impl in attrs['implements'].split(','):
-                name = impl.strip()
-                self.yield_needle('type', name)
-                self.yield_ref(TypeRef(self.tree, name), name)
+                impl_name = impl.strip()
+                self.yield_needle('type', impl_name)
+                self.yield_ref(TypeRef(self.tree, impl_name), impl_name)
 
-        elif "binding" in name:
+        elif 'binding' in name:
             # Enter the scope of a binding.
             self.namespace.append(attrs['id'])
 
-        elif "property" in name or "method" in name or "field" in name:
+        elif 'property' in name or 'method' in name or 'field' in name:
             def_name = attrs['name']
             # Build the qualified name from the most recent binding id.
             self.yield_needle('prop', def_name, '{}#{}'.format(self.namespace[-1], def_name))
 
     def EndElementHandler(self, name):
-        if "binding" in name:
+        if 'binding' in name:
             # Left scope of a binding tag, pop the stack.
             self.namespace.pop()

--- a/dxr/plugins/xbl/analyzer.py
+++ b/dxr/plugins/xbl/analyzer.py
@@ -29,13 +29,21 @@ class XBLAnalyzer(object):
         """Return Extent for the next occurrence of name."""
         # Because the parser does not provide location info on attr positions,
         # we can only search for them from the current position.
-        found = False
-        for number, line in enumerate(self.lines[self.parser.CurrentLineNumber - 1:]):
-            offset = line.find(name)
-            if offset != -1:
-                row, col = self.parser.CurrentLineNumber + number, offset
-                found = True
-                break
+        # First check the current line.
+        offset = self.lines[self.parser.CurrentLineNumber - 1].find(name, self.parser.currentColumnNumber - 1)
+        if offset != -1:
+            row, col = self.parser.CurrentLineNumber, offset
+            found = True
+        else:
+            found = False
+        # Not on the current line, keep going until we find it.
+        if not found:
+            for number, line in enumerate(self.lines[self.parser.CurrentLineNumber:]):
+                offset = line.find(name)
+                if offset != -1:
+                    row, col = self.parser.CurrentLineNumber + number + 1, offset
+                    found = True
+                    break
         if found:
             return Extent(Position(row, col), Position(row, col + len(name)))
         else:

--- a/dxr/plugins/xbl/filters.py
+++ b/dxr/plugins/xbl/filters.py
@@ -1,0 +1,23 @@
+from jinja2 import Markup
+from dxr.filters import NameFilterBase, QualifiedNameFilterBase
+from dxr.plugins.xbl.refs import PLUGIN_NAME
+
+
+class _NameFilter(NameFilterBase):
+    lang = PLUGIN_NAME
+
+
+class _QualifiedNameFilter(QualifiedNameFilterBase):
+    lang = PLUGIN_NAME
+
+
+class PropFilter(_QualifiedNameFilter):
+    name = 'prop'
+    is_identifier = True
+    description = Markup('XBL property definition filter: <code>prop:foo</code>')
+
+
+class TypeFilter(_NameFilter):
+    name = 'type'
+    is_identifier = True
+    description = Markup('XBL interface implementation filter: <code>type:nsInterface</code>')

--- a/dxr/plugins/xbl/refs.py
+++ b/dxr/plugins/xbl/refs.py
@@ -1,0 +1,25 @@
+from dxr.utils import search_url
+from dxr.lines import Ref
+
+
+PLUGIN_NAME = 'xbl'
+
+
+class _XblRef(Ref):
+    plugin = PLUGIN_NAME
+
+
+class TypeRef(_XblRef):
+    """Ref that yields a menu option for search on type and type-decl.
+    """
+    def menu_items(self):
+        name = self.menu_data
+        for text, filtername, title, icon in [
+                ("Find declaration of %s" % (name), "type-decl", "Find declaration", "reference"),
+                ("Find definition of %s" % (name), "type", "Find definition", "type")]:
+            yield {
+                'html': text,
+                'title': title,
+                'href': search_url(self.tree.name, '%s:"%s"' % (filtername, name)),
+                'icon': icon
+            }

--- a/dxr/plugins/xbl/refs.py
+++ b/dxr/plugins/xbl/refs.py
@@ -14,8 +14,8 @@ class TypeRef(_XblRef):
     def menu_items(self):
         name = self.menu_data
         for text, filtername, title, icon in [
-                ("Find declaration of %s" % (name), "type-decl", "Find declaration", "reference"),
-                ("Find definition of %s" % (name), "type", "Find definition", "type")]:
+                (u'Find declaration of %s' % (name), 'type-decl', 'Find declaration', 'reference'),
+                (u'Find definition of %s' % (name), 'type', 'Find definition', 'type')]:
             yield {
                 'html': text,
                 'title': title,

--- a/dxr/plugins/xbl/refs.py
+++ b/dxr/plugins/xbl/refs.py
@@ -10,8 +10,7 @@ class _XblRef(Ref):
 
 
 class TypeRef(_XblRef):
-    """Ref that yields a menu option for search on type and type-decl.
-    """
+    """Ref that yields a menu option for search on type and type-decl."""
     def menu_items(self):
         name = self.menu_data
         for text, filtername, title, icon in [

--- a/dxr/plugins/xbl/tests/test_xbl/code/socialchat.xml
+++ b/dxr/plugins/xbl/tests/test_xbl/code/socialchat.xml
@@ -5,8 +5,16 @@
     xmlns:xbl="http://www.mozilla.org/xbl"
     xmlns:xul="http://www.mozilla.org/keymaster/gatekeeper/there.is.only.xul">
 
-  <binding id="chatbox">
-    <implementation implements="nsIDOMEventListener, nsIMessageListener">
+  <binding
+
+
+
+
+
+  id="chatbox"
+  >
+    <implementation implements="nsIDOMEventListener,
+                                nsIMessageListener">
 
       <property name="promiseChatLoaded">
       </property>

--- a/dxr/plugins/xbl/tests/test_xbl/code/socialchat.xml
+++ b/dxr/plugins/xbl/tests/test_xbl/code/socialchat.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0"?>
+
+<bindings id="socialChatBindings"
+    xmlns="http://www.mozilla.org/xbl"
+    xmlns:xbl="http://www.mozilla.org/xbl"
+    xmlns:xul="http://www.mozilla.org/keymaster/gatekeeper/there.is.only.xul">
+
+  <binding id="chatbox">
+    <implementation implements="nsIDOMEventListener, nsIMessageListener">
+
+      <property name="promiseChatLoaded">
+      </property>
+
+      <field name="_chat" readonly="true">
+      </field>
+
+      <method name="focus">
+      </method>
+
+      <method name="showNotifications">
+        <parameter name="aAnchor"/>
+        <body>
+        </body>
+      </method>
+    </implementation>
+
+    <handlers>
+      <handler event="focus" phase="capturing">
+      </handler>
+    </handlers>
+  </binding>
+
+  <binding id="chatbar">
+    <implementation implements="nsIDOMEventListener2">
+
+      <method name="focus">
+        <body>
+        </body>
+      </method>
+
+      <property name="selectedChat">
+      </property>
+
+      <field name="menuItemMap">new WeakMap()</field>
+    </implementation>
+  </binding>
+
+</bindings>

--- a/dxr/plugins/xbl/tests/test_xbl/code/socialchat.xml
+++ b/dxr/plugins/xbl/tests/test_xbl/code/socialchat.xml
@@ -50,6 +50,9 @@
       </property>
 
       <field name="menuItemMap">new WeakMap()</field>
+
+      <method name="name">
+      </method>
     </implementation>
   </binding>
 

--- a/dxr/plugins/xbl/tests/test_xbl/dxr.config
+++ b/dxr/plugins/xbl/tests/test_xbl/dxr.config
@@ -1,0 +1,10 @@
+[DXR]
+enabled_plugins     = xbl
+es_index            = dxr_test_{format}_{tree}_{unique}
+es_alias            = dxr_test_{format}_{tree}
+es_catalog_index    = dxr_test_catalog
+
+[code]
+source_folder       = code
+build_command       =
+clean_command       =

--- a/dxr/plugins/xbl/tests/test_xbl/test_xbl.py
+++ b/dxr/plugins/xbl/tests/test_xbl/test_xbl.py
@@ -1,0 +1,61 @@
+"""Tests for whether buglink finds and links bug references"""
+
+from dxr.testing import DxrInstanceTestCase, menu_on
+
+
+class XblTests(DxrInstanceTestCase):
+    def test_refs(self):
+        markup = self.source_page('socialchat.xml')
+
+        # Expect refs to appear on "implements" sections.
+        menu_on(markup,
+                'nsIDOMEventListener',
+                {'html': 'Find declaration of nsIDOMEventListener',
+                 'href': '/code/search?q=type-decl%3A%22nsIDOMEventListener%22'})
+        menu_on(markup,
+                'nsIMessageListener',
+                {'html': 'Find definition of nsIMessageListener',
+                 'href': '/code/search?q=type%3A%22nsIMessageListener%22'})
+        menu_on(markup,
+                'nsIDOMEventListener2',
+                {'html': 'Find declaration of nsIDOMEventListener2',
+                 'href': '/code/search?q=type-decl%3A%22nsIDOMEventListener2%22'})
+
+    def test_searches(self):
+        """Be able to find fields, properties, and methods qualified and unqualified.
+        """
+        self.found_line_eq('type:nsIDOMEventListener',
+                           '&lt;implementation implements="<b>nsIDOMEventListener</b>, nsIMessageListener"&gt;',
+                           9)
+
+        self.found_line_eq('type:nsIMessageListener',
+                           '&lt;implementation implements="nsIDOMEventListener, <b>nsIMessageListener</b>"&gt;',
+                           9)
+
+        self.found_line_eq('prop:promiseChatLoaded',
+                           '&lt;property name="<b>promiseChatLoaded</b>"&gt;',
+                           11)
+
+        self.found_line_eq('prop:_chat',
+                           '&lt;field name="<b>_chat</b>" readonly="true"&gt;',
+                           14)
+
+        self.found_line_eq('+prop:chatbox#focus',
+                           '&lt;method name="<b>focus</b>"&gt;',
+                           17)
+
+        self.found_line_eq('+prop:chatbox#showNotifications',
+                           '&lt;method name="<b>showNotifications</b>"&gt;',
+                           20)
+
+        self.found_line_eq('+prop:chatbar#focus',
+                           '&lt;method name="<b>focus</b>"&gt;',
+                           36)
+
+        self.found_line_eq('+prop:chatbar#selectedChat',
+                           '&lt;property name="<b>selectedChat</b>"&gt;',
+                           41)
+
+        self.found_line_eq('prop:menuItemMap',
+                           '&lt;field name="<b>menuItemMap</b>"&gt;new WeakMap()&lt;/field&gt;',
+                           44)

--- a/dxr/plugins/xbl/tests/test_xbl/test_xbl.py
+++ b/dxr/plugins/xbl/tests/test_xbl/test_xbl.py
@@ -1,5 +1,7 @@
 """Tests for XBL plugin refs and needles."""
 
+from nose import SkipTest
+
 from dxr.testing import DxrInstanceTestCase, menu_on
 
 
@@ -59,3 +61,12 @@ class XblTests(DxrInstanceTestCase):
         self.found_line_eq('prop:menuItemMap',
                            '&lt;field name="<b>menuItemMap</b>"&gt;new WeakMap()&lt;/field&gt;',
                            52)
+
+    def test_doubled_name_search(self):
+        """Test that in a case where attr key === attr val, we pick out the val
+        as the needle.
+        """
+        raise SkipTest
+        self.found_line_eq('prop:name',
+                           '&lt;method name="<b>name</b>"&gt;',
+                           54)

--- a/dxr/plugins/xbl/tests/test_xbl/test_xbl.py
+++ b/dxr/plugins/xbl/tests/test_xbl/test_xbl.py
@@ -25,37 +25,37 @@ class XblTests(DxrInstanceTestCase):
         """Be able to find fields, properties, and methods qualified and unqualified.
         """
         self.found_line_eq('type:nsIDOMEventListener',
-                           '&lt;implementation implements="<b>nsIDOMEventListener</b>, nsIMessageListener"&gt;',
-                           9)
+                           '&lt;implementation implements="<b>nsIDOMEventListener</b>,',
+                           16)
 
         self.found_line_eq('type:nsIMessageListener',
-                           '&lt;implementation implements="nsIDOMEventListener, <b>nsIMessageListener</b>"&gt;',
-                           9)
+                           '<b>nsIMessageListener</b>"&gt;',
+                           17)
 
         self.found_line_eq('prop:promiseChatLoaded',
                            '&lt;property name="<b>promiseChatLoaded</b>"&gt;',
-                           11)
+                           19)
 
         self.found_line_eq('prop:_chat',
                            '&lt;field name="<b>_chat</b>" readonly="true"&gt;',
-                           14)
+                           22)
 
         self.found_line_eq('+prop:chatbox#focus',
                            '&lt;method name="<b>focus</b>"&gt;',
-                           17)
+                           25)
 
         self.found_line_eq('+prop:chatbox#showNotifications',
                            '&lt;method name="<b>showNotifications</b>"&gt;',
-                           20)
+                           28)
 
         self.found_line_eq('+prop:chatbar#focus',
                            '&lt;method name="<b>focus</b>"&gt;',
-                           36)
+                           44)
 
         self.found_line_eq('+prop:chatbar#selectedChat',
                            '&lt;property name="<b>selectedChat</b>"&gt;',
-                           41)
+                           49)
 
         self.found_line_eq('prop:menuItemMap',
                            '&lt;field name="<b>menuItemMap</b>"&gt;new WeakMap()&lt;/field&gt;',
-                           44)
+                           52)

--- a/dxr/plugins/xbl/tests/test_xbl/test_xbl.py
+++ b/dxr/plugins/xbl/tests/test_xbl/test_xbl.py
@@ -1,4 +1,4 @@
-"""Tests for whether buglink finds and links bug references"""
+"""Tests for XBL plugin refs and needles."""
 
 from dxr.testing import DxrInstanceTestCase, menu_on
 

--- a/setup.py
+++ b/setup.py
@@ -19,6 +19,7 @@ setup(
     packages=find_packages(exclude=['ez_setup']),
     entry_points={'dxr.plugins': ['urllink = dxr.plugins.urllink',
                                   'buglink = dxr.plugins.buglink:plugin',
+                                  'xbl = dxr.plugins.xbl:plugin',
                                   'clang = dxr.plugins.clang:plugin',
                                   'python = dxr.plugins.python:plugin',
                                   'omniglot = dxr.plugins.omniglot',

--- a/tests/test_non_ascii_paths/code/第五.xml
+++ b/tests/test_non_ascii_paths/code/第五.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0"?>
+
+<bindings id="一二三"
+          xmlns="http://www.mozilla.org/xbl"
+          xmlns:xul="http://www.mozilla.org/keymaster/gatekeeper/there.is.only.xul"
+          xmlns:xbl="http://www.mozilla.org/xbl">
+  <binding id="你" extends="chrome://global/content/bindings/button.xml#button-base">
+    <implementation implements="我, 他">
+      <method name="叶公好龙">
+      </method>
+    </implementation>
+  </binding>
+</bindings>
+


### PR DESCRIPTION
This plugin adds qualified needles for the method, property, and field
definitions within bindings. It also adds needles and refs for the
implements attr on the implementation tag.

Fixes bug 771004.

Next in the nice-to-have list would be JS analysis of the CDATA sections
of these files.
