### PR TITLE
Check that paths can decode in utf8 before sending to ES

### DIFF
--- a/dxr/build.py
+++ b/dxr/build.py
@@ -444,7 +444,13 @@ def index_file(tree, tree_indexers, path, es, index):
         else:
             raise
 
+    # Just like index_folders, if the path is not in UTF-8, then elasticsearch
+    # will not accept the path, so just move on.
     rel_path = relpath(path, tree.source_folder)
+    try:
+        rel_path = rel_path.decode('utf-8')
+    except UnicodeDecodeError:
+        return
     is_text = isinstance(contents, unicode)
     is_link = islink(path)
     # Index by line if the contents are text and the path is not a symlink.
@@ -591,6 +597,12 @@ def index_folders(tree, index, es):
                      label='Indexing folders') as folders:
         for folder in folders:
             rel_path = relpath(folder, tree.source_folder)
+            # If the path is not in UTF-8, then elasticsearch will not
+            # accept the path, so just move on.
+            try:
+                rel_path = rel_path.decode('utf-8')
+            except UnicodeDecodeError:
+                continue
             superfolder_path, folder_name = split(rel_path)
             es.index(index, FILE, {
                 'path': [rel_path],  # array for consistency with non-folder file docs

--- a/tests/test_non_utf8_paths/code/makefile
+++ b/tests/test_non_utf8_paths/code/makefile
@@ -1,0 +1,6 @@
+all:
+	mkdir code
+	cd code && python -c "import os; os.mkdir('\x8d\xae\xa2\xa0\xef')"
+	cd code && python -c "open('\x8d\xae\xa2\xa0\xef/\xaf\xa0\xaf\xaa\xa0', 'w').write('Hello!\n')"
+clean:
+	rm -rf code

--- a/tests/test_non_utf8_paths/dxr.config
+++ b/tests/test_non_utf8_paths/dxr.config
@@ -1,0 +1,9 @@
+[DXR]
+enabled_plugins     =
+es_index            = dxr_test_{format}_{tree}_{unique}
+es_alias            = dxr_test_{format}_{tree}
+es_catalog_index    = dxr_test_catalog
+
+[code]
+source_folder       = code
+build_command       = make clean; make -j $jobs

--- a/tests/test_non_utf8_paths/dxr.config
+++ b/tests/test_non_utf8_paths/dxr.config
@@ -6,4 +6,4 @@ es_catalog_index    = dxr_test_catalog
 
 [code]
 source_folder       = code
-build_command       = make clean; make -j $jobs
+build_command       = make clean; make

--- a/tests/test_non_utf8_paths/test_non_utf8_paths.py
+++ b/tests/test_non_utf8_paths/test_non_utf8_paths.py
@@ -1,0 +1,5 @@
+from dxr.testing import DxrInstanceTestCase
+
+
+class NonUTF8PathTest(DxrInstanceTestCase):
+    """Just tests that the index can be created without error."""

--- a/tests/test_non_utf8_paths/test_non_utf8_paths.py
+++ b/tests/test_non_utf8_paths/test_non_utf8_paths.py
@@ -3,3 +3,6 @@ from dxr.testing import DxrInstanceTestCase
 
 class NonUTF8PathTest(DxrInstanceTestCase):
     """Just tests that the index can be created without error."""
+
+    def test_indexes(self):
+        pass


### PR DESCRIPTION
There should be a way to index non-utf8 paths, but for now it seems prudent to block them and move on with getting the addon tree up.

Note: The test case does not work on OS X because HFS+ filesystem utf-8 encodes all nodes.