### PR TITLE
Make wildcard matches anchored to the ends of the string by default.

### DIFF
--- a/dxr/utils.py
+++ b/dxr/utils.py
@@ -162,10 +162,15 @@ def glob_to_regex(glob):
     """Return a regex equivalent to a shell-style glob.
 
     Don't include the regex flags and \\Z at the end like fnmatch.translate(),
-    because we don't parse flags and we don't want to pin to the end.
+    because we don't parse flags and JavaScript doesn't support \\Z.
+
+    Add ^ to the beginning and $ to the end to ensure that the match is exact
+    and not just occuring somewhere in the middle of the string.  If the user
+    wants the "match anywhere" behavior they can add a * to the beginning
+    and/or end of their query term.
 
     """
-    return fnmatch.translate(glob)[:-_FNMATCH_TRANSLATE_SUFFIX_LEN]
+    return '^' + fnmatch.translate(glob)[:-_FNMATCH_TRANSLATE_SUFFIX_LEN] + '$'
 
 
 def cached(f):

--- a/tests/test_core_plugin.py
+++ b/tests/test_core_plugin.py
@@ -58,7 +58,7 @@ class PathFilterTests(TestCase):
                             'lang': 'js',
                             'script': '(new RegExp(pattern, flags)).test(doc["path"][0])',
                             'params': {
-                                'pattern': r'.*hi.*hork.*\.cp.',
+                                'pattern': r'^.*hi.*hork.*\.cp.$',
                                 'flags': 'i'
                             }
                         }
@@ -94,7 +94,7 @@ class PathFilterTests(TestCase):
                             'lang': 'js',
                             'script': '(new RegExp(pattern, flags)).test(doc["path"][0])',
                             'params': {
-                                'pattern': r'fooba[rz]',
+                                'pattern': r'^fooba[rz]$',
                                 'flags': ''
                             }
                         }

--- a/tests/test_path_file_filters/test_path_file_filters.py
+++ b/tests/test_path_file_filters/test_path_file_filters.py
@@ -8,22 +8,22 @@ class PathAndFileFilterTests(DxrInstanceTestCase):
 
     def test_basic_path_results(self):
         """Check that a 'path:' result includes both file and folder matches."""
-        self.found_files_eq('path:fish', ['fish1', 'fishy_folder/fish2',
-                                          'fishy_folder/gill', 'folder/fish3',
-                                          'folder/fish4'])
+        self.found_files_eq('path:*fish*', ['fish1', 'fishy_folder/fish2',
+                                            'fishy_folder/gill', 'folder/fish3',
+                                            'folder/fish4'])
 
     def test_basic_file_results(self):
         """Check that a 'file:' result includes only file matches."""
-        self.found_files_eq('file:fish', ['fish1', 'fishy_folder/fish2',
-                                          'folder/fish3', 'folder/fish4'])
+        self.found_files_eq('file:fish*', ['fish1', 'fishy_folder/fish2',
+                                           'folder/fish3', 'folder/fish4'])
 
     def test_path_and_file_line_promotion(self):
         """Make sure promotion of a 'path:' or 'file:' filter to a LINE query
         works.
 
         """
-        self.found_files_eq('path:fish fins', ['folder/fish3'])
-        self.found_files_eq('file:fish fins', ['folder/fish3'])
+        self.found_files_eq('path:*fish* fins', ['folder/fish3'])
+        self.found_files_eq('file:fish* fins', ['folder/fish3'])
 
     # This fails because we currently intentionally exclude folder paths from
     # FILE query results - remove the @raises line when that's changed.  (Of
@@ -37,7 +37,7 @@ class PathAndFileFilterTests(DxrInstanceTestCase):
         """Test basic wildcard functionality."""
         # 'path:' and 'file:' currently have the same underlying wildcard
         # support, so we're spreading out the basic wildcard testing over both.
-        self.found_files_eq('path:fish?_fo*er',
+        self.found_files_eq('path:fish?_fo*er/*',
                             ['fishy_folder/fish2', 'fishy_folder/gill'])
 
         self.found_files_eq('file:fish[14]', ['fish1', 'folder/fish4'])

--- a/tests/test_symlink/test_symlink.py
+++ b/tests/test_symlink/test_symlink.py
@@ -18,7 +18,7 @@ class SymlinkTests(DxrInstanceTestCase):
         """Make sure that searching for path:<symlink name> does not return the symlink.
 
         """
-        self.found_files_eq('path:mkd', ['README.mkd'])
+        self.found_files_eq('path:*mkd', ['README.mkd'])
 
     def test_line_search(self):
         """Make sure that searching for contents within the real file does not return duplicates

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -95,7 +95,7 @@ def test_glob_to_regex():
     In other words, pin down the behavior of fnmatch.translate().
 
     """
-    eq_(glob_to_regex('hi'), 'hi')
+    eq_(glob_to_regex('hi'), '^hi$')
 
 
 def test_decode_es_datetime():


### PR DESCRIPTION
For query terms like path: and file: that allow wildcards, ensure that
they match the entire string.  For example, now file:bar.htm matches
only "bar.htm" and not "bar.html" or "foobar.htm".
If a user wants the old behavior of matching anywhere within the name
they can add an asterisk to the beginning and/or end of their search
term.  For example, file:\*bar.htm\* still matches all of "bar.htm",
"bar.html" and "foobar.htm".