### PR TITLE
Move VIRTUAL_ENV up in the file, scope lint to dxr/

### DIFF
--- a/makefile
+++ b/makefile
@@ -1,3 +1,8 @@
+# If there's an activated virtualenv, use that. Otherwise, make one in the cwd.
+# This lets the installed Python packages persist across container runs when
+# using Docker.
+VIRTUAL_ENV ?= $(PWD)/venv
+
 # Things you might normally want to run:
 
 ## These are meant to be run within whatever virtualized, containerized, or
@@ -11,7 +16,7 @@ test: all
 
 lint: $(VIRTUAL_ENV)/bin/activate requirements
 	$(VIRTUAL_ENV)/bin/pip install flake8
-	$(VIRTUAL_ENV)/bin/flake8 --config=tooling/flake8.config .
+	$(VIRTUAL_ENV)/bin/flake8 --config=tooling/flake8.config dxr/
 
 clean: static_clean
 	rm -rf .npm_installed \
@@ -62,10 +67,6 @@ docker_stop:
 
 # Private things:
 
-# If there's an activated virtualenv, use that. Otherwise, make one in the cwd.
-# This lets the installed Python packages persist across container runs when
-# using Docker.
-VIRTUAL_ENV ?= $(PWD)/venv
 DXR_PROD ?= 0
 
 # Bring the elasticsearch container up if it isn't:


### PR DESCRIPTION
Fix keeps flake8 from recursing into all subfolders from the root, such as virtualenvs kept with the project.