### PR TITLE
instruct docker to label the mount with the correct selinux label

### DIFF
--- a/tooling/docker/docker-compose.yml
+++ b/tooling/docker/docker-compose.yml
@@ -12,7 +12,7 @@ dev:
   ports:
     - "8000:8000"
   volumes:
-    - ../..:/home/dxr/dxr
+    - ../..:/home/dxr/dxr:Z
   volumes_from:
     - code
     - venv


### PR DESCRIPTION
because otherwise it won't work on on hosts that use selinux