### PR TITLE
Add /dxr/build to .gitignore.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 *.pyc
 *.o
 *.so
+/dxr/build
 /dxr/static
 /dxr/static_manifest
 /dxr/static_unhashed/js/templates.js


### PR DESCRIPTION
When running `make test` after `make shell`, the directory */dxr/build/* is created which is not currently covered by *.gitignore* and therefore shows up as an untracked file on `git status`.