### PR TITLE
Update docker build trigger to point to new mozilla-org repo.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,3 +41,4 @@ env:
     - GH_REF: github.com/mozilla/dxr.git
     - secure: "ZaFYROXPqDRTb9iPK196ar5rOHDIcOw7xD7kV0bbXMAaJZv7T7TmQQ9gRso/qwwAeOKO4IRi9iGRDQU5yqZ4hy6FbVXUV6AXI3QXbm0X+qd38kboXzwfbpwfRpZRj5CmzZ32wo3w4jtB7OSzX6OvP+7J5YHRoRwTj30JLhLrXfk="
     - secure: "O8n+VSEjws3YKrsaJmY32bYgzSstmiF6nyyuwQIodoNFoAes5XXAIj8xvrJE40Co7HK2JztKUzb0Hkx7cLMZOMeou/HT9N5O3ML15Ka9CWZ0gD8C0IlZvc8x1jbuB97uD9omID1d/HzIPABj2YZjgh5HdsIJnHXx1xnJ/xtuASI="
+    - secure: "LyHM0l5tRJjOx3kks29gW1w3/8hU26MNhtbJAMT3IEcLy0MYsAHIya2cWLe1yLSdMndBc3l4xGxE7Ly0Sw+SXBOwGAZVWbZa1bx25CIvu+vVNJroa2H5i4MSlh2SSs0donZM181FFejJ2rO1evojPdyFD7wSLLtlqxEhgUTjGRk="

--- a/tooling/travis_passed.sh
+++ b/tooling/travis_passed.sh
@@ -8,4 +8,4 @@ git push -q "https://${GH_TOKEN}@${GH_REF}" master:ci > /dev/null 2>&1
 
 # Bump quay so it builds a new indexer image:
 DOCKER_REPO_SHA=$(curl -s https://api.github.com/repos/mozilla-platform-ops/dxr-infra/git/refs/heads/master | python -c 'import json,sys;obj=json.load(sys.stdin);print obj["object"]["sha"]')
-curl -H "Content-Type: application/json" -X POST -d "{\"commit\":\"$DOCKER_REPO_SHA\",\"ref\":\"refs/heads/master\",\"default_branch\":\"master\"}" https://%24token:$QUAY_AUTH_TOKEN@quay.io/webhooks/push/trigger/fada413b-bb9f-4358-9303-ce742d77921f
+curl -H "Content-Type: application/json" -X POST -d "{\"commit\":\"$DOCKER_REPO_SHA\",\"ref\":\"refs/heads/master\",\"default_branch\":\"master\"}" https://%24token:$QUAY_AUTH_TOKEN@quay.io/webhooks/push/trigger/54f23971-f517-4e6c-88b0-d20453c9fefd


### PR DESCRIPTION
I can't tell which of the old encrypted values was the QUAY_AUTH_TOKEN, nor can I think of a way to test them without breaking master (I've lost track of the original GH_TOKEN, and encrypting the original QUAY_AUTH_TOKEN doesn't result in a matching string), so let's just append this new one and hope the last one wins.