### PR TITLE
Raise max number of entries DXR will show when browsing a folder.

### DIFF
--- a/dxr/app.py
+++ b/dxr/app.py
@@ -372,7 +372,7 @@ def _browse_folder(tree, path, config):
         FILE,
         filter={'folder': path},
         sort=[{'is_folder': 'desc'}, 'name'],
-        size=10000,
+        size=1000000,
         include=['name', 'modified', 'size', 'link', 'path', 'is_binary',
                  'is_folder'])
 


### PR DESCRIPTION
This fixes a problem when viewing the ridiculously large addons tree. ES makes us specify a ceiling, so we just raise it.