### PR TITLE
Properly index Python method calls, chained calls, and nested calls

### DIFF
--- a/dxr/plugins/python/analysis.py
+++ b/dxr/plugins/python/analysis.py
@@ -10,7 +10,7 @@ from warnings import warn
 
 from dxr.build import unicode_contents
 from dxr.plugins.python.utils import (ClassFunctionVisitorMixin,
-                                      convert_node_to_name, package_for_module,
+                                      convert_node_to_fullname, package_for_module,
                                       path_to_module, ast_parse)
 
 
@@ -192,7 +192,7 @@ class AnalyzingNodeVisitor(ast.NodeVisitor, ClassFunctionVisitorMixin):
         class_path = self.abs_module_name + '.' + node.name
         bases = []
         for base in node.bases:
-            base_name = convert_node_to_name(base)
+            base_name = convert_node_to_fullname(base)
             if base_name:
                 bases.append((self.abs_module_name, base_name))
         self.tree_analysis.base_classes[class_path] = bases

--- a/dxr/plugins/python/indexers.py
+++ b/dxr/plugins/python/indexers.py
@@ -317,7 +317,7 @@ class FileToIndex(FileToIndexBase):
         loc = node.lineno, node.col_offset
         try:
             self.node_start_table[loc].pop()
-        except Exception:
+        except (KeyError, IndexError):
             pass
 
 

--- a/dxr/plugins/python/tests/test_callers.py
+++ b/dxr/plugins/python/tests/test_callers.py
@@ -79,6 +79,8 @@ class CallersMethodTests(PythonSingleFileTestCase):
     foo.method()
 
     a.b().c().d
+
+    f(g(h()))
     """)
 
     def test_class_method_called(self):
@@ -95,3 +97,8 @@ class CallersMethodTests(PythonSingleFileTestCase):
         self.found_line_eq('callers:b', 'a.<b>b</b>().c().d', 15)
         self.found_line_eq('callers:c', 'a.b().<b>c</b>().d', 15)
         self.found_nothing('callers:d')
+
+    def test_sequence_of_nested_calls(self):
+        self.found_line_eq('callers:f', '<b>f</b>(g(h()))', 17)
+        self.found_line_eq('callers:g', 'f(<b>g</b>(h()))', 17)
+        self.found_line_eq('callers:h', 'f(g(<b>h</b>()))', 17)

--- a/dxr/plugins/python/tests/test_callers.py
+++ b/dxr/plugins/python/tests/test_callers.py
@@ -27,18 +27,18 @@ class CallersTests(PythonSingleFileTestCase):
     """)
 
     def test_called_once(self):
-        self.found_line_eq('callers:called_once', '<b>called_once()</b>', 3)
+        self.found_line_eq('callers:called_once', '<b>called_once</b>()', 3)
 
     def test_called_multiple_times(self):
         self.found_lines_eq('callers:called_multiple', [
-            ('<b>called_multiple()</b>', 6),
-            ('<b>called_multiple()</b>', 7),
+            ('<b>called_multiple</b>()', 6),
+            ('<b>called_multiple</b>()', 7),
         ])
 
     def test_called_in_several_functions(self):
         self.found_lines_eq('callers:called_in_separate_functions', [
-            ('<b>called_in_separate_functions()</b>', 10),
-            ('<b>called_in_separate_functions()</b>', 13),
+            ('<b>called_in_separate_functions</b>()', 10),
+            ('<b>called_in_separate_functions</b>()', 13),
         ])
 
     def test_called_in_inner_function(self):
@@ -46,21 +46,21 @@ class CallersTests(PythonSingleFileTestCase):
         function only.
 
         """
-        self.found_line_eq('callers:foo', '<b>foo()</b>', 17)
+        self.found_line_eq('callers:foo', '<b>foo</b>()', 17)
 
     def test_called_in_outer_function(self):
         """Make sure inner function definitions do not affect other
         calls in the outer function.
 
         """
-        self.found_line_eq('callers:bar', '<b>bar()</b>', 18)
+        self.found_line_eq('callers:bar', '<b>bar</b>()', 18)
 
     def test_called_outside_of_function(self):
         """Make sure calls that take place at the top level in a module are
         still recorded.
 
         """
-        self.found_line_eq('callers:outer_call_bar', '<b>outer_call_bar()</b>', 20)
+        self.found_line_eq('callers:outer_call_bar', '<b>outer_call_bar</b>()', 20)
 
 
 class CallersMethodTests(PythonSingleFileTestCase):
@@ -77,10 +77,21 @@ class CallersMethodTests(PythonSingleFileTestCase):
 
     foo = Foo()
     foo.method()
+
+    a.b().c().d
     """)
 
     def test_class_method_called(self):
-        self.found_nothing('callers:class_method')
+        self.found_line_eq('callers:class_method', 'Foo.<b>class_method</b>()', 10)
+
+    def test_class_called(self):
+        self.found_line_eq('callers:Foo', 'foo = <b>Foo</b>()', 12)
 
     def test_method_called(self):
-        self.found_nothing('callers:method')
+        self.found_line_eq('callers:method', 'foo.<b>method</b>()', 13)
+
+    def test_chain_of_calls(self):
+        self.found_nothing('callers:a')
+        self.found_line_eq('callers:b', 'a.<b>b</b>().c().d', 15)
+        self.found_line_eq('callers:c', 'a.b().<b>c</b>().d', 15)
+        self.found_nothing('callers:d')

--- a/dxr/plugins/python/tests/test_unicode.py
+++ b/dxr/plugins/python/tests/test_unicode.py
@@ -47,4 +47,4 @@ class UnicodeOffsetTests(PythonSingleFileTestCase):
         characters, not bytes.
 
         """
-        self.found_line_eq('callers:kilroy', u'print u"どうもありがとう " + <b>kilroy()</b>', 9)
+        self.found_line_eq('callers:kilroy', u'print u"どうもありがとう " + <b>kilroy</b>()', 9)

--- a/dxr/plugins/python/utils.py
+++ b/dxr/plugins/python/utils.py
@@ -52,6 +52,19 @@ def convert_node_to_name(node):
     if isinstance(node, ast.Name):
         return node.id
     elif isinstance(node, ast.Attribute):
+        return node.attr
+    else:
+        return None
+
+
+def convert_node_to_fullname(node):
+    """Convert an AST node to a full dotted name if possible. Return None
+    if we can't (such as function calls).
+
+    """
+    if isinstance(node, ast.Name):
+        return node.id
+    elif isinstance(node, ast.Attribute):
         value_name = convert_node_to_name(node.value)
         if value_name:
             return value_name + '.' + node.attr


### PR DESCRIPTION
Previous work (#487) broke the behavior of indexing calls that are
anything other than a plain function call.

fixes #490