### PR TITLE
Fix for failures in test_vcs_hg/test_vcs_hg.py

### DIFF
--- a/tests/test_decoding/code/makefile
+++ b/tests/test_decoding/code/makefile
@@ -1,5 +1,5 @@
 all:
-	@tar -xf git.tar
+	@tar --no-same-owner -xf git.tar
 
 clean:
 	@rm -rf .git

--- a/tests/test_vcs_git/code/Makefile
+++ b/tests/test_vcs_git/code/Makefile
@@ -1,5 +1,5 @@
 all:
-	@tar -xf git.tar
+	@tar --no-same-owner -xf git.tar
 
 clean:
 	@rm -rf .git

--- a/tests/test_vcs_hg/code/Makefile
+++ b/tests/test_vcs_hg/code/Makefile
@@ -1,5 +1,5 @@
 all:
-	@tar -xf hg.tar
+	@tar --no-same-owner -xf hg.tar
 
 clean:
 	@rm -rf .hg


### PR DESCRIPTION
Tests that check for links in tests/test_vcs_hg/test_vcs_hg.py fail when
run as any user other than dxr, with uid=502.

List of failing tests:

- test_blame
- test_diff_file{1,2,3}
- test_log
- test_raw

The tests fail because when tar extracts the test hg archive, it preserves
ownership permissions by default.

This causes hg to complain like so:
```
[root@hostname ~/dxr/dxr/tests/test_vcs_hg/code/.hg]# hg status
not trusting file /home/dxr/dxr/tests/test_vcs_hg/code/.hg/hgrc from untrusted user 502, group staff
not trusting file /home/dxr/dxr/tests/test_vcs_hg/code/.hg/hgrc from untrusted user 502, group staff
? Makefile
? hg.tar
```

The fix is to /not/ preserve ownership permissions while extracting the
test archives.

While this bug affects only Mercurial tests, the fix is applied to all
tests uniformly for consistency and to prevent future failures/bugs
arising out of the same underlying cause.