### PR TITLE
Strip whitespace on path segment renders.

### DIFF
--- a/dxr/static_unhashed/js/dxr.js
+++ b/dxr/static_unhashed/js/dxr.js
@@ -107,13 +107,15 @@ $(function() {
 
             dataPath.push(paths[pathIndex]);
 
+            // Render the path segment and trim white space so copying the
+            // path will not insert spaces.
             pathLines += nunjucks.render('path_line.html', {
                 'data_path': dataPath.join('/'),
                 'display_path': paths[pathIndex],
                 'url': pathRoot + dataPath.join('/'),
                 'is_first_or_only': isFirstOrOnly,
                 'is_dir': !isLastOrOnly
-            });
+            }).trim();
         }
 
         return [iconClass, pathLines];

--- a/dxr/templates/nunjucks/path_line.html
+++ b/dxr/templates/nunjucks/path_line.html
@@ -1,6 +1,4 @@
 {%- if not is_first_or_only -%}
 <span class="path-separator">/</span>
 {%- endif -%}
-<a href="{{ url }}" {%- if is_dir %} data-path="{{ data_path }}" {% endif %}>
-    {{ display_path }}
-</a>
+<a href="{{ url }}" {%- if is_dir %} data-path="{{ data_path }}" {% endif %}>{{ display_path }}</a>

--- a/dxr/templates/nunjucks/results.html
+++ b/dxr/templates/nunjucks/results.html
@@ -7,9 +7,7 @@
         <div class="left-column">
           <div class="{{result.iconClass}} icon-container"></div>
         </div>
-        <div>
-          {{ result.pathLine|safe }}
-        </div>
+        <div>{{ result.pathLine|safe }}</div>
       </div>
       {{ result_lines(result, www_root, tree) }}
     </div>


### PR DESCRIPTION
Removes spaces in copies of paths in results pages.
Fixes bug 1288853.