### PR TITLE
Stop using lazy regex in description plugin, add test.

### DIFF
--- a/dxr/plugins/descriptor/tests/test_descriptions/code/Makefile
+++ b/dxr/plugins/descriptor/tests/test_descriptions/code/Makefile
@@ -1,0 +1,5 @@
+code: clean
+	python -c "open('longline.c', 'w').write('/**' + 'h' * 400000 + '*/')"
+
+clean:
+	rm -f longline.c

--- a/dxr/plugins/descriptor/tests/test_descriptions/dxr.config
+++ b/dxr/plugins/descriptor/tests/test_descriptions/dxr.config
@@ -6,5 +6,3 @@ es_catalog_index    = dxr_test_catalog
 
 [code]
 source_folder       = code
-build_command       =
-clean_command       =

--- a/dxr/plugins/descriptor/tests/test_descriptions/test_descriptions.py
+++ b/dxr/plugins/descriptor/tests/test_descriptions/test_descriptions.py
@@ -29,6 +29,9 @@ class DescriptionTests(DxrInstanceTestCase):
         ok_("great code" in response)
         # Make sure license, vim, emacs mode lines skip.
         ok_("The description appears after a MPL and after some mode settings." in response)
+        # Test that the comment regular expression won't time out from lazy
+        # searching on big strings.
+        ok_("hhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhh" in response)
 
     def test_sub_browse_page(self):
         """Test that the expected descriptions appear on the subfolder's page.


### PR DESCRIPTION
Also anchor the comment at start of line.