### PR TITLE
Don't ignore failures when running "node".

### DIFF
--- a/dxr/plugins/js/indexers.py
+++ b/dxr/plugins/js/indexers.py
@@ -34,12 +34,11 @@ class TreeToIndex(dxr.indexers.TreeToIndex):
     def post_build(self):
         # Execute the esprima to dump metadata, by running node from here and
         # passing in the tree location
-        retcode = subprocess.call(['node', 'analyze_tree.js',
-                                   self.tree.source_folder,
-                                   join(self.tree.temp_folder, 'plugins/js')] +
-                                   self.tree.ignore_filenames,
-                                  cwd=join(self.plugin_folder, 'analyze_js'))
-        return retcode
+        subprocess.check_call(['node', 'analyze_tree.js',
+                               self.tree.source_folder,
+                               join(self.tree.temp_folder, 'plugins/js')] +
+                               self.tree.ignore_filenames,
+                              cwd=join(self.plugin_folder, 'analyze_js'))
 
     def file_to_index(self, path, contents):
         return FileToIndex(path, contents, self.plugin_name, self.tree)


### PR DESCRIPTION
The return value of post_build is ignored so the current code throws
away the exit code of the process.  Any failure is just ignored.
Using subprocess.check_call instead will throw an exception if
node exits with a non-zero status so we'll be sure to notice.
