### PR TITLE
Skip -Zsave-analysis when compiling lib.rs

### DIFF
--- a/dxr/plugins/rust/dxr-rustc.sh
+++ b/dxr/plugins/rust/dxr-rustc.sh
@@ -1,4 +1,4 @@
-if echo $@ | grep -q "build.rs"; then
+if echo $@ | egrep -q "build.rs|lib.rs"; then
     rustc "$@"
 else
     rustc -Zsave-analysis "$@"


### PR DESCRIPTION
/cc @nrc 

The -Z flag is unstable is has been causing rustfmt builds to bomb on an
internal compiler error while building libc: expected expr, found unknown node (id=XXXXXX)

   Compiling libc v0.2.13
     Running `/home/jenkins/dxr/dxr/plugins/rust/dxr-rustc.sh /home/jenkins/src/rustfmt/.cargo/registry/src/github.com-1ecc6299db9ec823/libc-0.2.13/src/lib.rs --crate-name libc --crate-type lib -g --cfg feature=\"default\" --cfg feature=\"use_std\" -C metadata=30d46fdd62f8c2eb -C extra-filename=-30d46fdd62f8c2eb --out-dir /home/jenkins/src/rustfmt/target/debug/deps --emit=dep-info,link -L dependency=/home/jenkins/src/rustfmt/target/debug/deps -L dependency=/home/jenkins/src/rustfmt/target/debug/deps --cap-lints allow`
warning: the option `Z` is unstable and should only be used on the nightly compiler, but it is currently accepted for backwards compatibility; this will soon change, see issue #31847 for more details
error: internal compiler error: ../src/librustc/hir/map/mod.rs:550: expected expr, found unknown node (id=12742)

There's already an exception in dxr/plugins/rust/dxr-rustc.sh to not use -Zsave-analysis on build.rs, so this just adds lib.rs. Tested manually and rustfmt builds and indexes correctly.