### PR TITLE
Run apt with DEBIAN_FRONTEND=noninteractive

### DIFF
--- a/tooling/docker/dev/Dockerfile
+++ b/tooling/docker/dev/Dockerfile
@@ -14,17 +14,17 @@ FROM ubuntu@sha256:0ca448cb174259ddb2ae6e213ebebe7590862d522fe38971e1175faedf0b6
 MAINTAINER Erik Rose <erik@mozilla.com>
 
 COPY set_up_ubuntu.sh /tmp/
-RUN /tmp/set_up_ubuntu.sh
+RUN DEBIAN_FRONTEND=noninteractive /tmp/set_up_ubuntu.sh
 
 COPY set_up_common.sh /tmp/
-RUN /tmp/set_up_common.sh
+RUN DEBIAN_FRONTEND=noninteractive /tmp/set_up_common.sh
 
 # Give root a known password so devs can become root:
 RUN echo "root:docker" | chpasswd
 
 # Install Graphviz, needed only for building docs.
 # Not running apt-get clean, to keep dev experience snappy.
-RUN apt-get -q -y install graphviz
+RUN DEBIAN_FRONTEND=noninteractive apt-get -q -y install graphviz
 
 RUN useradd --create-home --home-dir /home/dxr --shell /bin/bash --groups sudo --uid 1000 dxr
 RUN echo "dxr:docker" | chpasswd


### PR DESCRIPTION
Sets the debconf frontend to noninteractive, silencing "debconf: unable to initialize frontend: FOO" errors emitted during dev container build.