### PR TITLE
When pulling a file out of a VCS revision, don't assume its containin…

### DIFF
--- a/dxr/app.py
+++ b/dxr/app.py
@@ -276,8 +276,7 @@ def raw_rev(tree, revision, path):
 
     config = current_app.dxr_config
     tree_config = config.trees[tree]
-    abs_path = join(tree_config.source_folder, path)
-    data = file_contents_at_rev(abs_path, revision)
+    data = file_contents_at_rev(tree_config.source_folder, path, revision)
     if data is None:
         raise NotFound
     data_file = StringIO(data)
@@ -589,8 +588,7 @@ def rev(tree, revision, path):
     """
     config = current_app.dxr_config
     tree_config = config.trees[tree]
-    abs_path = join(tree_config.source_folder, path)
-    contents = file_contents_at_rev(abs_path, revision)
+    contents = file_contents_at_rev(tree_config.source_folder, path, revision)
     if contents is not None:
         image_rev = None
         if is_binary_image(path):


### PR DESCRIPTION
…g folder still exists. Fixes bug 1324026.

It may well have moved in the checkout's revision. So stop cd-ing to its containing folder. Instead, go into the deepest existing folder on its containing path, and run the VCS commands against the remainder of the relative path from there. Going into the deepest existing folder is a way to get the correct VCS invoked, even if there are nested repositories in the tree.

Refactor to create GenerativeTestCase, which should let us write these VCS test cases without tarring up an .hg or .git dir, which is hard to modify or examine and tempts us to couple too many tests together.