### PR TITLE
Add more of an inversion-of-control framework to the base TestCase. Make test_unicode work on Mac (HFS+) hosts.

### DIFF
--- a/tests/test_unicode/test_unicode.py
+++ b/tests/test_unicode/test_unicode.py
@@ -1,11 +1,43 @@
 # -*- coding: utf-8 -*-
 
-from dxr.testing import DxrInstanceTestCase
-from dxr.testing import SingleFileTestCase
+from os.path import basename, join
+from shutil import copytree
+
+from dxr.testing import GenerativeTestCase, SingleFileTestCase
 
 
-class NonAsciiPathTest(DxrInstanceTestCase):
+class NonAsciiPathTest(GenerativeTestCase):
     """Just tests that the index can be created without error."""
+
+    @classmethod
+    def generate(cls):
+        """Copy the whole tree to a temp dir so it's on a Linux FS which
+        accepts random bags of bytes as filenames.
+
+        macOS (hosting a folder shared through to the Docker container) throws
+        a fit on indexing because HFS+ won't put up with the
+        non-UTF-8-interpretable names made by the makefile.
+
+        """
+        super(NonAsciiPathTest, cls).generate()
+        temp_dir = join(cls._config_dir_path, basename(cls.this_dir()))
+        copytree(cls.this_dir(), temp_dir)
+        cls._orig_config_dir, cls._config_dir_path = cls._config_dir_path, temp_dir
+
+    @classmethod
+    def index(cls):
+        cls.dxr_index()
+
+    @classmethod
+    def teardown_class(cls):
+        """Restore config path so superclass will delete the temp dir made by
+        the superclass.
+
+        That dir also contains everything we've copied over.
+
+        """
+        cls._config_dir_path = cls._orig_config_dir
+        super(NonAsciiPathTest, cls).teardown_class()
 
     def test_indexes(self):
         pass


### PR DESCRIPTION
* Add hooks for generating source and indexing.
* Factor up the ES refresh() and the deletion of ES indices to the base class.
* Factor up this_dir() as well.
* Switch chdir() to cd(), which doesn't leave us in a deleted temp dir which makes future getcwd() calls deep in the stdlib grumpy.