### PR TITLE
Unregister ourselves as a DiagnosticsConsumer before we are destroyed.

### DIFF
--- a/dxr/plugins/clang/dxr-index.cpp
+++ b/dxr/plugins/clang/dxr-index.cpp
@@ -207,6 +207,14 @@ public:
     printPolicy.SuppressTagKeyword = true;
   }
 
+  ~IndexConsumer() {
+#if CLANG_AT_LEAST(3, 6)
+    ci.getDiagnostics().setClient(inner.release());
+#else
+    ci.getDiagnostics().setClient(inner);
+#endif
+  }
+
 #if CLANG_AT_LEAST(3, 3)
   // `clone` was removed from the DiagnosticConsumer interface in version 3.3,
   // so this can all be deleted once we're no longer supporting 3.2.


### PR DESCRIPTION
This prevents use-after-free bugs in clang 3.9.  It appears that in this new
version of clang, the DiagnosticsConsumer can be used even after the source
file has finished being processed and the ASTConsumer has been destroyed.