### PR TITLE
Reduce the range covered by references to template member functions.

### DIFF
--- a/dxr/plugins/clang/dxr-index.cpp
+++ b/dxr/plugins/clang/dxr-index.cpp
@@ -882,7 +882,7 @@ public:
     printReference(kindForDecl(e->getMemberDecl()),
                    e->getMemberDecl(),
                    e->getExprLoc(),
-                   e->getSourceRange().getEnd());
+                   e->getMemberNameInfo().getEndLoc());
     return true;
   }
 

--- a/dxr/plugins/clang/tests/test_functions.py
+++ b/dxr/plugins/clang/tests/test_functions.py
@@ -96,6 +96,43 @@ class TemplateClassMemberReferenceTests(CSingleFileTestCase):
                             [('Foo&lt;int&gt;().<b>bar</b>();', 16)])
 
 
+class TemplateMemberReferenceTests(CSingleFileTestCase):
+    """Tests for finding out where template member functions of a class are referenced or declared"""
+
+    source = r"""
+        class Foo
+        {
+        public:
+            template <typename T>
+            void bar();
+        };
+
+        template <typename T>
+        void Foo::bar()
+        {
+        }
+
+        void baz()
+        {
+            Foo().bar<int>();
+        }
+        """ + MINIMAL_MAIN
+
+    def test_function_decl(self):
+        """Try searching for function declaration."""
+        self.found_line_eq('+function-decl:Foo::bar()', 'void <b>bar</b>();')
+
+    def test_function(self):
+        """Try searching for function definition."""
+        self.found_lines_eq('+function:Foo::bar()',
+                            [('void Foo::<b>bar</b>()', 10)])
+
+    def test_function_ref(self):
+        """Try searching for function references."""
+        self.found_lines_eq('+function-ref:Foo::bar()',
+                            [('Foo().<b>bar</b>&lt;int&gt;();', 16)])
+
+
 class ConstTests(CSingleFileTestCase):
     source = """
         class ConstOverload


### PR DESCRIPTION
Given a call to a template member function with explicit template
arguments, we used to include those arguments in the source range for
the reference.  For instance:

    c.foo<int>()
      ^^^^^^^^-- reference covers this range

This is inconsistent with the behavior for non-member template functions
and it also prevents any references within the template arguments from
being available.  The new behavior only covers the member name:

    c.foo<int>()
      ^^^-- reference covers this range

