### PR TITLE
Fix popup menu not showing up when clicking on the far right side

### DIFF
--- a/dxr/static_unhashed/js/context_menu.js
+++ b/dxr/static_unhashed/js/context_menu.js
@@ -139,7 +139,7 @@ $(function() {
             }
 
             // If the offset is beyond the last word, no word was clicked on.
-            if (offset === endIndex) {
+            if (offset > endIndex) {
                 return;
             }
 


### PR DESCRIPTION
of an identifer.

It looks like `offset` is a value that has been rounded to the nearest integer.  So if you click on the right-half of the rightmost character in an identifier where you're clicking at, say, `(endIndex - 0.25)` it will get rounded up to `endIndex`.  Then the check would end up discarding the click.  Effectively it can take on values in the range [0, endIndex] instead of [0, endIndex) as one might expect.  

To be honest I'm not sure if this is a bug in Firefox or if this is the right way to fix the problem.
