### PR TITLE
Fix 2 gcc warnings

### DIFF
--- a/dxr/plugins/clang/sha1.cpp
+++ b/dxr/plugins/clang/sha1.cpp
@@ -38,7 +38,7 @@ namespace sha1
 {
 	namespace // local
 	{
-		inline const unsigned int rol(const unsigned int num, const unsigned int cnt)
+		inline unsigned int rol(const unsigned int num, const unsigned int cnt)
 		{
 			return((num << cnt) | (num >> (32-cnt)));
 		}

--- a/dxr/plugins/clang/sha1.h
+++ b/dxr/plugins/clang/sha1.h
@@ -41,6 +41,6 @@ namespace sha1
 		@param hexstring should point to a buffer of at least 41 bytes of size for storing the hexadecimal representation of the hash. A zero will be written at position 40, so the buffer will be a valid zero ended string.
 	*/
 	void toHexString(const unsigned char *hash, char *hexstring);
-}; // namespace sha1
+} // namespace sha1
 
 #endif // SHA1_DEFINED


### PR DESCRIPTION
warning: extra ‘;’ [-Wpedantic]
warning: type qualifiers ignored on function return type [-Wignored-qualifiers]