### PR TITLE
Fix anonymous namespaces in headers.

### DIFF
--- a/dxr/plugins/clang/tests/test_anon_ns/code/main.cpp
+++ b/dxr/plugins/clang/tests/test_anon_ns/code/main.cpp
@@ -1,4 +1,5 @@
 #include "main2.h"
+#include "main3.h"
 
 namespace
 {
@@ -11,5 +12,6 @@ int main()
 {
     foo();  /* calling foo in main */
     bar();
+    baz();
     return 0;
 }

--- a/dxr/plugins/clang/tests/test_anon_ns/code/main2.cpp
+++ b/dxr/plugins/clang/tests/test_anon_ns/code/main2.cpp
@@ -1,4 +1,5 @@
 #include "main2.h"
+#include "main3.h"
 
 namespace
 {
@@ -10,4 +11,5 @@ namespace
 void bar()
 {
     foo();  /* calling foo in main2 */
+    baz();
 }

--- a/dxr/plugins/clang/tests/test_anon_ns/code/main3.h
+++ b/dxr/plugins/clang/tests/test_anon_ns/code/main3.h
@@ -1,0 +1,6 @@
+namespace
+{
+    void baz() /* in main3.h */
+    {
+    }
+}

--- a/dxr/plugins/clang/tests/test_anon_ns/test_anon_ns.py
+++ b/dxr/plugins/clang/tests/test_anon_ns/test_anon_ns.py
@@ -6,12 +6,20 @@ class AnonymousNamespaceTests(DxrInstanceTestCase):
 
     def test_function(self):
         self.found_line_eq('+function:"(anonymous namespace in main.cpp)::foo()"',
-                           'void <b>foo</b>() /* in main */', 5)
+                           'void <b>foo</b>() /* in main */', 6)
         self.found_line_eq('+function:"(anonymous namespace in main2.cpp)::foo()"',
-                           'void <b>foo</b>() /* in main2 */', 5)
+                           'void <b>foo</b>() /* in main2 */', 6)
 
     def test_function_ref(self):
         self.found_line_eq('+function-ref:"(anonymous namespace in main.cpp)::foo()"',
-                           '<b>foo</b>();  /* calling foo in main */', 12)
+                           '<b>foo</b>();  /* calling foo in main */', 13)
         self.found_line_eq('+function-ref:"(anonymous namespace in main2.cpp)::foo()"',
-                           '<b>foo</b>();  /* calling foo in main2 */', 12)
+                           '<b>foo</b>();  /* calling foo in main2 */', 13)
+
+    def test_anonymous_namespace_in_header(self):
+        self.found_line_eq('+function:"(anonymous namespace in main3.h)::baz()"',
+                           'void <b>baz</b>() /* in main3.h */', 3)
+        self.found_files_eq('+function-ref:"(anonymous namespace in main3.h)::baz()"', [
+            "main.cpp",
+            "main2.cpp"])
+


### PR DESCRIPTION
Previously these namespaces would get a name assigned using the name of the
.cpp file that they were included from.  This caused problems when the header
was included in more than one file.  Searching for references to things
defined in such an anonymous namespace would show only results from a single
.cpp file and not all results.

The new behavior is to assign these namespaces a name based on the header
that they are defined in.  This allows the search to correctly find all references.

For an example, go to https://dxr.mozilla.org/mozilla-central/source/ipc/glue/ProtocolUtils.h#49
and try to find references for `CHANNEL_OPENED_MESSAGE_TYPE`.  The search
will not find any results and the search query shows
`(anonymous namespace in obj-x86_64-pc-linux-gnu/xpcom/threads/Unified_cpp_xpcom_threads1.cpp)`.
That .cpp file is one that includes this header but it doesn't have any references to
this identifier.  Effectively the search is limited to only that .cpp file.
There are actually several references to this identifier, for example:
https://dxr.mozilla.org/mozilla-central/source/ipc/glue/ProtocolUtils.cpp#77

I didn't properly account for the effect of having an anonymous namespace in
a header when I originally wrote this code.  This should do the correct thing now.

I separated the logic out into a helper function because I have a followup change
for static functions that's also going to need this.
