### PR TITLE
Disabmiguate static functions that share the same name but appear in …

### DIFF
--- a/dxr/plugins/clang/dxr-index.cpp
+++ b/dxr/plugins/clang/dxr-index.cpp
@@ -395,6 +395,9 @@ public:
       const std::string &realname = getRealFilenameForDefinition(d);
       ret = "(" + ret.substr(1, anon_ns.size() - 2) + " in " + realname + ")" +
         ret.substr(anon_ns.size());
+    } else if (d.getLinkageInternal() == InternalLinkage) {
+      const std::string &realname = getRealFilenameForDefinition(d);
+      ret = "(static in " + realname + ")::" + ret;
     }
     return ret;
   }

--- a/dxr/plugins/clang/tests/test_static/code/main.cpp
+++ b/dxr/plugins/clang/tests/test_static/code/main.cpp
@@ -1,0 +1,14 @@
+#include "main2.h"
+#include "main3.h"
+
+static void foo() /* in main */
+{
+}
+
+int main()
+{
+    foo();  /* calling foo in main */
+    bar();
+    baz();
+    return 0;
+}

--- a/dxr/plugins/clang/tests/test_static/code/main2.cpp
+++ b/dxr/plugins/clang/tests/test_static/code/main2.cpp
@@ -1,0 +1,12 @@
+#include "main2.h"
+#include "main3.h"
+
+static void foo() /* in main2 */
+{
+}
+
+void bar()
+{
+    foo();  /* calling foo in main2 */
+    baz();
+}

--- a/dxr/plugins/clang/tests/test_static/code/main2.h
+++ b/dxr/plugins/clang/tests/test_static/code/main2.h
@@ -1,0 +1,1 @@
+extern void bar();

--- a/dxr/plugins/clang/tests/test_static/code/main3.h
+++ b/dxr/plugins/clang/tests/test_static/code/main3.h
@@ -1,0 +1,4 @@
+static void baz() /* in main3.h */
+{
+}
+

--- a/dxr/plugins/clang/tests/test_static/code/makefile
+++ b/dxr/plugins/clang/tests/test_static/code/makefile
@@ -1,0 +1,5 @@
+all: code
+code: main.o main2.o
+	$(CXX) -o $@ $^
+clean:
+	$(RM) code main.o main2.o

--- a/dxr/plugins/clang/tests/test_static/dxr.config
+++ b/dxr/plugins/clang/tests/test_static/dxr.config
@@ -1,0 +1,9 @@
+[DXR]
+enabled_plugins     = pygmentize clang
+es_index            = dxr_test_{format}_{tree}_{unique}
+es_alias            = dxr_test_{format}_{tree}
+es_catalog_index    = dxr_test_catalog
+
+[code]
+source_folder       = code
+build_command       = make clean; make -j $jobs

--- a/dxr/plugins/clang/tests/test_static/test_static.py
+++ b/dxr/plugins/clang/tests/test_static/test_static.py
@@ -1,0 +1,25 @@
+from dxr.testing import DxrInstanceTestCase
+
+
+class AnonymousNamespaceTests(DxrInstanceTestCase):
+    """Tests for static file-scoped functions"""
+
+    def test_function(self):
+        self.found_line_eq('+function:"(static in main.cpp)::foo()"',
+                           'static void <b>foo</b>() /* in main */', 4)
+        self.found_line_eq('+function:"(static in main2.cpp)::foo()"',
+                           'static void <b>foo</b>() /* in main2 */', 4)
+
+    def test_function_ref(self):
+        self.found_line_eq('+function-ref:"(static in main.cpp)::foo()"',
+                           '<b>foo</b>();  /* calling foo in main */', 10)
+        self.found_line_eq('+function-ref:"(static in main2.cpp)::foo()"',
+                           '<b>foo</b>();  /* calling foo in main2 */', 10)
+
+    def test_anonymous_namespace_in_header(self):
+        self.found_line_eq('+function:"(static in main3.h)::baz()"',
+                           'static void <b>baz</b>() /* in main3.h */', 1)
+        self.found_files_eq('+function-ref:"(static in main3.h)::baz()"', [
+            "main.cpp",
+            "main2.cpp"])
+


### PR DESCRIPTION
…different files.

Before this change if you had a function like "static void foo()" in
one file and another, different function also called "static void foo()"
in a different file, DXR would not be able to entirely distinguish
between the two.  For instance, if you clicked on one of the
definitions and selected "Find references" then the list that was
produced would include references not only to the selected function but
also to the other function.

The way I mangled the name is to add "(static in filename.cpp)::" to the beginning.
This is similar to the "(anonymous namespace in filename.cpp)::" that we already
use for anonymous namespaces.  If somebody has a suggestion for something
better or different I'm more than willing to change this.

The `test_static` directory is mostly a copy of `test_anon_ns` but with static
functions instead of functions inside of anonymous namespaces.
