### PR TITLE
Keep fonts from 404ing when fetched from filter.css. Fixes bug 1356328.

### DIFF
--- a/dxr/static_unhashed/css/filter.css
+++ b/dxr/static_unhashed/css/filter.css
@@ -1,8 +1,8 @@
 @font-face {
     font-family: 'icons';
-    src: url('/static/fonts/icons.eot?#iefix2013') format('embedded-opentype'),
-         url('/static/fonts/icons.woff?2013') format('woff'),
-         url('/static/fonts/icons.ttf?2013') format('truetype');
+    src: url('/static/fonts/icons.eot') format('embedded-opentype'),
+         url('/static/fonts/icons.woff') format('woff'),
+         url('/static/fonts/icons.ttf') format('truetype');
     font-weight: normal;
     font-style: normal;
 }


### PR DESCRIPTION
The cachebusting was failing to find the hashed version of the filename because the static_manifest doesn't include those querystrings. The querystrings don't do anything anyway, so I removed them.