### PR TITLE
Fix the context menu not appearing when clicking on a call to operator()

### DIFF
--- a/dxr/static_unhashed/js/context_menu.js
+++ b/dxr/static_unhashed/js/context_menu.js
@@ -145,18 +145,16 @@ $(function() {
 
             word = selectedTxtString.substr(startIndex, endIndex - startIndex);
 
-            // No word was clicked on, nothing to search.
-            if (word === '') {
-                return;
-            }
+            var menuItems = [];
 
-            // Build the Object needed for the context-menu template.
-            var contextMenu = {},
-                menuItems = [{
+            if (word !== '') {
+                // A word was clicked on.
+                menuItems.push({
                     html: 'Search for the substring <strong>' + htmlEscape(word) + '</strong>',
                     href: dxr.wwwRoot + "/" + encodeURIComponent(dxr.tree) + "/search?q=" + encodeURIComponent(word),
                     icon: 'search'
-                }];
+                });
+            }
 
             var currentNode = $(node).closest('a');
             // Only check for the data-menu attribute if the current node has an
@@ -168,13 +166,17 @@ $(function() {
                 menuItems = menuItems.concat(currentNodeData);
             }
 
-            contextMenu.menuItems = menuItems;
+            if (menuItems.length === 0) {
+                // Nothing to display.
+                return;
+            }
+
             // Rather than putting the context menu in the file container,
             // attaching it to the body makes the re-layout much quicker
             // because the lines of the file do not need to be re-flowed.
             // In the end they're the same, since the menu will be absolute'd
             // to where it should go.
-            setContextMenu($('body'), contextMenu, event);
+            setContextMenu($('body'), { menuItems: menuItems }, event);
         }
     });
 


### PR DESCRIPTION
We treat the call as covering just the token `(`.  Since this has no letters or numbers the code decided that a substring search was not appropriate and then didn't display the context menu at all.  But items like "Jump to definition" and "Find references" are still appropriate and should be shown.

This is on top of #656 since I can no longer build without that patch.