### PR TITLE
Analyze files as JavaScript only if their name ends in .js or .jsm.

### DIFF
--- a/dxr/plugins/js/analyze_js/analyze_tree.js
+++ b/dxr/plugins/js/analyze_js/analyze_tree.js
@@ -55,8 +55,8 @@ function main() {
   walker.on("file", (root, stat, next) => {
     const fullPath = path.join(root, stat.name);
     const pathSegment = path.relative(treeRoot, root);
-        // Test each ignore pattern against the path, and make sure it ends in .js.
-    const disallow = (reduceIgnores(fullPath, !/jsm?$/.test(stat.name))
+    // Test each ignore pattern against the path, and make sure it ends in .js or .jsm
+    const disallow = (reduceIgnores(fullPath, !/\.jsm?$/.test(stat.name))
                         || testSegments(pathSegment));
     if (!disallow) {
       const tempPath = path.join(tempRoot, pathSegment);


### PR DESCRIPTION
Files like "foojs" will no longer have a JavaScript analysis attempted
on them.