### PR TITLE
Add support for references to overloaded operators.

### DIFF
--- a/dxr/plugins/clang/dxr-index.cpp
+++ b/dxr/plugins/clang/dxr-index.cpp
@@ -914,6 +914,8 @@ public:
       visitNestedNameSpecifierLoc(e->getQualifierLoc());
     SourceLocation start = e->getNameInfo().getBeginLoc();
     SourceLocation end = e->getNameInfo().getEndLoc();
+    if (end.isInvalid())
+        end = start;
     if (FunctionDecl *fd = dyn_cast<FunctionDecl>(e->getDecl())) {
       /* We want to avoid overlapping refs for operator() or operator[]
          at least until we have better support for overlapping refs.

--- a/dxr/plugins/clang/tests/test_operators.py
+++ b/dxr/plugins/clang/tests/test_operators.py
@@ -1,0 +1,66 @@
+from dxr.plugins.clang.tests import CSingleFileTestCase
+
+
+class OverloadedOperatorTests(CSingleFileTestCase):
+    source = """
+        struct Foo
+        {
+            void operator++() {}
+            void operator++(int) {}
+            void operator+(int) {}
+        };
+
+        int main()
+        {
+            Foo foo;
+            ++foo;
+            foo++;
+            foo + 1;
+            return 0;
+        }
+        """
+
+    def test_preincrement(self):
+        self.found_line_eq('+function-ref:Foo::operator++()',
+            '<b>++</b>foo;')
+
+    def test_postincrement(self):
+        self.found_line_eq('+function-ref:Foo::operator++(int)',
+            'foo<b>++</b>;')
+
+    def test_addition(self):
+        self.found_line_eq('+function-ref:Foo::operator+(int)',
+            'foo <b>+</b> 1;')
+
+
+class OverloadedOperatorExplicitCallTests(CSingleFileTestCase):
+    source = """
+        struct Foo
+        {
+            void operator++() {}
+            void operator++(int) {}
+            void operator+(int) {}
+        };
+
+        int main()
+        {
+            Foo foo;
+            foo.operator++();
+            foo.operator++(1);
+            foo.operator+(1);
+            return 0;
+        }
+        """
+
+    def test_preincrement(self):
+        self.found_line_eq('+function-ref:Foo::operator++()',
+            'foo.<b>operator++</b>();')
+
+    def test_postincrement(self):
+        self.found_line_eq('+function-ref:Foo::operator++(int)',
+            'foo.<b>operator++</b>(1);')
+
+    def test_addition(self):
+        self.found_line_eq('+function-ref:Foo::operator+(int)',
+            'foo.<b>operator+</b>(1);')
+


### PR DESCRIPTION
clang doesn't provide an end point for these but since they are a single token
we can use the start point as the end point.