### PR TITLE
Fix user-defined literals.

### DIFF
--- a/dxr/plugins/clang/dxr-index.cpp
+++ b/dxr/plugins/clang/dxr-index.cpp
@@ -419,17 +419,15 @@ public:
     *out << name;
   }
 
-  void recordValue(const char *key, std::string value, bool needQuotes=false) {
+  void recordValue(const char *key, std::string value) {
     *out << "," << key << ",\"";
     int start = 0;
-    if (needQuotes) {
-      int quote = value.find('"');
-      while (quote != -1) {
-        // Need to repeat the "
-        *out << value.substr(start, quote - start + 1) << "\"";
-        start = quote + 1;
-        quote = value.find('"', start);
-      }
+    int quote = value.find('"');
+    while (quote != -1) {
+      // Need to repeat the "
+      *out << value.substr(start, quote - start + 1) << "\"";
+      start = quote + 1;
+      quote = value.find('"', start);
     }
     *out << value.substr(start) << "\"";
   }
@@ -721,10 +719,10 @@ public:
       recordValue("qualname", getQualifiedName(*d));
       recordValue("loc", locationToString(location));
       recordValue("locend", locationToString(afterToken(location)));
-      recordValue("type", d->getType().getAsString(printPolicy), true);
+      recordValue("type", d->getType().getAsString(printPolicy));
       const std::string &value = getValueForValueDecl(d);
       if (!value.empty())
-        recordValue("value", value, true);
+        recordValue("value", value);
       printScope(d);
       *out << std::endl;
     }
@@ -1121,7 +1119,7 @@ public:
     info.FormatDiagnostic(message);
 
     beginRecord("warning", info.getLocation());
-    recordValue("msg", message.c_str(), true);
+    recordValue("msg", message.c_str());
     StringRef opt = DiagnosticIDs::getWarningOptionForDiag(info.getID());
     if (!opt.empty())
       recordValue("opt", ("-W" + opt).str());
@@ -1227,7 +1225,7 @@ public:
     std::map<SourceLocation, std::string>::const_iterator it =
       macromap.find(macroLoc);
     if (it != macromap.end()) {
-      recordValue("text", it->second, true);
+      recordValue("text", it->second);
     }
     *out << std::endl;
   }

--- a/dxr/plugins/clang/tests/__init__.py
+++ b/dxr/plugins/clang/tests/__init__.py
@@ -3,12 +3,13 @@ from dxr.testing import SingleFileTestCase
 
 class CSingleFileTestCase(SingleFileTestCase):
     source_filename = 'main.cpp'
+    cflags = ''
 
     @classmethod
     def config_input(cls, config_dir_path):
         input = super(CSingleFileTestCase, cls).config_input(config_dir_path)
         input['DXR']['enabled_plugins'] = 'pygmentize clang'
-        input['code']['build_command'] = '$CXX -o main main.cpp'
+        input['code']['build_command'] = '$CXX %s -o main main.cpp' % cls.cflags
         return input
 
 

--- a/dxr/plugins/clang/tests/test_user_defined_literals.py
+++ b/dxr/plugins/clang/tests/test_user_defined_literals.py
@@ -1,0 +1,23 @@
+from dxr.plugins.clang.tests import CSingleFileTestCase
+
+
+class UserDefinedLiteralTests(CSingleFileTestCase):
+    cflags = '-std=c++11'
+
+    source = """
+        int operator "" _i(const char *) { return 0; }
+
+        int main() {
+          42_i;
+          return 0;
+        }
+        """
+
+    def test_def(self):
+        self.found_line_eq('+function:"operator""_i(const char *)"',
+            'int <b>operator "" _i</b>(const char *) { return 0; }')
+
+    def test_ref(self):
+        self.found_line_eq('+function-ref:"operator""_i(const char *)"',
+            '42<b>_i</b>;')
+


### PR DESCRIPTION
C++ introduced a new thing called "user-defined literals".  These have double
quotes in their name.  This was causing problems when writing out the
temporary .csv files.  If there is a double quote in a CSV field then the
quote should be escaped by doubling it.  There was already code to do this
but it was only enabled for certain fields.  Identifiers were assumed to
never contain quotes and thus not need escaping.

Since using the proper quoting algorithm will always produce the correct
result for any type of field, turn it on unconditionally for all fields.

I'm not sure if the query syntax is what we want to use here or not.  Having unescaped literal double quotes inside of a double-quoted string feels odd.  I was a bit surprised that it worked as-is.
Is this guaranteed to do the right thing or is it just a quirk of the way the query parser works?
