### PR TITLE
Don't get confused between the source and object directories.

### DIFF
--- a/dxr/plugins/clang/dxr-index.cpp
+++ b/dxr/plugins/clang/dxr-index.cpp
@@ -67,7 +67,7 @@ struct FileInfo {
     interesting = rname.compare(0, srcdir.length(), srcdir) == 0;
     if (interesting) {
       // Remove the trailing `/' as well.
-      realname.erase(0, srcdir.length() + 1);
+      realname.erase(0, srcdir.length());
     } else if (rname.compare(0, output.length(), output) == 0) {
       // We're in the output directory, so we are probably a generated header.
       // We use the escape character to indicate the objdir nature.
@@ -1428,7 +1428,7 @@ protected:
       D.Report(DiagID) << args[0];
       return false;
     }
-    FileInfo::srcdir = abs_src;
+    FileInfo::srcdir = std::string(abs_src) + "/";
 
     // The build output directory.
     const char *env = getenv("DXR_CXX_CLANG_OBJECT_FOLDER");


### PR DESCRIPTION
To be sure that files are actually under the source directory we need
to check that they begin with "/path/to/project/" not merely
"/path/to/project".

If the source directory is /path/to/project and the object directory is
/path/to/project-obj then we were previously incorrectly treating
generated files under the object directory as if they were in
/path/to/project/obj.