### PR TITLE
Allow searching for references to things defined in third-party code

### DIFF
--- a/dxr/plugins/clang/condense.py
+++ b/dxr/plugins/clang/condense.py
@@ -207,7 +207,8 @@ def process_call(props):
     call_end_col += 1
     props['span'] = Extent(call_start,
                            Position(row=call_end_row, col=call_end_col))
-    props['calleeloc'] = _process_loc(props['calleeloc'])  # for Jump To
+    if 'calleeloc' in props:
+        props['calleeloc'] = _process_loc(props['calleeloc'])  # for Jump To
     return props
 
 

--- a/dxr/plugins/clang/tests/__init__.py
+++ b/dxr/plugins/clang/tests/__init__.py
@@ -9,7 +9,7 @@ class CSingleFileTestCase(SingleFileTestCase):
     def config_input(cls, config_dir_path):
         input = super(CSingleFileTestCase, cls).config_input(config_dir_path)
         input['DXR']['enabled_plugins'] = 'pygmentize clang'
-        input['code']['build_command'] = '$CXX %s -o main main.cpp' % cls.cflags
+        input['code']['build_command'] = '$CXX %s -c main.cpp' % cls.cflags
         return input
 
 

--- a/dxr/plugins/clang/tests/__init__.py
+++ b/dxr/plugins/clang/tests/__init__.py
@@ -12,11 +12,3 @@ class CSingleFileTestCase(SingleFileTestCase):
         input['code']['build_command'] = '$CXX %s -c main.cpp' % cls.cflags
         return input
 
-
-# Tests that don't otherwise need a main() can append this one just to get
-# their code to compile:
-MINIMAL_MAIN = """
-    int main(int argc, char* argv[]) {
-        return 0;
-    }
-    """

--- a/dxr/plugins/clang/tests/test_callers.py
+++ b/dxr/plugins/clang/tests/test_callers.py
@@ -1,6 +1,6 @@
 """Tests for searches using callers"""
 
-from dxr.plugins.clang.tests import CSingleFileTestCase, MINIMAL_MAIN
+from dxr.plugins.clang.tests import CSingleFileTestCase
 
 
 class DirectCallTests(CSingleFileTestCase):
@@ -79,7 +79,7 @@ class IndirectCallTests(CSingleFileTestCase):
             d.foo();
             d.bar();
         }
-        """ + MINIMAL_MAIN
+        """
 
     def test_virtual_base(self):
         """Virtual methods on base classes should be found only on invocations

--- a/dxr/plugins/clang/tests/test_decl.py
+++ b/dxr/plugins/clang/tests/test_decl.py
@@ -1,6 +1,6 @@
 """Tests for searches for declarations"""
 
-from dxr.plugins.clang.tests import CSingleFileTestCase, MINIMAL_MAIN
+from dxr.plugins.clang.tests import CSingleFileTestCase
 
 
 class TypeDeclarationTests(CSingleFileTestCase):
@@ -11,7 +11,7 @@ class TypeDeclarationTests(CSingleFileTestCase):
         class MyClass
         {
         };
-        """ + MINIMAL_MAIN
+        """
 
     def test_type(self):
         """Try searching for type declarations."""
@@ -27,7 +27,7 @@ class FunctionDeclarationTests(CSingleFileTestCase):
         void foo()
         {
         };
-        """ + MINIMAL_MAIN
+        """
 
     def test_function(self):
         """Try searching for function declarations."""
@@ -45,7 +45,7 @@ class VariableDeclarationTests(CSingleFileTestCase):
         {
             extern int x;
         }
-        """ + MINIMAL_MAIN
+        """
 
     def test_variable(self):
         """Try searching for variable declarations."""

--- a/dxr/plugins/clang/tests/test_direct.py
+++ b/dxr/plugins/clang/tests/test_direct.py
@@ -1,4 +1,4 @@
-from dxr.plugins.clang.tests import CSingleFileTestCase, MINIMAL_MAIN
+from dxr.plugins.clang.tests import CSingleFileTestCase
 
 
 class TypeAndMethodTests(CSingleFileTestCase):
@@ -23,7 +23,7 @@ class TypeAndMethodTests(CSingleFileTestCase):
         }
         void MemberFunction::unique_member_function(int a) {
         }
-        """ + MINIMAL_MAIN
+        """
 
     def test_qualified_function_name_insensitive(self):
         """A unique, case-insensitive match on fully qualified function name
@@ -105,7 +105,7 @@ class MacroTypedefTests(CSingleFileTestCase):
         typedef int MyTypeDef;
         typedef int MYTYPEDEF;
         typedef int MyUniqueTypeDef;
-        """ + MINIMAL_MAIN
+        """
 
     def test_macro_name_insensitive(self):
         """A unique, case-insensitive match on a macro name should take you

--- a/dxr/plugins/clang/tests/test_functions.py
+++ b/dxr/plugins/clang/tests/test_functions.py
@@ -2,7 +2,7 @@
 
 from nose import SkipTest
 
-from dxr.plugins.clang.tests import CSingleFileTestCase, MINIMAL_MAIN
+from dxr.plugins.clang.tests import CSingleFileTestCase
 
 
 class DefinitionTests(CSingleFileTestCase):
@@ -78,7 +78,7 @@ class TemplateClassMemberReferenceTests(CSingleFileTestCase):
         {
             Foo<int>().bar();
         }
-        """ + MINIMAL_MAIN
+        """
 
     def test_function_decl(self):
         """Try searching for function declaration."""
@@ -116,7 +116,7 @@ class TemplateMemberReferenceTests(CSingleFileTestCase):
         {
             Foo().bar<int>();
         }
-        """ + MINIMAL_MAIN
+        """
 
     def test_function_decl(self):
         """Try searching for function declaration."""
@@ -147,7 +147,7 @@ class ConstTests(CSingleFileTestCase):
 
         void ConstOverload::foo() const {
         }
-        """ + MINIMAL_MAIN
+        """
 
     def test_const_functions(self):
         """Make sure const functions are indexed separately from non-const but
@@ -165,7 +165,7 @@ class PrototypeParamTests(CSingleFileTestCase):
         int prototype_parameter_function(int prototype_parameter) {
             return prototype_parameter;
         }
-        """ + MINIMAL_MAIN
+        """
 
     def test_prototype_params(self):
         # I have no idea what this tests.

--- a/dxr/plugins/clang/tests/test_inheritance.py
+++ b/dxr/plugins/clang/tests/test_inheritance.py
@@ -1,6 +1,6 @@
 """Tests for queries about superclasses and subclasses"""
 
-from dxr.plugins.clang.tests import CSingleFileTestCase, MINIMAL_MAIN
+from dxr.plugins.clang.tests import CSingleFileTestCase
 
 
 class InheritanceTests(CSingleFileTestCase):
@@ -21,7 +21,7 @@ class InheritanceTests(CSingleFileTestCase):
 
         struct E : public D {
         };
-        """ + MINIMAL_MAIN
+        """
 
     def test_subclasses(self):
         """We should find all direct and indirect subclasses."""

--- a/dxr/plugins/clang/tests/test_macros.py
+++ b/dxr/plugins/clang/tests/test_macros.py
@@ -1,4 +1,4 @@
-from dxr.plugins.clang.tests import CSingleFileTestCase, MINIMAL_MAIN
+from dxr.plugins.clang.tests import CSingleFileTestCase
 
 from nose.tools import ok_
 
@@ -9,7 +9,7 @@ class MacroTests(CSingleFileTestCase):
         #define MACRO
         #define ADD(x, y) ((x) + (y))
 
-        """ + MINIMAL_MAIN
+        """
 
     def test_simple(self):
         """Make sure macro definitions are found."""
@@ -36,7 +36,7 @@ class MacroRefTests(CSingleFileTestCase):
         #endif
 
         #undef MACRO
-        """ + MINIMAL_MAIN
+        """
 
     def test_refs(self):
         self.found_lines_eq('+macro-ref:MACRO', [
@@ -71,7 +71,7 @@ class MacroArgumentReferenceTests(CSingleFileTestCase):
                 ID(y) +
                 ADD(x, y);
         }
-        """ + MINIMAL_MAIN
+        """
 
     def test_refs(self):
         """Test variables referenced in macro arguments"""
@@ -103,7 +103,7 @@ class MacroArgumentFieldReferenceTests(CSingleFileTestCase):
                 FOO(bar) +
                 FIELD(foo, bar);
         }
-        """ + MINIMAL_MAIN
+        """
 
     def test_refs(self):
         """Test struct fields referenced in macro arguments"""
@@ -129,7 +129,7 @@ class MacroArgumentDeclareTests(CSingleFileTestCase):
             DECLARE(b);
             DECLARE2(c, d);
         }
-        """ + MINIMAL_MAIN
+        """
 
     def test_decls(self):
         """Test variables declared in macro arguments"""
@@ -151,7 +151,7 @@ SD;
 #define ADD(x, y)  ((x) + (y))
 
 int c = ADD(0, 0);
-        """ + MINIMAL_MAIN
+        """
 
     def test_macro_titles(self):
         """Test that a ref to a macro gets a title tooltip containing the

--- a/dxr/plugins/clang/tests/test_members.py
+++ b/dxr/plugins/clang/tests/test_members.py
@@ -1,4 +1,4 @@
-from dxr.plugins.clang.tests import CSingleFileTestCase, MINIMAL_MAIN
+from dxr.plugins.clang.tests import CSingleFileTestCase
 
 
 class MemberVariableTests(CSingleFileTestCase):
@@ -7,7 +7,7 @@ class MemberVariableTests(CSingleFileTestCase):
             public:
                 int member_variable;
         };
-        """ + MINIMAL_MAIN
+        """
 
     def test_member_variable(self):
         """Test searching for members of a class (or struct) that contains
@@ -31,7 +31,7 @@ class MemberVariableCtorTests(CSingleFileTestCase):
             Bar bar;
             int baz;
         };
-        """ + MINIMAL_MAIN
+        """
 
     def test_implicit_init(self):
         """Test searching for references to a member of a class that is
@@ -53,7 +53,7 @@ class MemberFunctionTests(CSingleFileTestCase):
 
         void MemberFunction::member_function() {
         }
-        """ + MINIMAL_MAIN
+        """
 
     def test_member_function(self):
         """Test searching for members of a class (or struct) that contains
@@ -70,7 +70,7 @@ class StaticMemberTests(CSingleFileTestCase):
         };
 
         int StaticMember::static_member = 0;
-        """ + MINIMAL_MAIN
+        """
 
     def test_static_members(self):
         self.found_line_eq('+var:StaticMember::static_member', 'int StaticMember::<b>static_member</b> = 0;')
@@ -143,7 +143,7 @@ class MemberTests(CSingleFileTestCase):
             retval &= rhs;
             return retval;
         }
-        """ + MINIMAL_MAIN
+        """
 
     def test_members(self):
         """Make sure we can find all the members of a class."""

--- a/dxr/plugins/clang/tests/test_namespaces.py
+++ b/dxr/plugins/clang/tests/test_namespaces.py
@@ -1,6 +1,6 @@
 """Tests for searches about namespaces"""
 
-from dxr.plugins.clang.tests import CSingleFileTestCase, MINIMAL_MAIN
+from dxr.plugins.clang.tests import CSingleFileTestCase
 
 
 class NamespaceDefTests(CSingleFileTestCase):
@@ -13,7 +13,7 @@ class NamespaceDefTests(CSingleFileTestCase):
             namespace Inner {
             }
         }
-        """ + MINIMAL_MAIN
+        """
 
     def test_namespace_definitions(self):
         self.found_lines_eq('+namespace:Outer', [
@@ -40,7 +40,7 @@ class NamespaceExprRefTests(CSingleFileTestCase):
             Outer::baz = 1;
             Outer::Inner::bar();
         }
-        """ + MINIMAL_MAIN
+        """
 
     def test_namespace_expression_references(self):
         self.found_lines_eq('+namespace-ref:Outer', [
@@ -66,7 +66,7 @@ class NamespaceDeclRefTests(CSingleFileTestCase):
             Outer::MyClass *x;
             Outer::Inner::MyClass *y;
         }
-        """ + MINIMAL_MAIN
+        """
 
     def test_namespace_declaration_references(self):
         self.found_lines_eq('+namespace-ref:Outer', [
@@ -85,7 +85,7 @@ class NamespaceUsingDirectiveTests(CSingleFileTestCase):
         }
         using namespace Outer;
         using namespace Outer::Inner;
-        """ + MINIMAL_MAIN
+        """
 
     def test_namespace_using_directive_references(self):
         self.found_lines_eq('+namespace-ref:Outer', [
@@ -112,7 +112,7 @@ class NamespaceUsingDeclarationTests(CSingleFileTestCase):
             using Outer::foo;
             using Outer::Inner::bar;
         }
-        """ + MINIMAL_MAIN
+        """
 
     def test_namespace_using_declaration_references(self):
         self.found_lines_eq('+namespace-ref:Outer', [
@@ -132,7 +132,7 @@ class NamespaceAliasTests(CSingleFileTestCase):
             namespace OuterAlias = Outer;
             OuterAlias::foo();
         }
-        """ + MINIMAL_MAIN
+        """
 
     def test_namespace_alias_definitions(self):
         """Try searching for namespace alias definitions."""

--- a/dxr/plugins/clang/tests/test_overrides/test_overrides.py
+++ b/dxr/plugins/clang/tests/test_overrides/test_overrides.py
@@ -1,7 +1,7 @@
 """Tests for searches about overrides of virtual methods"""
 
 from dxr.testing import DxrInstanceTestCase
-from dxr.plugins.clang.tests import CSingleFileTestCase, MINIMAL_MAIN
+from dxr.plugins.clang.tests import CSingleFileTestCase
 
 
 class ParallelOverrideTests(CSingleFileTestCase):
@@ -24,7 +24,7 @@ class ParallelOverrideTests(CSingleFileTestCase):
         };
         void DerivedB::foo() {
         }
-        """ + MINIMAL_MAIN
+        """
 
     def test_overridden(self):
         self.found_line_eq(
@@ -57,7 +57,7 @@ class HierarchyOverrideTests(CSingleFileTestCase):
         };
         void Derived2::foo() {
         }
-        """ + MINIMAL_MAIN
+        """
 
     def test_overridden(self):
         self.found_line_eq(
@@ -92,7 +92,7 @@ class HierarchyImplicitOverrideTests(CSingleFileTestCase):
         };
         void Derived2::foo() {
         }
-        """ + MINIMAL_MAIN
+        """
 
     def test_overridden(self):
         self.found_line_eq('+overridden:Derived2::foo()',
@@ -123,7 +123,7 @@ class MultipleOverrides(CSingleFileTestCase):
         };
         void Derived::foo() {
         }
-        """ + MINIMAL_MAIN
+        """
 
     def test_overridden(self):
         self.found_lines_eq('+overridden:Derived::foo()',

--- a/dxr/plugins/clang/tests/test_third_party_refs.py
+++ b/dxr/plugins/clang/tests/test_third_party_refs.py
@@ -1,0 +1,51 @@
+from dxr.plugins.clang.tests import CSingleFileTestCase
+
+
+class ThirdPartyRefsTests(CSingleFileTestCase):
+    source = """
+        #include <string.h>
+
+        void foo(int);
+
+        struct C {
+            C(int);
+        };
+
+        int main()
+        {
+            char s[6];
+            strcpy(s, "Hello");
+            foo(1);
+            C c(1);
+            return 0;
+        }
+        """
+
+    def test_ref_libc(self):
+        self.found_line_eq('function-ref:strcpy',
+            '<b>strcpy</b>(s, "Hello");')
+
+    def test_ref_not_defined(self):
+        self.found_line_eq('+function-ref:foo(int)',
+            '<b>foo</b>(1);')
+
+    def test_decl_not_defined(self):
+        self.found_line_eq('+function-decl:foo(int)',
+            'void <b>foo</b>(int);')
+
+    def test_decl_constructor(self):
+        self.found_line_eq('+function-decl:C::C(int)',
+            '<b>C</b>(int);')
+
+    def test_call_libc(self):
+        self.found_line_eq('callers:strcpy',
+            '<b>strcpy(s, "Hello")</b>;')
+
+    def test_call_not_defined(self):
+        self.found_line_eq('+callers:foo(int)',
+            '<b>foo(1)</b>;')
+
+    def test_call_constructor(self):
+        self.found_line_eq('+callers:C::C(int)',
+            'C <b>c(1)</b>;')
+

--- a/dxr/plugins/clang/tests/test_third_party_refs.py
+++ b/dxr/plugins/clang/tests/test_third_party_refs.py
@@ -22,30 +22,37 @@ class ThirdPartyRefsTests(CSingleFileTestCase):
         """
 
     def test_ref_libc(self):
+        """Search for references to a function that is defined in libc."""
         self.found_line_eq('function-ref:strcpy',
             '<b>strcpy</b>(s, "Hello");')
 
     def test_ref_not_defined(self):
+        """Search for references to a function that is not defined."""
         self.found_line_eq('+function-ref:foo(int)',
             '<b>foo</b>(1);')
 
     def test_decl_not_defined(self):
+        """Search for declarations for a function that is not defined."""
         self.found_line_eq('+function-decl:foo(int)',
             'void <b>foo</b>(int);')
 
     def test_decl_constructor(self):
+        """Search for declarations for a constructor that is not defined."""
         self.found_line_eq('+function-decl:C::C(int)',
             '<b>C</b>(int);')
 
     def test_call_libc(self):
+        """Search for calls to a function that is defined in libc."""
         self.found_line_eq('callers:strcpy',
             '<b>strcpy(s, "Hello")</b>;')
 
     def test_call_not_defined(self):
+        """Search for calls to a function that is not defined."""
         self.found_line_eq('+callers:foo(int)',
             '<b>foo(1)</b>;')
 
     def test_call_constructor(self):
+        """Search for calls to a constructor that is not defined."""
         self.found_line_eq('+callers:C::C(int)',
             'C <b>c(1)</b>;')
 

--- a/dxr/plugins/clang/tests/test_type_templates.py
+++ b/dxr/plugins/clang/tests/test_type_templates.py
@@ -1,4 +1,4 @@
-from dxr.plugins.clang.tests import CSingleFileTestCase, MINIMAL_MAIN
+from dxr.plugins.clang.tests import CSingleFileTestCase
 
 
 class TypeTests(CSingleFileTestCase):
@@ -11,7 +11,7 @@ class TypeTests(CSingleFileTestCase):
         {
             Foo<int>();
         }
-        """ + MINIMAL_MAIN
+        """
 
     def test_simple_type(self):
         self.found_line_eq('type:Foo',
@@ -29,7 +29,7 @@ class BaseClassTests(CSingleFileTestCase):
         class Bar : public Foo<T>
         {
         };
-        """ + MINIMAL_MAIN
+        """
 
     def test_base_class(self):
         self.found_line_eq('type-ref:Foo',
@@ -46,7 +46,7 @@ class TemplateParameterTests(CSingleFileTestCase):
         void bar(const T &)
         {
         }
-        """ + MINIMAL_MAIN
+        """
 
     def test_class_template_parameter(self):
         self.found_line_eq('+type:Foo::T',

--- a/dxr/plugins/clang/tests/test_typedefs.py
+++ b/dxr/plugins/clang/tests/test_typedefs.py
@@ -1,4 +1,4 @@
-from dxr.plugins.clang.tests import CSingleFileTestCase, MINIMAL_MAIN
+from dxr.plugins.clang.tests import CSingleFileTestCase
 
 
 class TypedefTests(CSingleFileTestCase):
@@ -7,7 +7,7 @@ class TypedefTests(CSingleFileTestCase):
 
         void my_typedef_function(MyTypedef) {
         }
-        """ + MINIMAL_MAIN
+        """
 
     def test_typedefs(self):
         self.found_line_eq('+type:MyTypedef',

--- a/dxr/plugins/clang/tests/test_types.py
+++ b/dxr/plugins/clang/tests/test_types.py
@@ -1,11 +1,11 @@
-from dxr.plugins.clang.tests import CSingleFileTestCase, MINIMAL_MAIN
+from dxr.plugins.clang.tests import CSingleFileTestCase
 
 
 class TypeTests(CSingleFileTestCase):
     source = r"""
         class Foo {};
         class Bar {};
-        """ + MINIMAL_MAIN
+        """
 
     def test_simple_type(self):
         self.found_line_eq('type:Foo',
@@ -24,7 +24,7 @@ class InjectedTypeTests(CSingleFileTestCase):
         class Foo {
             void bar(const Foo &);
         };
-        """ + MINIMAL_MAIN
+        """
 
     def test_injected_type(self):
         self.found_line_eq('type-ref:Foo', 'void bar(const <b>Foo</b> &amp;);')

--- a/dxr/plugins/clang/tests/test_vars.py
+++ b/dxr/plugins/clang/tests/test_vars.py
@@ -1,4 +1,4 @@
-from dxr.plugins.clang.tests import CSingleFileTestCase, MINIMAL_MAIN
+from dxr.plugins.clang.tests import CSingleFileTestCase
 
 
 class VarTests(CSingleFileTestCase):
@@ -9,7 +9,7 @@ class VarTests(CSingleFileTestCase):
         void smoo(int i, char **c) {
             int inner;
         }
-        """ + MINIMAL_MAIN
+        """
 
     def test_unqualified(self):
         """Search for var definitions using unqualified names."""

--- a/dxr/plugins/clang/tests/test_warnings.py
+++ b/dxr/plugins/clang/tests/test_warnings.py
@@ -1,6 +1,6 @@
 """Tests for searches about warnings"""
 
-from dxr.plugins.clang.tests import CSingleFileTestCase, MINIMAL_MAIN
+from dxr.plugins.clang.tests import CSingleFileTestCase
 
 
 class TautWarningTests(CSingleFileTestCase):
@@ -12,7 +12,7 @@ class TautWarningTests(CSingleFileTestCase):
             if (x < 0)
                 return;
         }
-        """ + MINIMAL_MAIN
+        """
 
     def test_warning(self):
         self.found_line_eq(
@@ -33,7 +33,7 @@ class MultipleOnSameLineWarningTests(CSingleFileTestCase):
             if (!x < 3)
                 return;
         }
-        """ + MINIMAL_MAIN
+        """
 
     def test_warning(self):
         if self.clang_at_least(3.4):


### PR DESCRIPTION
This is split into 3 commits for easier review.

Until now functions, classes and variables that were not defined within the source tree were "invisible".  Uses of these things were not hyperlinked and searching for references to them found no results.

With this change we no longer ignore these things and they become searchable just like other identifiers.  You won't be able to find the definition for such items but other searches like "Find references" will work.

This works for things defined in third-party libraries and even libc.  So now you can search for all uses of "strcpy" or "gets" in your code.
