### PR TITLE
Fix menu items on variable declarations.

### DIFF
--- a/dxr/plugins/clang/indexers.py
+++ b/dxr/plugins/clang/indexers.py
@@ -88,10 +88,11 @@ class FileToIndex(FileToIndexBase):
                            # together with other getters.
                            kind_getter('ref', 'function')]),
             (VariableRef, [getter_or_empty('variable'),
-                           kind_getter('ref', 'variable')]),
+                           kind_getter('ref', 'variable'),
+                           kind_getter('decldef', 'variable')]),
             (TypeRef, [getter_or_empty('type'),
                        kind_getter('ref', 'type'),
-                       not_kind_getter('decldef', 'function')]),
+                       kind_getter('decldef', 'type')]),
             (TypedefRef, [getter_or_empty('typedef'),
                           kind_getter('ref', 'typedef')]),
             (NamespaceRef, [getter_or_empty('namespace'),
@@ -175,12 +176,6 @@ class FileToIndex(FileToIndexBase):
 def kind_getter(field, kind, condensed):
     """Reach into a field and filter based on the kind."""
     return (ref for ref in condensed.get(field, []) if ref.get('kind') == kind)
-
-
-@autocurry
-def not_kind_getter(field, kind, condensed):
-    """Reach into a field and filter out those with given kind."""
-    return (ref for ref in condensed.get(field, []) if ref.get('kind') != kind)
 
 
 

--- a/dxr/plugins/clang/tests/test_var_decl.py
+++ b/dxr/plugins/clang/tests/test_var_decl.py
@@ -1,0 +1,24 @@
+from dxr.testing import menu_on
+from dxr.plugins.clang.tests import CSingleFileTestCase
+
+
+class VarDeclTests(CSingleFileTestCase):
+    source = r"""
+        extern int Default;
+
+        int Default = 42;
+
+        int getDefault()
+        {
+            return Default;
+        }
+        """
+
+    def test_menu(self):
+        """Menu can search for declarations and references."""
+        menu_on(self.source_page(self.source_filename),
+                'Default',
+                {'html': 'Find declarations',
+                 'href': '/code/search?q=%2Bvar-decl%3ADefault'},
+                {'html': 'Find references',
+                 'href': '/code/search?q=%2Bvar-ref%3ADefault'})


### PR DESCRIPTION
These were being treated like types instead of variables and getting type-decl
and type-ref in the menu instead of the correct var-decl and var-ref.