### PR TITLE
Compatibility with clang 6.

### DIFF
--- a/dxr/plugins/clang/tests/test_warnings.py
+++ b/dxr/plugins/clang/tests/test_warnings.py
@@ -6,6 +6,8 @@ from dxr.plugins.clang.tests import CSingleFileTestCase
 class TautWarningTests(CSingleFileTestCase):
     """Tests for searches of a tautological comparison warning"""
 
+    cflags = '-Weverything'
+
     source = r"""
         void foo(unsigned int x)
         {
@@ -15,17 +17,27 @@ class TautWarningTests(CSingleFileTestCase):
         """
 
     def test_warning(self):
+        if self.clang_at_least(6.0):
+            warning_message = "result of comparison of unsigned expression < 0 is always false"
+        else:
+            warning_message = "comparison of unsigned expression < 0 is always false"
         self.found_line_eq(
-            'warning:"comparison of unsigned expression < 0 is always false"',
+            'warning:"%s"' % (warning_message,),
             'if (<b>x</b> &lt; 0)')
 
     def test_warning_opt(self):
+        if self.clang_at_least(6.0):
+            warning_option = '-Wtautological-unsigned-zero-compare'
+        else:
+            warning_option = '-Wtautological-compare'
         self.found_line_eq(
-            'warning-opt:-Wtautological-compare', 'if (<b>x</b> &lt; 0)')
+            'warning-opt:' + warning_option, 'if (<b>x</b> &lt; 0)')
 
 
 class MultipleOnSameLineWarningTests(CSingleFileTestCase):
     """Tests for searches when there are multiple warnings on one line"""
+
+    cflags = '-Weverything'
 
     source = r"""
         void foo(int x)
@@ -39,8 +51,12 @@ class MultipleOnSameLineWarningTests(CSingleFileTestCase):
         if self.clang_at_least(3.4):
             self.found_line_eq(
                 'warning:"logical not is only applied to the left hand side of this comparison"', 'if (!x <b>&lt;</b> 3)')
+        if self.clang_at_least(6.0):
+            warning_message = "result of comparison of constant 3 with expression of type 'bool' is always true"
+        else:
+            warning_message = "comparison of constant 3 with expression of type 'bool' is always true"
         self.found_line_eq(
-            'warning:"comparison of constant 3 with expression of type \'bool\' is always true"',
+            'warning:"%s"' % (warning_message,),
             'if (<b>!x</b> &lt; 3)')
 
     def test_warning_opt(self):


### PR DESCRIPTION
This version of clang slightly changed the way warnings worked,
breaking some of our tests.