### PR TITLE
Update for new version of rustup

### DIFF
--- a/docs/source/deployment.rst
+++ b/docs/source/deployment.rst
@@ -85,7 +85,7 @@ also need to install rust.  Refer to
 :file:`tooling/docker/dev/set_up_common.sh` for the currently recommended
 install command, something like::
 
-  curl -s https://static.rust-lang.org/rustup.sh | sh -s -- --channel=nightly --date=<date> --yes
+  curl -sSf https://sh.rustup.rs | sh -s -- --default-toolchain nightly-<date> -y
 
 .. note::
 

--- a/tooling/docker/dev/Dockerfile
+++ b/tooling/docker/dev/Dockerfile
@@ -16,9 +16,6 @@ MAINTAINER Erik Rose <erik@mozilla.com>
 COPY set_up_ubuntu.sh /tmp/
 RUN DEBIAN_FRONTEND=noninteractive /tmp/set_up_ubuntu.sh
 
-COPY set_up_common.sh /tmp/
-RUN DEBIAN_FRONTEND=noninteractive /tmp/set_up_common.sh
-
 # Give root a known password so devs can become root:
 RUN echo "root:docker" | chpasswd
 
@@ -31,10 +28,13 @@ RUN echo "dxr:docker" | chpasswd
 VOLUME /home/dxr/dxr
 USER dxr
 
+COPY set_up_common.sh /tmp/
+RUN DEBIAN_FRONTEND=noninteractive /tmp/set_up_common.sh
+
 # Activate a virtualenv. make will make it later. Also, set SHELL so mach
 # doesn't complain while building Firefox. Other things probably expect it as
 # well.
-ENV VIRTUAL_ENV=/venv PATH=/venv/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin SHELL=/bin/bash
+ENV VIRTUAL_ENV=/venv PATH=/venv/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/home/dxr/.cargo/bin SHELL=/bin/bash
 
 WORKDIR /home/dxr/dxr
 

--- a/tooling/docker/dev/set_up_common.sh
+++ b/tooling/docker/dev/set_up_common.sh
@@ -3,4 +3,4 @@
 # don't do anything specific to development or CI.
 
 # Install Rust.
-curl -s https://static.rust-lang.org/rustup.sh | sh -s -- --channel=nightly --date=2016-01-25 --yes
+curl -sSf https://sh.rustup.rs | sh -s -- --default-toolchain nightly-2016-01-25 -y


### PR DESCRIPTION
The new version is hosted at a different location, takes different
command line arguments, and installs to the user's home directory
instead of /usr/local.

I'm hopeful that this will fix the CI failure seen in #689